### PR TITLE
feat: Generative Pages デプロイ教訓追加 - タイムアウト対策/PublishXmlフォールバック

### DIFF
--- a/.github/skills/generative-page-dev/SKILL.md
+++ b/.github/skills/generative-page-dev/SKILL.md
@@ -62,7 +62,7 @@ uuid: ^9.0.1
 24. **D3 チャートのツールチップは `position: absolute` + 親コンテナ基準** — `position: fixed` は Generative Pages ランタイムのコンテナ構造でマウスから大きく離れた位置に表示される。ルート div に `position: "relative"` を設定し、ツールチップ div は `position: "absolute"` + `pointerEvents: "none"` で配置。`getBoundingClientRect()` + `scrollLeft`/`scrollTop` でコンテナオフセットを計算し、マウスの右10px・上10pxに表示する。Fluent UI の `Tooltip` コンポーネントは D3 SVG 要素には使えないため、生の HTML div + `innerHTML` で実装する
 25. **`pac model genpage upload` の新規ページ作成はタイムアウトしやすい** — 新規ページ（`--name` 指定）は既存ページ更新（`--page-id` 指定）より大幅に遅い。`--prompt` と `--agent-message` は **英語または最短の文字列** にすると成功率が上がる。日本語の長い文字列はサーバー側処理が重くなりタイムアウト（「タスクが取り消されました」）の原因になる。失敗したら英語の短い値でリトライする
 26. **`PublishXml` API はタイムアウトすることがある** — 公開処理は環境やサーバー応答状況によって完了まで時間がかかり、`PublishXml` がタイムアウトする場合がある。タイムアウトしたら、フォールバックとして `pac solution publish` を使う。PAC CLI 側の公開処理のほうが成功率が高い場合がある
-27. **SiteMap 更新スクリプトの `PublishXml` がハングしたら `pac solution publish` で代替** — `update_sitemap.py` の SiteMap XML PATCH は成功しても、最後の `PublishXml`（アプリ公開）でハングする場合がある。この場合、スクリプトを中断（Ctrl+C / kill）して `pac solution publish` を実行すれば公開される。SiteMap XML 更新自体は PATCH 時点で確定しているため、公開さえ通れば問題ない
+27. **SiteMap 更新処理の `PublishXml` がハングしたら `pac solution publish` で代替** — プロジェクト側で用意した SiteMap 更新スクリプト／手順で SiteMap XML PATCH が成功しても、最後の `PublishXml`（アプリ公開）でハングする場合がある。この場合、その処理を中断（Ctrl+C / kill）して `pac solution publish` を実行すれば公開される。SiteMap XML 更新自体は PATCH 時点で確定しているため、公開さえ通れば問題ない
 
 ## 開発フロー
 

--- a/.github/skills/generative-page-dev/SKILL.md
+++ b/.github/skills/generative-page-dev/SKILL.md
@@ -60,6 +60,9 @@ uuid: ^9.0.1
 22. **ガントチャート等のギャラリー行は固定 height + border-box** — `minHeight` + padding の組み合わせは D3 側の行位置計算とズレる。ギャラリー側は `height: 36px` + `boxSizing: "border-box"` で固定し、D3 側は `scaleBand` ではなく `headerH + i * rowH` の手動ピクセル計算でアイテム位置を決定する
 23. **DatePicker は使わず `<Input type="date">` を使う** — `@fluentui/react-datepicker-compat` の `DatePicker` は Generative Pages ランタイムでポップアップが透明になり背後のコンテンツと重なる。Portal 経由のレンダリングに背景色が適用されないため。Fluent UI `Input` に `type: "date"` を指定してブラウザネイティブの日付ピッカーを使う
 24. **D3 チャートのツールチップは `position: absolute` + 親コンテナ基準** — `position: fixed` は Generative Pages ランタイムのコンテナ構造でマウスから大きく離れた位置に表示される。ルート div に `position: "relative"` を設定し、ツールチップ div は `position: "absolute"` + `pointerEvents: "none"` で配置。`getBoundingClientRect()` + `scrollLeft`/`scrollTop` でコンテナオフセットを計算し、マウスの右10px・上10pxに表示する。Fluent UI の `Tooltip` コンポーネントは D3 SVG 要素には使えないため、生の HTML div + `innerHTML` で実装する
