### PR TITLE
feat: generative-page-dev スキル追加

### DIFF
--- a/.github/skills/generative-page-dev/SKILL.md
+++ b/.github/skills/generative-page-dev/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: generative-page-dev
+description: "Power Apps Generative Pages (genux) の開発・デバッグ・デプロイ。React 17 + TypeScript + Fluent UI V9 + D3.js の単一ファイル構成。Use when: generative page, genpage, genux, pac model genpage, DataAPI, Fluent UI V9, D3 chart, model-driven app page, generative page deploy, generative page debug"
+argument-hint: "[ページの説明 or 'deploy' or 'debug']"
+user-invocable: true
+---
+
+# Generative Pages 開発スキル
+
+Power Apps モデル駆動型アプリの **Generative Pages (genux)** を開発・デバッグ・デプロイするスキル。
+
+> **Code Apps スキル (`code-apps-dev`) との違い**: Code Apps は React 18 + Tailwind + shadcn + Vite + `npx power-apps push` のフルスタック開発。Generative Pages は React 17 + Fluent UI V9 + D3.js の **単一 `.tsx` ファイル構成** で `pac model genpage upload` でデプロイする軽量ページ。
+
+## 技術スタック
+
+| レイヤー | 技術 |
+|----------|------|
+| UI | React 17 + TypeScript |
+| コンポーネント | `@fluentui/react-components` (Fluent UI V9) |
+| アイコン | `@fluentui/react-icons`（サイズなしバリアントのみ） |
+| チャート | D3.js v7 |
+| データ | `props.dataApi` (DataAPI) |
+| デプロイ | PAC CLI (`pac model genpage upload`) |
+
+**利用可能ライブラリ（これ以外は使用禁止）:**
+
+```
+react: ^17.0.2
+@fluentui/react-components: ^9.46.4
+@fluentui/react-icons: ^2.0.292
+@fluentui/react-datepicker-compat: ^0.5.0
+@fluentui/react-timepicker-compat: ^0.3.0
+d3: ^7.9.0
+uuid: ^9.0.1
+```
+
+## 絶対遵守ルール
+
+1. **React 17 構文のみ** — React 18 の `useId`, `useTransition` 等は使用不可
+2. **FluentProvider 追加禁止** — ルートで提供済み。追加すると React 17 でダブルレンダーが発生
+3. **`100vh` / `100vw` 禁止** — flexbox と相対単位を使用
+4. **単一ファイル構成** — 全コンポーネント・ユーティリティを 1 つの `.tsx` ファイルに記述
+5. **`export default GeneratedComponent`** — エントリポイントの関数名と export 形式は固定
+6. **`makeStyles` + `tokens`** でスタイリング。インラインスタイルは動的値のみ
+7. **DataAPI は TableRegistrations がある場合のみ使用** — `props.dataApi.queryTable()` で CRUD
+8. **カラム名は RuntimeTypes.ts を確認** — 推測禁止
+9. **`@fluentui/react-icons` はサイズなしバリアントのみ** — `AddRegular` ✅ / `Add24Regular` ❌
+10. **`Map` / `Set` に `for...of` 禁止** — `.forEach()` または `[...map]` でイテレーション
+
+## 開発フロー
+
+### Step 1: 前提確認
+
+```powershell
+pac help          # バージョン >= 2.3.1 確認
+pac auth list     # 認証プロファイル確認（* がアクティブ）
+```
+
+認証がなければ:
+```powershell
+pac auth create --environment https://your-env.crm7.dynamics.com
+```
+
+### Step 2: アプリ・ページ確認
+
+```powershell
+pac model list                                           # アプリ一覧 → app-id 取得
+pac model genpage list --app-id <app-id>                 # 既存ページ一覧 → page-id 取得
+```
+
+### Step 3: スキーマ生成（Dataverse 使用時・必須）
+
+**コードを書く前に必ず実行する。カラム名の推測は禁止。**
+
+```powershell
+pac model genpage generate-types --data-sources "entity1,entity2,entity3" --output-file RuntimeTypes.ts
+```
+
+生成された `RuntimeTypes.ts` を読み、利用可能なカラム名・型・Choice 値を確認する。
+
+### Step 4: コード作成
+
+[コードパターンリファレンス](./references/code-patterns.md) に従い `.tsx` ファイルを作成する。
+
+**基本構造:**
+
+```typescript
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import type { ReadableTableRow, GeneratedComponentProps, entity_name } from "./RuntimeTypes";
+import { makeStyles, tokens, Card, Text, /* ... */ } from "@fluentui/react-components";
+import { IconRegular } from "@fluentui/react-icons";
+import * as d3 from "d3";
+
+// ユーティリティ関数（トップレベル）
+// サブコンポーネント（トップレベル関数）
+
+const GeneratedComponent = (props: GeneratedComponentProps) => {
+  const { dataApi } = props;
+  // 実装
+};
+
+export default GeneratedComponent;
+```
+
+### Step 5: デプロイ
+
+**新規ページ:**
+```powershell
+pac model genpage upload `
+  --app-id <app-id> `
+  --code-file MyPage.tsx `
+  --name "ページ名" `
+  --data-sources "entity1,entity2" `
+  --add-to-sitemap
+```
+
+**既存ページ更新:**
+```powershell
+pac model genpage upload `
+  --app-id <app-id> `
+  --code-file MyPage.tsx `
+  --page-id <page-id> `
+  --data-sources "entity1,entity2"
+```
+
+### Step 6: デバッグ
+
+問題が発生した場合は [トラブルシューティング](./references/troubleshooting.md) を参照。
+
+## DataAPI パターン
+
+### クエリ（ページネーション対応）
+
+```typescript
+async function loadAllRows<T>(
+  api: GeneratedComponentProps["dataApi"],
+  table: string,
+  options: { select: string[]; filter?: string; orderBy?: string; pageSize?: number }
+): Promise<ReadableTableRow<T>[]> {
+  let res = await api.queryTable(table as any, {
+    select: options.select as any,
+    filter: options.filter,
+    orderBy: options.orderBy,
+    pageSize: options.pageSize || 250,
+  });
+  let rows = [...res.rows];
+  while (res.hasMoreRows && res.loadMoreRows) {
+    res = await res.loadMoreRows();
+    rows = rows.concat(res.rows);
+  }
+  return rows as any;
+}
+```
+
+### Choice 値の取得
+
+```typescript
+const areaChoices = (await dataApi.getChoices("entity_name-field_name"))
+  .map((c) => ({ label: c.label, value: c.value as number }));
+```
+
+### FK（Lookup）の ID 抽出
+
+Lookup フィールドの値は `EntityReference(guid)` 形式で返る場合がある:
+
+```typescript
+function fkId(fk: any): string {
+  if (!fk) return "";
+  const s = String(fk);
+  const m = s.match(/\(([^)]+)\)/);
+  return m ? m[1] : s;
+}
+```
+
+## ダークモード（themeToVars パターン）
+
+FluentProvider を追加せず、CSS 変数でテーマを切り替える:
+
+```typescript
+import { webDarkTheme, webLightTheme } from "@fluentui/react-components";
+
+function themeToVars(theme: Record<string, string>): React.CSSProperties {
+  const v: Record<string, string> = {};
+  Object.entries(theme).forEach(([k, val]) => { v["--" + k] = val; });
+  return v as React.CSSProperties;
+}
+
+// JSX
+<div style={{ ...themeToVars((isDark ? webDarkTheme : webLightTheme) as unknown as Record<string, string>), height: "100%", overflow: "auto" }}>
+  <div className={styles.root}>
+    {/* コンテンツ */}
+  </div>
+</div>
+```
+
+## 多言語対応パターン
+
+```typescript
+function detectLanguage(): { code: string; name: string } {
+  const uiLang = (typeof Xrm !== "undefined" &&
+    Xrm.Utility?.getGlobalContext()?.userSettings?.languageId) || 1041;
+  if (uiLang === 1033) return { code: "en-US", name: "English" };
+  return { code: "ja-JP", name: "Japanese" };
+}
+
+const T: Record<string, Record<string, string>> = {
+  "ja-JP": { title: "ダッシュボード", save: "保存" },
+  "en-US": { title: "Dashboard", save: "Save" },
+};
+
+// コンポーネント内
+const lang = useMemo(() => detectLanguage(), []);
+const t = useCallback((k: string): string => T[lang.code]?.[k] || T["en-US"]?.[k] || k, [lang.code]);
+```
+
+## D3.js チャートパターン
+
+詳細は [コードパターンリファレンス](./references/code-patterns.md) を参照。
+
+- **棒グラフ**: `useRef<SVGSVGElement>` + `useEffect` 内で D3 描画
+- **ドーナツ**: `d3.pie()` + `d3.arc()` でセグメント描画
+- **地図**: SVG パスデータ + バブルオーバーレイ
+
+全チャートで共通ポイント:
+- `svg.selectAll("*").remove()` でクリーンアップしてから描画
+- ツールチップは `position: absolute` の `div` を `ref` で管理
+- レスポンシブ: `viewBox` を設定し `width: "100%"` + `height: "auto"`
+
+## ウィンドウキャッシュパターン
+
+ページ間遷移でデータを保持する:
+
+```typescript
+let _cache: MyData | null = (window as any).__ppMyPageData ?? null;
+
+// loadData 完了後
+_cache = result;
+(window as any).__ppMyPageData = result;
+
+// 初回レンダリング
+const [state, setState] = useState({ data: _cache, loading: _cache === null, error: null });
+```
+
+## 反復開発のベストプラクティス
+
+1. **最小構成で初回デプロイ** → 動作確認 → 段階的に機能追加
+2. **`generate-types` は最初に 1 回** — カラム名を確定してからコーディング
+3. **`.rows` は必ずスプレッド** — `[...res.rows]` で配列化
+4. **Map/Set のイテレーション** — `.forEach()` のみ。`for...of` は Power Apps ランタイムでエラー
+5. **スタイル変更はインクリメンタル** — 大規模なリファクタリングより小さな変更を頻繁にデプロイ
+6. **デプロイごとにブラウザキャッシュクリア** — Power Apps は積極的にキャッシュする

--- a/.github/skills/generative-page-dev/references/code-patterns.md
+++ b/.github/skills/generative-page-dev/references/code-patterns.md
@@ -1,0 +1,648 @@
+# Generative Pages コードパターンリファレンス
+
+## 1. コンポーネント基本構造
+
+```typescript
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import type {
+  ReadableTableRow,
+  GeneratedComponentProps,
+  my_entity,
+} from "./RuntimeTypes";
+import {
+  makeStyles,
+  tokens,
+  Card,
+  CardHeader,
+  Text,
+  Button,
+  Spinner,
+  TabList,
+  Tab,
+  Dropdown,
+  Option,
+  Switch,
+  Badge,
+  DataGrid,
+  DataGridHeader,
+  DataGridRow,
+  DataGridHeaderCell,
+  DataGridBody,
+  DataGridCell,
+  TableColumnDefinition,
+  createTableColumn,
+  Dialog,
+  DialogTrigger,
+  DialogSurface,
+  DialogTitle,
+  DialogBody,
+  DialogActions,
+  Tooltip,
+} from "@fluentui/react-components";
+import {
+  ChevronLeftRegular,
+  ChevronRightRegular,
+  ArrowUpRegular,
+  ArrowDownRegular,
+  FilterRegular,
+  SearchRegular,
+} from "@fluentui/react-icons";
+import * as d3 from "d3";
+
+/* ---------- スタイル ---------- */
+const useStyles = makeStyles({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalM,
+    padding: tokens.spacingHorizontalL,
+    height: "100%",
+    boxSizing: "border-box",
+    overflow: "auto",
+  },
+  card: {
+    padding: tokens.spacingHorizontalM,
+  },
+  row: {
+    display: "flex",
+    gap: tokens.spacingHorizontalM,
+    flexWrap: "wrap",
+  },
+});
+
+/* ---------- メインコンポーネント ---------- */
+const GeneratedComponent = (props: GeneratedComponentProps) => {
+  const styles = useStyles();
+  const { dataApi } = props;
+
+  // state, effects, render...
+  return <div className={styles.root}>{/* 内容 */}</div>;
+};
+
+export default GeneratedComponent;
+```
+
+## 2. DataAPI パターン
+
+### 2.1 全件取得（ページネーション対応）
+
+```typescript
+async function loadAllRows<T>(
+  api: GeneratedComponentProps["dataApi"],
+  table: string,
+  options: {
+    select: string[];
+    filter?: string;
+    orderBy?: string;
+    pageSize?: number;
+  }
+): Promise<ReadableTableRow<T>[]> {
+  let res = await api.queryTable(table as any, {
+    select: options.select as any,
+    filter: options.filter,
+    orderBy: options.orderBy,
+    pageSize: options.pageSize || 250,
+  });
+  let rows = [...res.rows]; // 必須: スプレッドで配列化
+  while (res.hasMoreRows && res.loadMoreRows) {
+    res = await res.loadMoreRows();
+    rows = rows.concat(res.rows);
+  }
+  return rows as any;
+}
+```
+
+### 2.2 Choice フィールドの取得
+
+```typescript
+const statusChoices = (
+  await dataApi.getChoices("entity_name-field_name")
+).map((c) => ({ label: c.label, value: c.value as number }));
+```
+
+### 2.3 Lookup ID 抽出
+
+Lookup（外部キー）フィールドの値は `EntityReference(guid)` 形式で返る:
+
+```typescript
+function fkId(fk: any): string {
+  if (!fk) return "";
+  const s = String(fk);
+  const m = s.match(/\(([^)]+)\)/);
+  return m ? m[1] : s;
+}
+```
+
+### 2.4 数値フィールドの安全な変換
+
+Dataverse から返る数値は文字列の場合がある:
+
+```typescript
+function num(v: any): number {
+  if (v == null) return 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+```
+
+### 2.5 日付フィールドの処理
+
+```typescript
+function parseDate(v: any): Date | null {
+  if (!v) return null;
+  const d = new Date(String(v));
+  return isNaN(d.getTime()) ? null : d;
+}
+```
+
+## 3. 集計パターン
+
+### 3.1 Map ベースの集計（forEach 必須）
+
+```typescript
+function aggregateByKey<T>(
+  rows: T[],
+  keyFn: (r: T) => string,
+  valueFn: (r: T) => number
+): Map<string, number> {
+  const map = new Map<string, number>();
+  rows.forEach((r) => {
+    const k = keyFn(r);
+    map.set(k, (map.get(k) || 0) + valueFn(r));
+  });
+  return map;
+}
+
+// Map の利用時は forEach または スプレッド
+const entries: [string, number][] = [];
+map.forEach((v, k) => entries.push([k, v]));
+// または
+const entries2 = [...map.entries()];
+```
+
+> **⚠️ `for...of` は Map / Set に対して使用禁止** — Power Apps ランタイムでイテレータエラーが発生する。
+
+### 3.2 月次集計
+
+```typescript
+interface MonthlyData {
+  yearMonth: string; // "2024-04"
+  total: number;
+}
+
+function aggregateMonthly(
+  rows: ReadableTableRow<any>[],
+  dateField: string,
+  amountField: string
+): MonthlyData[] {
+  const map = new Map<string, number>();
+  rows.forEach((r) => {
+    const d = parseDate(r[dateField]);
+    if (!d) return;
+    const ym = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    map.set(ym, (map.get(ym) || 0) + num(r[amountField]));
+  });
+  const result: MonthlyData[] = [];
+  map.forEach((total, yearMonth) => result.push({ yearMonth, total }));
+  return result.sort((a, b) => a.yearMonth.localeCompare(b.yearMonth));
+}
+```
+
+## 4. D3.js チャートパターン
+
+### 4.1 棒グラフ（Bar Chart）
+
+```typescript
+interface BarChartProps {
+  data: { label: string; value: number }[];
+  width?: number;
+  height?: number;
+}
+
+const BarChart: React.FC<BarChartProps> = ({ data, width = 500, height = 300 }) => {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!svgRef.current || data.length === 0) return;
+
+    const svg = d3.select(svgRef.current);
+    svg.selectAll("*").remove(); // 必ずクリーンアップ
+
+    const margin = { top: 20, right: 20, bottom: 40, left: 60 };
+    const w = width - margin.left - margin.right;
+    const h = height - margin.top - margin.bottom;
+
+    const g = svg
+      .attr("viewBox", `0 0 ${width} ${height}`)
+      .append("g")
+      .attr("transform", `translate(${margin.left},${margin.top})`);
+
+    const x = d3
+      .scaleBand()
+      .domain(data.map((d) => d.label))
+      .range([0, w])
+      .padding(0.2);
+
+    const y = d3
+      .scaleLinear()
+      .domain([0, d3.max(data, (d) => d.value) || 0])
+      .nice()
+      .range([h, 0]);
+
+    // X 軸
+    g.append("g")
+      .attr("transform", `translate(0,${h})`)
+      .call(d3.axisBottom(x))
+      .selectAll("text")
+      .attr("transform", "rotate(-30)")
+      .style("text-anchor", "end")
+      .style("font-size", "11px");
+
+    // Y 軸
+    g.append("g").call(d3.axisLeft(y).ticks(5));
+
+    // バー
+    g.selectAll(".bar")
+      .data(data)
+      .enter()
+      .append("rect")
+      .attr("x", (d) => x(d.label) || 0)
+      .attr("y", (d) => y(d.value))
+      .attr("width", x.bandwidth())
+      .attr("height", (d) => h - y(d.value))
+      .attr("fill", tokens.colorBrandBackground)
+      .attr("rx", 4)
+      .on("mouseenter", (ev, d) => {
+        if (tooltipRef.current) {
+          tooltipRef.current.style.display = "block";
+          tooltipRef.current.style.left = `${ev.offsetX + 10}px`;
+          tooltipRef.current.style.top = `${ev.offsetY - 10}px`;
+          tooltipRef.current.textContent = `${d.label}: ${d.value.toLocaleString()}`;
+        }
+      })
+      .on("mouseleave", () => {
+        if (tooltipRef.current) tooltipRef.current.style.display = "none";
+      });
+  }, [data, width, height]);
+
+  return (
+    <div style={{ position: "relative", width: "100%" }}>
+      <svg ref={svgRef} style={{ width: "100%", height: "auto" }} />
+      <div
+        ref={tooltipRef}
+        style={{
+          display: "none",
+          position: "absolute",
+          background: tokens.colorNeutralBackground1,
+          border: `1px solid ${tokens.colorNeutralStroke1}`,
+          borderRadius: tokens.borderRadiusMedium,
+          padding: "4px 8px",
+          fontSize: "12px",
+          pointerEvents: "none",
+          zIndex: 10,
+        }}
+      />
+    </div>
+  );
+};
+```
+
+### 4.2 ドーナツチャート（Donut Chart）
+
+```typescript
+interface DonutChartProps {
+  data: { label: string; value: number; color: string }[];
+  size?: number;
+}
+
+const DonutChart: React.FC<DonutChartProps> = ({ data, size = 200 }) => {
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!svgRef.current || data.length === 0) return;
+
+    const svg = d3.select(svgRef.current);
+    svg.selectAll("*").remove();
+
+    const radius = size / 2;
+    const g = svg
+      .attr("viewBox", `0 0 ${size} ${size}`)
+      .append("g")
+      .attr("transform", `translate(${radius},${radius})`);
+
+    const pie = d3.pie<{ label: string; value: number; color: string }>()
+      .value((d) => d.value)
+      .sort(null);
+
+    const arc = d3.arc<d3.PieArcDatum<any>>()
+      .innerRadius(radius * 0.55)
+      .outerRadius(radius * 0.9);
+
+    g.selectAll("path")
+      .data(pie(data))
+      .enter()
+      .append("path")
+      .attr("d", arc as any)
+      .attr("fill", (d) => d.data.color);
+
+    // 中央テキスト
+    const total = data.reduce((s, d) => s + d.value, 0);
+    g.append("text")
+      .attr("text-anchor", "middle")
+      .attr("dy", "-0.2em")
+      .style("font-size", "18px")
+      .style("font-weight", "bold")
+      .text(total.toLocaleString());
+  }, [data, size]);
+
+  return <svg ref={svgRef} style={{ width: "100%", maxWidth: size, height: "auto" }} />;
+};
+```
+
+### 4.3 SVG 地図 + バブルオーバーレイ
+
+地図データは SVG パスの座標配列として定義し、バブル（円）を重ねる:
+
+```typescript
+interface MapRegion {
+  id: string;
+  name: string;
+  path: string; // SVG path data
+  cx: number; // バブル中心 X
+  cy: number; // バブル中心 Y
+}
+
+interface BubbleMapProps {
+  regions: MapRegion[];
+  values: Map<string, number>;
+  onRegionClick?: (id: string) => void;
+}
+
+const BubbleMap: React.FC<BubbleMapProps> = ({ regions, values, onRegionClick }) => {
+  const maxVal = Math.max(1, ...([...values.values()]));
+  const rScale = d3.scaleSqrt().domain([0, maxVal]).range([4, 30]);
+
+  return (
+    <svg viewBox="0 0 800 1000" style={{ width: "100%", height: "auto" }}>
+      {/* 地域パス */}
+      {regions.map((r) => (
+        <path
+          key={r.id}
+          d={r.path}
+          fill={tokens.colorNeutralBackground3}
+          stroke={tokens.colorNeutralStroke1}
+          strokeWidth={0.5}
+          onClick={() => onRegionClick?.(r.id)}
+          style={{ cursor: onRegionClick ? "pointer" : "default" }}
+        />
+      ))}
+      {/* バブル */}
+      {regions.map((r) => {
+        const val = values.get(r.id) || 0;
+        if (val === 0) return null;
+        return (
+          <circle
+            key={`bubble-${r.id}`}
+            cx={r.cx}
+            cy={r.cy}
+            r={rScale(val)}
+            fill={tokens.colorBrandBackground}
+            fillOpacity={0.6}
+            stroke={tokens.colorBrandForeground1}
+            strokeWidth={1}
+            onClick={() => onRegionClick?.(r.id)}
+            style={{ cursor: "pointer" }}
+          />
+        );
+      })}
+    </svg>
+  );
+};
+```
+
+## 5. ダークモード対応
+
+### themeToVars パターン（FluentProvider 不要）
+
+```typescript
+import { webDarkTheme, webLightTheme } from "@fluentui/react-components";
+
+function themeToVars(
+  theme: Record<string, string>
+): React.CSSProperties {
+  const v: Record<string, string> = {};
+  Object.entries(theme).forEach(([k, val]) => {
+    v["--" + k] = val;
+  });
+  return v as React.CSSProperties;
+}
+
+// コンポーネント内
+const [isDark, setIsDark] = useState(false);
+
+// JSX: 外側 div にテーマ CSS 変数を適用
+<div
+  style={{
+    ...themeToVars(
+      (isDark ? webDarkTheme : webLightTheme) as unknown as Record<string, string>
+    ),
+    height: "100%",
+    overflow: "auto",
+  }}
+>
+  <div className={styles.root}>
+    <Switch
+      label={isDark ? "ダークモード" : "ライトモード"}
+      checked={isDark}
+      onChange={(_, d) => setIsDark(d.checked)}
+    />
+    {/* コンテンツ */}
+  </div>
+</div>
+```
+
+## 6. 多言語対応（i18n）
+
+```typescript
+function detectLanguage(): { code: string; name: string } {
+  const uiLang =
+    (typeof Xrm !== "undefined" &&
+      Xrm.Utility?.getGlobalContext()?.userSettings?.languageId) ||
+    1041;
+  if (uiLang === 1033) return { code: "en-US", name: "English" };
+  return { code: "ja-JP", name: "Japanese" };
+}
+
+const T: Record<string, Record<string, string>> = {
+  "ja-JP": {
+    title: "ダッシュボード",
+    loading: "読み込み中...",
+    error: "エラーが発生しました",
+    noData: "データがありません",
+    save: "保存",
+    cancel: "キャンセル",
+  },
+  "en-US": {
+    title: "Dashboard",
+    loading: "Loading...",
+    error: "An error occurred",
+    noData: "No data available",
+    save: "Save",
+    cancel: "Cancel",
+  },
+};
+
+// コンポーネント内での使用
+const lang = useMemo(() => detectLanguage(), []);
+const t = useCallback(
+  (k: string): string => T[lang.code]?.[k] || T["en-US"]?.[k] || k,
+  [lang.code]
+);
+```
+
+## 7. KPI カード
+
+```typescript
+interface KpiCardProps {
+  title: string;
+  value: string;
+  subValue?: string;
+  trend?: { value: number; label: string };
+  icon?: React.ReactNode;
+}
+
+const KpiCard: React.FC<KpiCardProps> = ({ title, value, subValue, trend, icon }) => (
+  <Card style={{ minWidth: 180, flex: "1 1 180px" }}>
+    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+      <div>
+        <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>
+          {title}
+        </Text>
+        <div>
+          <Text size={600} weight="bold">{value}</Text>
+        </div>
+        {subValue && (
+          <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>
+            {subValue}
+          </Text>
+        )}
+        {trend && (
+          <Badge
+            appearance="filled"
+            color={trend.value >= 0 ? "success" : "danger"}
+            style={{ marginTop: 4 }}
+          >
+            {trend.value >= 0 ? "↑" : "↓"} {Math.abs(trend.value).toFixed(1)}%{" "}
+            {trend.label}
+          </Badge>
+        )}
+      </div>
+      {icon && <div style={{ color: tokens.colorBrandForeground1 }}>{icon}</div>}
+    </div>
+  </Card>
+);
+```
+
+## 8. DataGrid テーブル
+
+```typescript
+const columns: TableColumnDefinition<MyRow>[] = [
+  createTableColumn({
+    columnId: "name",
+    renderHeaderCell: () => "名前",
+    renderCell: (item) => <Text>{item.name}</Text>,
+    compare: (a, b) => a.name.localeCompare(b.name),
+  }),
+  createTableColumn({
+    columnId: "amount",
+    renderHeaderCell: () => "売上",
+    renderCell: (item) => <Text>{item.amount.toLocaleString()}円</Text>,
+    compare: (a, b) => a.amount - b.amount,
+  }),
+];
+
+// JSX
+<DataGrid items={items} columns={columns} sortable>
+  <DataGridHeader>
+    <DataGridRow>
+      {({ renderHeaderCell }) => (
+        <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>
+      )}
+    </DataGridRow>
+  </DataGridHeader>
+  <DataGridBody<MyRow>>
+    {({ item, rowId }) => (
+      <DataGridRow<MyRow> key={rowId}>
+        {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
+      </DataGridRow>
+    )}
+  </DataGridBody>
+</DataGrid>
+```
+
+## 9. フィルター UI（Dropdown）
+
+```typescript
+const [selectedArea, setSelectedArea] = useState<string>("all");
+
+<Dropdown
+  placeholder="エリアを選択"
+  value={selectedArea === "all" ? "全エリア" : selectedArea}
+  onOptionSelect={(_, d) => setSelectedArea(d.optionValue || "all")}
+>
+  <Option value="all">全エリア</Option>
+  {areas.map((a) => (
+    <Option key={a.id} value={a.id}>{a.name}</Option>
+  ))}
+</Dropdown>
+```
+
+## 10. ウィンドウキャッシュ
+
+Power Apps ページ遷移時にデータを保持する:
+
+```typescript
+const CACHE_KEY = "__ppMyPageData";
+
+let _cache: MyData | null = (window as any)[CACHE_KEY] ?? null;
+
+// データロード完了後
+_cache = result;
+(window as any)[CACHE_KEY] = result;
+
+// useState の初期値にキャッシュを使用
+const [data, setData] = useState<MyData | null>(_cache);
+const [loading, setLoading] = useState(_cache === null);
+
+useEffect(() => {
+  if (_cache) {
+    setData(_cache);
+    setLoading(false);
+    return;
+  }
+  // fetch data...
+}, []);
+```
+
+## 11. 数値フォーマット
+
+```typescript
+function fmtN(v: number): string {
+  if (Math.abs(v) >= 1e8) return (v / 1e8).toFixed(1) + "億";
+  if (Math.abs(v) >= 1e4) return (v / 1e4).toFixed(1) + "万";
+  return v.toLocaleString();
+}
+
+function fmtPct(v: number): string {
+  return (v * 100).toFixed(1) + "%";
+}
+
+function fmtCurrency(v: number, currency = "JPY"): string {
+  return new Intl.NumberFormat("ja-JP", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0,
+  }).format(v);
+}
+```

--- a/.github/skills/generative-page-dev/references/troubleshooting.md
+++ b/.github/skills/generative-page-dev/references/troubleshooting.md
@@ -1,0 +1,223 @@
+# Generative Pages トラブルシューティング
+
+## 1. PAC CLI 関連
+
+### 1.1 `pac model genpage upload` が失敗する
+
+**症状**: `Error: The term 'pac' is not recognized` またはバージョンエラー
+
+**対処**:
+```powershell
+# PAC CLI のバージョン確認（>= 2.3.1 必須）
+pac help
+
+# 最新版に更新
+dotnet tool update --global Microsoft.PowerApps.CLI.Tool
+```
+
+### 1.2 認証エラー
+
+**症状**: `Error: No active auth profile found`
+
+**対処**:
+```powershell
+# 認証プロファイル確認
+pac auth list
+
+# 新規作成（対話式ブラウザ認証）
+pac auth create --environment https://your-env.crm7.dynamics.com
+
+# 既存プロファイルに切り替え
+pac auth select --index <n>
+```
+
+### 1.3 `generate-types` でテーブルが見つからない
+
+**症状**: `Table 'xxx' not found`
+
+**対処**:
+- テーブルの論理名（例: `cr123_store`）を使用しているか確認。表示名（例: `店舗`）は不可
+- 認証先の環境にそのテーブルが存在するか確認
+- カンマ区切りにスペースを入れない: `"entity1,entity2"` ✅ / `"entity1, entity2"` ❌
+
+### 1.4 デプロイ後にページが更新されない
+
+**対処**:
+1. ブラウザのハードリロード（Ctrl+Shift+R）
+2. ブラウザキャッシュクリア
+3. Power Apps のプレビューキャッシュ: URL に `&clearcache=1` パラメータ追加
+4. InPrivate / シークレットウィンドウで確認
+
+## 2. ランタイムエラー
+
+### 2.1 `TypeError: xxx is not a function` (Map/Set イテレーション)
+
+**原因**: Power Apps ランタイムは ES6 イテレータプロトコルを完全サポートしていない。`for...of` を `Map` / `Set` に使うとイテレータエラーが発生する。
+
+**NG**:
+```typescript
+for (const [key, value] of myMap) { /* エラー！ */ }
+for (const item of mySet) { /* エラー！ */ }
+```
+
+**OK**:
+```typescript
+myMap.forEach((value, key) => { /* OK */ });
+mySet.forEach((item) => { /* OK */ });
+
+// 配列化してからイテレーション
+const entries = [...myMap.entries()];
+entries.forEach(([key, value]) => { /* OK */ });
+```
+
+> **注意**: 配列に対する `for...of` は問題ない。制限は `Map` と `Set` のみ。
+
+### 2.2 `.rows` が配列メソッドを持たない
+
+**原因**: `dataApi.queryTable()` の返却値 `res.rows` は配列風オブジェクトだが、純粋な配列ではない場合がある。
+
+**対処**: 必ずスプレッドで配列化する:
+```typescript
+let rows = [...res.rows];  // ✅
+// let rows = res.rows;     // ❌ 配列メソッドが動かない場合あり
+```
+
+### 2.3 `FluentProvider` を追加すると描画が壊れる
+
+**原因**: Power Apps ランタイムはルートで `FluentProvider` を既に提供している。再度ラップすると React 17 でダブルレンダーが発生し、テーマやスタイルが壊れる。
+
+**対処**: `FluentProvider` は絶対に追加しない。ダークモードは `themeToVars` パターンを使用（[コードパターン](./code-patterns.md) セクション 5 参照）。
+
+### 2.4 `100vh` / `100vw` でレイアウトが壊れる
+
+**原因**: Generative Page はモデル駆動型アプリのフレーム内に表示される。`100vh` はフレーム全体の高さではなくビューポート全体を取るため、スクロールやオーバーフローが発生する。
+
+**対処**:
+```typescript
+// ❌
+const useStyles = makeStyles({ root: { height: "100vh", width: "100vw" } });
+
+// ✅
+const useStyles = makeStyles({
+  root: {
+    height: "100%",
+    display: "flex",
+    flexDirection: "column",
+    overflow: "auto",
+  },
+});
+```
+
+### 2.5 コンポーネントが真っ白（何も表示されない）
+
+**チェックリスト**:
+1. `export default GeneratedComponent` が存在するか？
+2. コンポーネント名が `GeneratedComponent` か？
+3. `props: GeneratedComponentProps` の型が正しいか？
+4. `useEffect` 内で未処理の例外が発生していないか？
+5. ブラウザの DevTools console でエラーを確認
+
+### 2.6 データが空（ロードされない）
+
+**チェックリスト**:
+1. `generate-types` でスキーマ生成済みか？
+2. `upload` 時に `--data-sources` で対象テーブルを指定したか？
+3. カラム名（`select` 配列）は `RuntimeTypes.ts` のものと一致しているか？
+4. `filter` 文字列の構文は正しいか？（OData フィルター構文）
+5. テーブルにデータが存在するか？（Power Apps の Advanced Find で確認）
+
+## 3. TypeScript / ビルドエラー
+
+### 3.1 `Cannot find module './RuntimeTypes'`
+
+**対処**: `generate-types` を実行して `RuntimeTypes.ts` を生成する。このファイルは IDE 上の型チェック用で、アップロード時には自動解決される。
+
+### 3.2 型エラー: DataAPI の `select` / `filter`
+
+**対処**: `as any` でキャストして回避:
+```typescript
+const res = await dataApi.queryTable("entity_name" as any, {
+  select: ["field1", "field2"] as any,
+  filter: "field1 ne null",
+});
+```
+
+### 3.3 `@fluentui/react-icons` のサイズ付きバリアントエラー
+
+**症状**: `Module '"@fluentui/react-icons"' has no exported member 'Add24Regular'`
+
+**対処**: サイズなしバリアントを使用:
+```typescript
+// ❌
+import { Add24Regular } from "@fluentui/react-icons";
+
+// ✅
+import { AddRegular } from "@fluentui/react-icons";
+```
+
+## 4. レイアウト・スタイル問題
+
+### 4.1 横スクロールが発生する
+
+**原因**: 固定幅の要素がコンテナ幅を超えている。
+
+**対処**:
+```typescript
+const useStyles = makeStyles({
+  root: {
+    maxWidth: "100%",
+    overflow: "hidden", // または "auto"
+    boxSizing: "border-box",
+  },
+  chart: {
+    width: "100%",     // 固定幅ではなく相対幅
+    minWidth: 0,       // flex child の shrink 有効化
+  },
+});
+```
+
+### 4.2 D3 チャートがレスポンシブにならない
+
+**対処**: `viewBox` + `width: "100%"` パターンを使用:
+```typescript
+svg
+  .attr("viewBox", `0 0 ${width} ${height}`)
+
+// JSX
+<svg ref={svgRef} style={{ width: "100%", height: "auto" }} />
+```
+
+### 4.3 地図表示で特定ブラウザのみ問題
+
+**対処**:
+- SVG パスに `transform` を使用する場合は `transform-origin` も指定
+- `pointer-events="all"` を SVG 要素に追加してクリックイベントを確実に受ける
+- Edge / Chrome でのテストを推奨
+
+## 5. パフォーマンス
+
+### 5.1 大量データでページが遅い
+
+**対処**:
+1. `pageSize: 250` でページネーション（デフォルト 250）
+2. 必要なカラムのみ `select` で指定（不要なカラムを含めない）
+3. 集計はフロントで一度だけ実行し `useMemo` でキャッシュ
+4. ウィンドウキャッシュパターン（[コードパターン](./code-patterns.md) セクション 10）でページ遷移を高速化
+5. DataGrid は仮想スクロールが組み込まれているので大量行に向いている
+
+### 5.2 D3 チャートの再描画が重い
+
+**対処**:
+- `useEffect` の依存配列を適切に設定（不要な再描画を防止）
+- `svg.selectAll("*").remove()` でクリーンアップ後に描画
+- `useMemo` でチャートデータの変換を一度だけ実行
+
+## 6. デプロイのベストプラクティス
+
+```
+1. ローカルで TypeScript エラーがないことを確認
+2. 最小構成で初回デプロイ → 動作確認
+3. 機能を段階的に追加し、各段階でデプロイ・確認
+4. エラー発生時はブラウザ DevTools の Console を確認
+5. ハードリロード（Ctrl+Shift+R）でキャッシュを無効化
+```


### PR DESCRIPTION
## 概要

Power Apps Generative Pages (genux) の開発・デバッグ・デプロイを支援するスキルを追加します。

### 既存の code-apps-dev スキルとの違い

| | Code Apps | Generative Pages |
|---|---|---|
| React | 18 | **17** |
| UI | Tailwind + shadcn | **Fluent UI V9** |
| チャート | - | **D3.js v7** |
| 構成 | マルチファイル | **単一 .tsx** |
| デプロイ | \
px power-apps push\ | **\pac model genpage upload\** |

### 追加ファイル

- \.github/skills/generative-page-dev/SKILL.md\ — メインスキル定義（技術スタック、開発フロー、DataAPI、ダークモード、多言語対応）
- \.github/skills/generative-page-dev/references/code-patterns.md\ — 再利用可能なコードパターン（D3 チャート、DataGrid、KPI カード、集計、フィルター等）
- \.github/skills/generative-page-dev/references/troubleshooting.md\ — PAC CLI、ランタイム、レイアウト、パフォーマンスのトラブルシューティング

### スキルのカバー範囲

- PAC CLI セットアップ・認証・スキーマ生成
- React 17 + Fluent UI V9 + D3.js の制約とパターン
- DataAPI のページネーション・Choice・Lookup 処理
- ダークモード（themeToVars パターン、FluentProvider 不使用）
- 多言語対応（Xrm.Utility ベース言語検出）
- Map/Set の forEach 必須制約
- 段階的デプロイのベストプラクティス