+25. **`pac model genpage upload` の新規ページ作成はタイムアウトしやすい** — 新規ページ（`--name` 指定）は既存ページ更新（`--page-id` 指定）より大幅に遅い。`--prompt` と `--agent-message` は **英語または最短の文字列** にすると成功率が上がる。日本語の長い文字列はサーバー側処理が重くなりタイムアウト（「タスクが取り消されました」）の原因になる。失敗したら英語の短い値でリトライする
+26. **`PublishXml` API は 120 秒でタイムアウトすることがある** — `auth_helper.py` の `timeout=120` ではサーバー応答が間に合わない場合がある。`PublishXml` がタイムアウトしたら、フォールバックとして `pac solution publish` を使う。PAC CLI は独自のタイムアウト管理を持ち、成功率が高い
+27. **SiteMap 更新スクリプトの `PublishXml` がハングしたら `pac solution publish` で代替** — `update_sitemap.py` の SiteMap XML PATCH は成功しても、最後の `PublishXml`（アプリ公開）でハングする場合がある。この場合、スクリプトを中断（Ctrl+C / kill）して `pac solution publish` を実行すれば公開される。SiteMap XML 更新自体は PATCH 時点で確定しているため、公開さえ通れば問題ない
 
 ## 開発フロー
 
@@ -150,14 +153,17 @@ export default GeneratedComponent;
 
 **新規ページ:**
 
+> **❗ 新規ページ作成はタイムアウトしやすい**。`--prompt` と `--agent-message` は **英語の短い文字列** を使う。
+> 日本語の長い文字列は「タスクが取り消されました」エラーの原因になる（2026-04-21 検証済み）。
+
 ```powershell
 pac model genpage upload `
   --app-id <app-id> `
   --code-file MyPage.tsx `
-  --name "ページ名" `
+  --name "PageName" `
   --data-sources "entity1,entity2" `
-  --prompt "ページの説明" `
-  --agent-message "変更内容の要約"
+  --prompt "short english description" `
+  --agent-message "short english summary"
 ```
 
 > **`--name` は新規ページ作成時に必須**。省略すると `The --name parameter is required when creating a new page.` エラー。既存ページ更新時（`--page-id` 指定時）は不要。
@@ -176,6 +182,7 @@ pac model genpage upload `
 ```
 
 > **PAC CLI v2.6.4 以降**: `--prompt` と `--agent-message` フラグが必須。省略するとエラーになる。
+> **デプロイのタイムアウト対策**: 新規ページ作成時は `--prompt` と `--agent-message` を **英語の短い文字列**（例: `--prompt "kanban" --agent-message "kanban board"`）にする。日本語の長い説明文はサーバー側でタイムアウト（「タスクが取り消されました」）を引き起こしやすい（2026-04-21 検証済み: 日本語で3回失敗 → 英語短縮で成功）。既存ページ更新時（`--page-id`）はこの問題は発生しにくい。
 
 ### Step 5.5: SiteMap 更新（デプロイ後に必ず実施 — 省略禁止）
 
@@ -185,7 +192,17 @@ pac model genpage upload `
 1. 既存 SiteMap を取得: `sitemaps?$select=sitemapid,sitemapname` で検索
 2. SiteMap XML に新しいページの `<SubArea GenPageId="{page-id}" ...>` を追加
 3. `PATCH sitemaps({id})` で XML を更新
-4. `PublishXml` でアプリを公開
+4. `PublishXml` でアプリを公開。**タイムアウトしたら `pac solution publish` で代替**
+
+**PublishXml タイムアウト時のフォールバック:**
+
+```powershell
+# Python スクリプトの PublishXml がタイムアウトした場合:
+# SiteMap XML の PATCH は完了済みなので、公開だけ行えばよい
+pac solution publish
+```
+
+> **注意**: `PublishXml` API は 120 秒でタイムアウトすることがある（環境の負荷に依存）。`pac solution publish` は PAC CLI 独自のタイムアウト管理で成功率が高い。
 
 **SubArea フォーマット:**
 

--- a/.github/skills/generative-page-dev/SKILL.md
+++ b/.github/skills/generative-page-dev/SKILL.md
@@ -61,7 +61,7 @@ uuid: ^9.0.1
 23. **DatePicker は使わず `<Input type="date">` を使う** — `@fluentui/react-datepicker-compat` の `DatePicker` は Generative Pages ランタイムでポップアップが透明になり背後のコンテンツと重なる。Portal 経由のレンダリングに背景色が適用されないため。Fluent UI `Input` に `type: "date"` を指定してブラウザネイティブの日付ピッカーを使う
 24. **D3 チャートのツールチップは `position: absolute` + 親コンテナ基準** — `position: fixed` は Generative Pages ランタイムのコンテナ構造でマウスから大きく離れた位置に表示される。ルート div に `position: "relative"` を設定し、ツールチップ div は `position: "absolute"` + `pointerEvents: "none"` で配置。`getBoundingClientRect()` + `scrollLeft`/`scrollTop` でコンテナオフセットを計算し、マウスの右10px・上10pxに表示する。Fluent UI の `Tooltip` コンポーネントは D3 SVG 要素には使えないため、生の HTML div + `innerHTML` で実装する
 25. **`pac model genpage upload` の新規ページ作成はタイムアウトしやすい** — 新規ページ（`--name` 指定）は既存ページ更新（`--page-id` 指定）より大幅に遅い。`--prompt` と `--agent-message` は **英語または最短の文字列** にすると成功率が上がる。日本語の長い文字列はサーバー側処理が重くなりタイムアウト（「タスクが取り消されました」）の原因になる。失敗したら英語の短い値でリトライする
-26. **`PublishXml` API は 120 秒でタイムアウトすることがある** — `auth_helper.py` の `timeout=120` ではサーバー応答が間に合わない場合がある。`PublishXml` がタイムアウトしたら、フォールバックとして `pac solution publish` を使う。PAC CLI は独自のタイムアウト管理を持ち、成功率が高い
+26. **`PublishXml` API はタイムアウトすることがある** — 公開処理は環境やサーバー応答状況によって完了まで時間がかかり、`PublishXml` がタイムアウトする場合がある。タイムアウトしたら、フォールバックとして `pac solution publish` を使う。PAC CLI 側の公開処理のほうが成功率が高い場合がある
 27. **SiteMap 更新スクリプトの `PublishXml` がハングしたら `pac solution publish` で代替** — `update_sitemap.py` の SiteMap XML PATCH は成功しても、最後の `PublishXml`（アプリ公開）でハングする場合がある。この場合、スクリプトを中断（Ctrl+C / kill）して `pac solution publish` を実行すれば公開される。SiteMap XML 更新自体は PATCH 時点で確定しているため、公開さえ通れば問題ない
 
 ## 開発フロー

--- a/.github/skills/generative-page-dev/troubleshooting.md
+++ b/.github/skills/generative-page-dev/troubleshooting.md
@@ -238,7 +238,7 @@ const useStyles = makeStyles({
 ```typescript
 // ❌ NG: viewBox + height: "auto"（Generative Pages で高さ 0px になる）
 svg.attr("viewBox", `0 0 ${width} ${height}`);
-// JSX: <svg ref={ref} style={{ width: "100%", height: "auto" }} />
+// JSX: <svg ref={svgRef} style={{ width: "100%", height: "auto" }} />
 
 // ✅ OK: 明示的 width/height（requestAnimationFrame 内で取得）
 var container = svgRef.current.parentElement;
@@ -246,7 +246,7 @@ var W = container ? container.clientWidth : 400;
 if (W < 200) W = 400;
 var H = 200;
 svg.attr("width", W).attr("height", H);
-// JSX: <div style={{ height: 200, overflow: "hidden" }}><svg ref={ref} style={{ display: "block" }} /></div>
+// JSX: <div style={{ height: 200, overflow: "hidden" }}><svg ref={svgRef} style={{ display: "block" }} /></div>
 ```
 
 ### 4.3 地図表示で特定ブラウザのみ問題
@@ -345,14 +345,14 @@ async function handleSave() {
 ```typescript
 // ❌ NG: viewBox + height: "auto"
 svg.attr("viewBox", "0 0 500 200");
-// JSX: <svg ref={ref} style={{ width: "100%", height: "auto" }} />
+// JSX: <svg ref={svgRef} style={{ width: "100%", height: "auto" }} />
 
 // ✅ OK: 明示的 width/height
 var container = svgRef.current.parentElement;
 var W = container ? container.clientWidth : 400;
 var H = 200;
 svg.attr("width", W).attr("height", H);
-// JSX: <div style={{ height: 200, overflow: "hidden" }}><svg ref={ref} style={{ display: "block" }} /></div>
+// JSX: <div style={{ height: 200, overflow: "hidden" }}><svg ref={svgRef} style={{ display: "block" }} /></div>
 ```
 
 **重要**: SVG のラッパー `<div>` にも明示的な `height` を設定すること。`height: "auto"` は禁止。

--- a/.github/skills/generative-page-dev/troubleshooting.md
+++ b/.github/skills/generative-page-dev/troubleshooting.md
@@ -233,14 +233,20 @@ const useStyles = makeStyles({
 
 ### 4.2 D3 チャートがレスポンシブにならない
 
-**対処**: `viewBox` + `width: "100%"` パターンを使用:
+**対処**: **`viewBox` は使わない**（ルール 19 参照）。コンテナの `clientWidth` から動的にサイズを取得する:
 
 ```typescript
-svg
-  .attr("viewBox", `0 0 ${width} ${height}`)
+// ❌ NG: viewBox + height: "auto"（Generative Pages で高さ 0px になる）
+svg.attr("viewBox", `0 0 ${width} ${height}`);
+// JSX: <svg ref={ref} style={{ width: "100%", height: "auto" }} />
 
-// JSX
-<svg ref={svgRef} style={{ width: "100%", height: "auto" }} />
+// ✅ OK: 明示的 width/height（requestAnimationFrame 内で取得）
+var container = svgRef.current.parentElement;
+var W = container ? container.clientWidth : 400;
+if (W < 200) W = 400;
+var H = 200;
+svg.attr("width", W).attr("height", H);
+// JSX: <div style={{ height: 200, overflow: "hidden" }}><svg ref={ref} style={{ display: "block" }} /></div>
 ```
 
 ### 4.3 地図表示で特定ブラウザのみ問題
@@ -279,6 +285,9 @@ svg
 3. 機能を段階的に追加し、各段階でデプロイ・確認
 4. エラー発生時はブラウザ DevTools の Console を確認
 5. ハードリロード（Ctrl+Shift+R）でキャッシュを無効化
+6. 新規ページは --prompt と --agent-message を英語短縮文字列にする（§7.8 参照）
+7. 成功したら Page ID を .env に保存し、以降は --page-id で更新する
+8. PublishXml がタイムアウトしたら pac solution publish でフォールバック（§7.9 参照）
 ```
 
 ## 7. DataAPI の書き込み制限
@@ -451,3 +460,75 @@ React.createElement(Input, {
 ```
 
 **注意**: `popupSurface` プロップや CSS 注入（`<style>` タグ挿入）でも解決できなかった（2026-04-21 検証済み）。
+
+### 7.8 新規ページの `pac model genpage upload` が「タスクが取り消されました」で失敗する
+
+**症状**: TypeScript トランスパイル成功後、`Pushing generated page...` のまま長時間待機し、最終的に以下のエラーで失敗する:
+
+```
+Error: Error updating project in batch: タスクが取り消されました。
+    タスクが取り消されました。
+```
+
+**原因**: 新規ページ作成（`--name` 指定）はサーバー側の処理が重い。`--prompt` や `--agent-message` に日本語の長い文字列を指定すると、サーバー側のタイムアウトを超過する。
+
+**対処**:
+
+1. **`--prompt` と `--agent-message` を英語の短い文字列にする**:
+
+```powershell
+# ❌ NG: 日本語の長い説明文（タイムアウトしやすい）
+pac model genpage upload --app-id <id> --code-file Page.tsx --name "Page" `
+  --data-sources "table1,table2" `
+  --prompt "4レーンカンバンボード: ドラッグ＆ドロップでステータス変更" `
+  --agent-message "未着手/作業中/完了/保留の4レーンカンバンボード"
+
+# ✅ OK: 英語の短い文字列（成功率が高い）
+pac model genpage upload --app-id <id> --code-file Page.tsx --name "Page" `
+  --data-sources "table1,table2" `
+  --prompt "kanban" `
+  --agent-message "kanban board"
+```
+
+2. **失敗したらリトライ**（サーバー側の一時的な問題の場合もある）
+3. **既存ページ更新（`--page-id`）ではこの問題は発生しにくい** — 新規作成時のみの制限
+
+**検証結果** (2026-04-21):
+- 日本語 `--prompt` + `--agent-message`: 3回連続タイムアウト
+- 英語短縮 `--prompt "kanban" --agent-message "kanban board"`: 1回目で成功
+
+### 7.9 `PublishXml` API がタイムアウトする（SiteMap 更新後の公開）
+
+**症状**: `update_sitemap.py` で SiteMap XML の PATCH は成功するが、最後の `PublishXml` API 呼び出しで 120 秒以上応答がなくタイムアウトする:
+
+```
+requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='xxx.crm7.dynamics.com', port=443): Read timed out. (read timeout=120)
+```
+
+**原因**: `PublishXml` はサーバー側で全カスタマイズを公開する重い処理。環境の負荷状況やカスタマイズの量によっては 120 秒では完了しない。
+
+**対処**: `pac solution publish` をフォールバックとして使う:
+
+```powershell
+# Python スクリプトの PublishXml がタイムアウトした場合:
+# 1. スクリプトを中断（Ctrl+C / kill）
+# 2. PAC CLI で公開（独自のタイムアウト管理で成功率が高い）
+pac solution publish
+```
+
+**重要**: SiteMap XML の PATCH は `PublishXml` の前に完了しているため、`pac solution publish` で公開さえ通れば SiteMap の変更は反映される。
+
+### 7.10 新規ページ作成が既存ページ更新より大幅に遅い
+
+**症状**: `--page-id` 指定の既存ページ更新は数秒〜数十秒で完了するが、`--name` 指定の新規ページ作成は数分かかる、またはタイムアウトする。
+
+**原因**: 新規ページ作成はサーバー側で以下の追加処理が発生する:
+- ページレコードの作成
+- Generative Page プロジェクトの初期化
+- AI モデルとの関連付け
+
+**対処**:
+1. 新規作成は余裕を持ったタイムアウトを想定する
+2. `--prompt` と `--agent-message` を英語の短い文字列にする（§7.8 参照）
+3. 一度作成に成功したら Page ID を `.env` に保存し、以降は `--page-id` で更新する
+4. 作成成功後の初回確認はブラウザのハードリロード（Ctrl+Shift+R）を行う


### PR DESCRIPTION
## 変更概要

### SKILL.md (絶対遵守ルール追加)
- Rule 25: 新規ページの pac model genpage upload はタイムアウトしやすい。--prompt/--agent-message は英語の短い文字列にする
- Rule 26: PublishXml API が 120秒タイムアウトしたら pac solution publish でフォールバック
- Rule 27: SiteMap 更新スクリプトの PublishXml がハングしたら kill して pac solution publish で代替
- Step 5: 新規デプロイの --prompt/--agent-message を英語短縮に変更
- Step 5.5: PublishXml タイムアウト時のフォールバック手順を追加

### troubleshooting.md (トラブルシューティング追加)
- 7.8: 新規ページの「タスクが取り消されました」エラー（日本語3回失敗→英語短縮で成功）
- 7.9: PublishXml API タイムアウト（pac solution publish フォールバック）
- 7.10: 新規ページ作成が既存更新より大幅に遅い（原因と対処）
- 4.2: viewBox パターンを修正（ルール19との矛盾解消）
- セクション6: デプロイベストプラクティスに3項目追加

### 検証環境
- Power Apps Generative Pages (React 17 + Fluent UI V9)
- jpgeek.crm7.dynamics.com (2026-04-21 検証済み)