### PR TITLE
feat: Code Apps メール送信スキル (PDF 添付 + JST タイムゾーン教訓)

### DIFF
--- a/.github/agents/GeekPowerCode.agent.md
+++ b/.github/agents/GeekPowerCode.agent.md
@@ -39,6 +39,7 @@ argument-hint: "Power Platform の開発作業を指示してください（例:
 | Phase 1.5: Generative Page     | `generative-page-dev`    | `.github/skills/generative-page-dev/SKILL.md`    |
 | Phase 2: Code Apps UI 設計     | `code-apps-design`       | `.github/skills/code-apps-design/SKILL.md`       |
 | Phase 2: Code Apps 開発        | `code-apps-dev`          | `.github/skills/code-apps-dev/SKILL.md`          |
+| Code Apps CSP（iframe/外部接続）| `code-apps-csp`          | `.github/skills/code-apps-csp/SKILL.md`          |
 | Phase 2.5: Power Automate      | `power-automate-flow`    | `.github/skills/power-automate-flow/SKILL.md`    |
 | Phase 3: Copilot Studio        | `copilot-studio-agent`   | `.github/skills/copilot-studio-agent/SKILL.md`   |
 | Phase 3.5: CS トリガー         | `copilot-studio-trigger` | `.github/skills/copilot-studio-trigger/SKILL.md` |

--- a/.github/agents/GeekPowerCode.agent.md
+++ b/.github/agents/GeekPowerCode.agent.md
@@ -40,6 +40,7 @@ argument-hint: "Power Platform の開発作業を指示してください（例:
 | Phase 2: Code Apps UI 設計     | `code-apps-design`       | `.github/skills/code-apps-design/SKILL.md`       |
 | Phase 2: Code Apps 開発        | `code-apps-dev`          | `.github/skills/code-apps-dev/SKILL.md`          |
 | Code Apps CSP（iframe/外部接続）| `code-apps-csp`          | `.github/skills/code-apps-csp/SKILL.md`          |
+| Code Apps メール送信（PDF添付） | `code-apps-mail`         | `.github/skills/code-apps-mail/SKILL.md`         |
 | Phase 2.5: Power Automate      | `power-automate-flow`    | `.github/skills/power-automate-flow/SKILL.md`    |
 | Phase 3: Copilot Studio        | `copilot-studio-agent`   | `.github/skills/copilot-studio-agent/SKILL.md`   |
 | Phase 3.5: CS トリガー         | `copilot-studio-trigger` | `.github/skills/copilot-studio-trigger/SKILL.md` |
@@ -147,24 +148,32 @@ argument-hint: "Power Platform の開発作業を指示してください（例:
 56. **`auth_helper.get_token()` は `scope` キーワード引数のみ**。`.env` から TENANT_ID を自動読み込み
 57. **MSAL Python 3.14 互換性問題**。MSAL 内部トークンキャッシュが壊れる（scopes が dict として格納される）。`auth_helper.py` のインメモリキャッシュ + フォールバック再構築で対策済み。`PP_NO_PERSISTENT_CACHE=1` で OS 永続キャッシュ無効化可能
 
+### Code Apps メール送信（PDF 添付）
+
+58. **HTML→PDF 変換は DOMParser + hidden div**。Code Apps サンドボックスの cross-origin 制約により、iframe 内での html2canvas は失敗する。`DOMParser.parseFromString()` でパースし、hidden div（`position: fixed; left: -9999px`）に展開して html2canvas でキャプチャする
+59. **SendEmailV2 の ContentBytes は `@base64ToBinary()` で渡す**。`@{json(...)['pdfBase64']}` の文字列補間だと PA が再 base64 エンコードし、PDF が破損する。`@base64ToBinary(json(...)['pdfBase64'])` でバイナリに変換して渡す
+60. **メール本文の時刻は `convertTimeZone()` で JST 変換**。`utcNow('yyyy年...')` は UTC で 9 時間ずれる。`convertTimeZone(utcNow(),'UTC','Tokyo Standard Time','yyyy年MM月dd日 HH:mm')` を使う
+61. **html2canvas の幅を HTML テンプレートのコンテナ幅に合わせる**。テンプレートが 1100px のとき、794px でキャプチャすると右端が切れる。`width: NNNpx` を正規表現で検出し、`html2canvas({ width, windowWidth })` に反映する
+62. **Memo 列 1MB 制限に注意**。PDF base64 が大きいため `html2canvas({ scale: 1.5 })` + `canvas.toDataURL("image/jpeg", 0.7)` でサイズ抑制。scale: 2 + JPEG 0.85 は 1MB 超のリスク
+
 ### Teams チャネル情報の取得
 
-58. **Teams チャネル情報はリンク URL から取得**。ユーザーには「Teams アプリで投稿先チャネルを **右クリック → 「チャネルへのリンクを取得」** でコピーした URL をペーストしてください」と案内する。URL から groupId（チーム ID）と channelId を自動抽出する
+63. **Teams チャネル情報はリンク URL から取得**。ユーザーには「Teams アプリで投稿先チャネルを **右クリック → 「チャネルへのリンクを取得」** でコピーした URL をペーストしてください」と案内する。URL から groupId（チーム ID）と channelId を自動抽出する
 
 ### モデル駆動型アプリ
 
-59. **既存アプリの SiteMap は PATCH で XML を直接更新**。新しい SiteMap を作成して `AddAppComponents` で追加すると `0x80050111` (App can't have multiple site maps) エラー。既存 SiteMap を `appmodulecomponent?$filter=componenttype eq 62` で特定し、`PATCH sitemaps({id})` で `sitemapxml` を更新する
-60. **`appmodulecomponent` は `appmoduleidunique` でフィルタ不可**。プロパティが存在しない。`componenttype eq 62` で全件取得し `objectid` で照合する
+64. **既存アプリの SiteMap は PATCH で XML を直接更新**。新しい SiteMap を作成して `AddAppComponents` で追加すると `0x80050111` (App can't have multiple site maps) エラー。既存 SiteMap を `appmodulecomponent?$filter=componenttype eq 62` で特定し、`PATCH sitemaps({id})` で `sitemapxml` を更新する
+65. **`appmodulecomponent` は `appmoduleidunique` でフィルタ不可**。プロパティが存在しない。`componenttype eq 62` で全件取得し `objectid` で照合する
 
 ### 設計フェーズ（最重要 — 全フェーズ共通原則）
 
-61. **全フェーズで設計→ユーザー承認→実装の順序を守る**。Dataverse・Code Apps・Power Automate・Copilot Studio のいずれも、設計をユーザーに提示し「この設計で進めてよいですか？」と承認を得てから構築に進む
-62. **テーブル設計**: 全 Lookup リレーションシップを設計書に明記。漏れると Lookup が機能しない
-63. **テーブル設計**: デモデータは全テーブル（従属テーブル含む）に計画。コメント等の従属テーブルにもデモデータを用意
-64. **テーブル設計**: マスタテーブルは要件から網羅的に洗い出す。カテゴリ・場所・設備等、ユーザーが言及した分類はすべてマスタ化
-65. **Code Apps 設計**: `code-apps-design` スキルを読み、画面構成・コンポーネント選定・Lookup 名前解決パターンを設計。ユーザー承認後に `code-apps-dev` で実装
-66. **Power Automate 設計**: フロー名・トリガー・アクション・接続・通知先を設計書として提示。ユーザー承認後にデプロイスクリプトを作成
-67. **Copilot Studio 設計**: エージェント名・Instructions・推奨プロンプト・会話の開始のメッセージ・会話の開始のクイック返信・ナレッジ・ツール（MCP Server）を設計書として提示。ユーザー承認後に構築
+66. **全フェーズで設計→ユーザー承認→実装の順序を守る**。Dataverse・Code Apps・Power Automate・Copilot Studio のいずれも、設計をユーザーに提示し「この設計で進めてよいですか？」と承認を得てから構築に進む
+67. **テーブル設計**: 全 Lookup リレーションシップを設計書に明記。漏れると Lookup が機能しない
+68. **テーブル設計**: デモデータは全テーブル（従属テーブル含む）に計画。コメント等の従属テーブルにもデモデータを用意
+69. **テーブル設計**: マスタテーブルは要件から網羅的に洗い出す。カテゴリ・場所・設備等、ユーザーが言及した分類はすべてマスタ化
+70. **Code Apps 設計**: `code-apps-design` スキルを読み、画面構成・コンポーネント選定・Lookup 名前解決パターンを設計。ユーザー承認後に `code-apps-dev` で実装
+71. **Power Automate 設計**: フロー名・トリガー・アクション・接続・通知先を設計書として提示。ユーザー承認後にデプロイスクリプトを作成
+72. **Copilot Studio 設計**: エージェント名・Instructions・推奨プロンプト・会話の開始のメッセージ・会話の開始のクイック返信・ナレッジ・ツール（MCP Server）を設計書として提示。ユーザー承認後に構築
 
 ## 作業手順
 

--- a/.github/skills/code-apps-csp/SKILL.md
+++ b/.github/skills/code-apps-csp/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: code-apps-csp
+description: "Code Apps のコンテンツセキュリティポリシー（CSP）を構成する。iframe 埋め込み（Google Maps 等）・外部 API 接続・外部フォント/スクリプト読み込み時に CSP ディレクティブを追加する。"
+category: security
+triggers:
+  - "iframe"
+  - "embed"
+  - "埋め込み"
+  - "地図"
+  - "Google Maps"
+  - "マップ"
+  - "CSP"
+  - "Content Security Policy"
+  - "frame-src"
+  - "connect-src"
+  - "frame blocked"
+  - "フレームブロック"
+  - "Refused to frame"
+  - "外部 API"
+  - "外部スクリプト"
+---
+
+# Code Apps CSP 構成スキル
+
+Code Apps で **iframe 埋め込み**・**外部 API 呼び出し**・**外部リソース読み込み** を行う場合、
+CSP（Content Security Policy）ディレクティブの追加が必要。
+設定なしでは `Refused to frame` エラーでブロックされる。
+
+> **参考**: https://learn.microsoft.com/ja-jp/power-apps/developer/code-apps/how-to/content-security-policy
+
+## デフォルト CSP ディレクティブ
+
+Code Apps は以下のデフォルト CSP で動作する:
+
+| ディレクティブ | デフォルト値 | 用途 |
+|---|---|---|
+| `frame-src` | `'self'` | **iframe で読み込める外部サイト** |
+| `connect-src` | `'none'` | **fetch/XHR で接続できる外部 API** |
+| `script-src` | `'self' <platform>` | 外部 JS スクリプト |
+| `img-src` | `'self' data: <platform>` | 外部画像 |
+| `style-src` | `'self' 'unsafe-inline'` | 外部 CSS |
+| `font-src` | `'self'` | 外部フォント |
+| `frame-ancestors` | `'self' https://*.powerapps.com` | Code Apps を iframe に埋め込むホスト |
+| `media-src` | `'self' data:` | 動画・音声 |
+| `default-src` | `'self'` | 上記以外のデフォルト |
+
+> **重要**: カスタム値はデフォルト値に**マージ**される。デフォルト値が `'none'` の場合はカスタム値で**置換**される。
+
+## よくあるユースケースと必要な設定
+
+### 1. Google Maps iframe 埋め込み（地図表示）
+
+**症状**: `Refused to frame 'https://maps.google.com/'` CSP 違反エラー
+
+**必要な設定**:
+| ディレクティブ | 追加するソース |
+|---|---|
+| `frame-src` | `https://www.google.com` `https://maps.google.com` |
+
+**コード例**（iframe 埋め込み）:
+```tsx
+const embedUrl = `https://maps.google.com/maps?q=${lat},${lon}&z=16&output=embed`;
+
+<iframe
+  src={embedUrl}
+  className="w-full h-full"
+  style={{ border: 0 }}
+  loading="lazy"
+  referrerPolicy="no-referrer-when-downgrade"
+  title="地図"
+  sandbox="allow-scripts allow-same-origin allow-popups"
+/>
+```
+
+### 2. 外部 API 呼び出し（REST API / GraphQL）
+
+**症状**: `Refused to connect to 'https://api.example.com/'`
+
+**必要な設定**:
+| ディレクティブ | 追加するソース |
+|---|---|
+| `connect-src` | 呼び出し先のドメイン（例: `https://api.example.com`） |
+
+### 3. 外部動画/メディア埋め込み（YouTube 等）
+
+**症状**: `Refused to frame 'https://www.youtube.com/'`
+
+**必要な設定**:
+| ディレクティブ | 追加するソース |
+|---|---|
+| `frame-src` | `https://www.youtube.com` |
+
+### 4. 外部フォント読み込み（Google Fonts 等）
+
+**必要な設定**:
+| ディレクティブ | 追加するソース |
+|---|---|
+| `font-src` | `https://fonts.gstatic.com` |
+| `style-src` | `https://fonts.googleapis.com` |
+
+### 5. 外部 CDN スクリプト
+
+**必要な設定**:
+| ディレクティブ | 追加するソース |
+|---|---|
+| `script-src` | CDN ドメイン（例: `https://cdn.jsdelivr.net`） |
+
+## 設定方法
+
+### 方法 A: Power Platform 管理センター（GUI — 推奨）
+
+1. [Power Platform 管理センター](https://admin.powerplatform.microsoft.com/) にサインイン
+2. **環境** > 対象環境を選択
+3. **設定** > **製品** を展開 > **プライバシー + セキュリティ**
+4. **コンテンツ セキュリティ ポリシー** セクション > **アプリ** タブを選択
+5. 対象ディレクティブの **「既定値を使用」トグルをオフ** にする
+6. 追加したいソース URL を入力
+7. **保存**
+
+> **注意**: カスタム値はデフォルト値とマージされる。デフォルトが消えることはない。
+
+### 方法 B: REST API（PowerShell）
+
+Power Platform API で CSP をプログラム的に設定できる。
+
+**1. 認証トークン取得**:
+```powershell
+$tenantId = "<your-tenant-id>"
+$clientId = "9cee029c-6210-4654-90bb-17e6e9d36617"  # Power Platform CLI の client ID
+$token = azureauth aad --resource "https://api.powerplatform.com/" --tenant $tenantId --client $clientId --output token | ConvertTo-SecureString -AsPlainText -Force
+```
+
+**2. 現在の設定を取得**:
+```powershell
+# Get-CodeAppContentSecurityPolicy 関数（下記参照）を読み込み済みの前提
+Get-CodeAppContentSecurityPolicy -Token $token -Env "<environment-id>"
+```
+
+**3. ディレクティブを更新**（例: Google Maps iframe 許可）:
+```powershell
+$env = "<environment-id>"
+$directives = (Get-CodeAppContentSecurityPolicy -Token $token -Env $env).Directives
+
+# frame-src に Google Maps を追加
+$directives['Frame-Src'] = @('https://www.google.com', 'https://maps.google.com')
+
+Set-CodeAppContentSecurityPolicy -Token $token -Env $env -Directives $directives
+```
+
+> **警告**: `-Directives` はディレクティブコレクション全体を置換する。
+> 必ず既存の設定を GET してからマージして PATCH すること。
+
+**PowerShell ヘルパー関数**: https://learn.microsoft.com/ja-jp/power-apps/developer/code-apps/how-to/content-security-policy#powershell-helper-functions
+
+## 実装手順チェックリスト
+
+iframe 埋め込み（地図等）を実装する場合の手順:
+
+1. **CSP 設定を先に追加** — Power Platform 管理センターで `frame-src` にドメインを追加
+2. **コード実装** — iframe コンポーネントを作成
+3. **ビルド＆デプロイ** — `npm run build && pac code push`
+4. **動作確認** — ブラウザの DevTools > Console で CSP 違反エラーがないことを確認
+
+> **重要**: CSP 設定なしでデプロイすると iframe がブロックされて何も表示されない。
+> 必ず **CSP 設定 → デプロイ** の順序で行う。
+
+## トラブルシューティング
+
+### iframe が表示されない（白い空白）
+
+1. ブラウザ DevTools > Console を開く
+2. `Refused to frame` エラーがあれば **`frame-src`** に該当ドメインを追加
+3. CSP 設定後、ブラウザキャッシュをクリアしてリロード
+
+### fetch/API 呼び出しが失敗する
+
+1. Console で `Refused to connect` エラーを確認
+2. **`connect-src`** に API ドメインを追加
+
+### CSP 設定が反映されない
+
+- 設定変更後、**数分のラグ** がある場合がある
+- ブラウザのハードリロード（Ctrl+Shift+R）を試す
+- Power Platform 管理センターで設定が保存されているか再確認
+
+## 教訓（検証済み 2026-04-23）
+
+- **Code Apps の CSP はデフォルトで厳格**。`frame-src: 'self'` のため、外部サイトの iframe は全てブロックされる
+- **Google Maps iframe は `https://maps.google.com` と `https://www.google.com` の両方が必要**。リダイレクトで両ドメインを経由する
+- **CSP 設定は環境レベル**。同一環境内の全 Code Apps に適用される
+- **`sandbox` 属性を適切に設定**。`allow-scripts allow-same-origin allow-popups` で地図操作・ポップアップを許可
+- **iframe の代替手段も検討**。CSP 設定が困難な場合は SVG 地図やリンクボタンで代替できる

--- a/.github/skills/code-apps-mail/SKILL.md
+++ b/.github/skills/code-apps-mail/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: code-apps-mail
+description: "Code Apps からの PDF メール添付送信。HTML→PDF 変換（html2canvas + jsPDF）、Power Automate フローの ContentBytes 二重エンコード回避、UTC→JST 時刻変換の検証済みパターン。"
+category: integration
+triggers:
+  - "メール送信"
+  - "PDF添付"
+  - "PDF生成"
+  - "htmlToPdfBase64"
+  - "SendEmailV2"
+  - "ContentBytes"
+  - "base64"
+  - "添付ファイル"
+  - "メール添付"
+  - "PDF破損"
+  - "UTC"
+  - "JST"
+  - "タイムゾーン"
+  - "html2canvas"
+  - "jsPDF"
+---
+
+# Code Apps メール送信スキル（PDF 添付）
+
+Code Apps から Power Automate フロー経由で **PDF 添付メール** を送信するための検証済みパターン。
+HTML 帳票を PDF に変換し、Dataverse Memo フィールド経由でフローに渡す方式。
+
+> **2026-04-24 検証済み**: 作業前確認書（A4 ランドスケープ 1100px）・保守レポート（A4 ポートレート 1000px）の
+> 両方で PDF 添付メール送信に成功。
+
+## アーキテクチャ
+
+```
+Code Apps                          Power Automate                    Outlook
+───────                            ──────────                        ───────
+1. HTML テンプレート生成
+2. html2canvas + jsPDF で PDF base64
+3. Dataverse Memo 列に JSON 書き込み
+   (pdfBase64 含む)
+                                   4. Dataverse トリガーで検知
+                                   5. JSON パース
+                                   6. base64ToBinary() でバイナリ変換
+                                   7. SendEmailV2 で PDF 添付送信
+                                                                    8. 受信者が PDF を開く
+```
+
+## 絶対遵守ルール（検証済み教訓）
+
+### 1. HTML → PDF 変換: iframe を使わない（最重要）
+
+**Code Apps はサンドボックス iframe 内で実行される。**
+隠し iframe を追加で作成すると cross-origin 制約で html2canvas が正常動作しない。
+
+```
+❌ NG: iframe を作成して HTML を書き込み → html2canvas(iframe.body)
+✅ OK: DOMParser + hidden div → html2canvas(container)
+```
+
+**正しいパターン（DOMParser + hidden div）:**
+
+```typescript
+const parser = new DOMParser();
+const parsed = parser.parseFromString(html, "text/html");
+
+const container = document.createElement("div");
+container.style.position = "fixed";
+container.style.left = "-9999px";
+container.style.top = "0";
+container.style.width = `${renderWidth}px`;
+container.style.background = "#fff";
+container.style.zIndex = "-9999";
+
+// <style> タグをコピー
+parsed.querySelectorAll("style").forEach((s) => {
+  const clone = document.createElement("style");
+  clone.textContent = s.textContent;
+  container.appendChild(clone);
+});
+
+// <body> の中身をコピー
+const bodyClone = document.createElement("div");
+bodyClone.innerHTML = parsed.body.innerHTML;
+container.appendChild(bodyClone);
+
+document.body.appendChild(container);
+```
+
+### 2. HTML の幅に応じて iframe/div 幅を動的調整
+
+HTML テンプレートのコンテナ幅（例: `.sheet { width: 1100px }`）が A4 デフォルト幅 (794px) を超える場合、
+キャプチャ幅を合わせないとコンテンツが切れて破損 PDF になる。
+
+```typescript
+function detectContentWidth(html: string): number {
+  const matches = [...html.matchAll(/width\s*:\s*(\d{3,4})px/g)];
+  if (matches.length === 0) return 794;
+  const maxWidth = Math.max(...matches.map((m) => parseInt(m[1], 10)));
+  return maxWidth > 794 ? maxWidth + 40 : 794; // padding 分を加算
+}
+```
+
+### 3. ランドスケープ/ポートレートの自動検出
+
+`@page { size: A4 landscape }` を正規表現で検出し、jsPDF の orientation と寸法を切り替える。
+
+```typescript
+function detectLandscape(html: string): boolean {
+  return /size\s*:\s*A4\s+landscape/i.test(html);
+}
+
+const orientation = isLandscape ? "landscape" : "portrait";
+const pageWidth = isLandscape ? 297 : 210;   // mm
+const pageHeight = isLandscape ? 210 : 297;
+```
+
+### 4. html2canvas パラメータ
+
+```typescript
+const canvas = await html2canvas(container, {
+  scale: 1.5,           // 2 だとファイルサイズが大きすぎる（Memo 1MB 制限）
+  useCORS: true,
+  allowTaint: true,
+  logging: false,
+  width: renderWidth,
+  windowWidth: renderWidth,
+  backgroundColor: "#ffffff",
+});
+```
+
+| パラメータ | 値 | 理由 |
+|---|---|---|
+| `scale` | 1.5 | 2 だと PDF が ~500KB-1MB 超。1.5 で十分な品質 |
+| `useCORS` | true | 外部画像（署名 data URL 等）を正しくキャプチャ |
+| `allowTaint` | true | data: URL 画像のレンダリングを許可 |
+
+### 5. base64 変換: Blob → FileReader（安全な方式）
+
+`btoa()` は大きなバイナリ文字列でスタックオーバーフローする可能性がある。
+`pdf.output("datauristring").split(",")[1]` も不安定。
+
+**正しいパターン（Blob → FileReader）:**
+
+```typescript
+const blob = pdf.output("blob");
+return new Promise<string>((resolve, reject) => {
+  const reader = new FileReader();
+  reader.onloadend = () => {
+    const dataUrl = reader.result as string;
+    const base64 = dataUrl.split(",")[1];
+    if (!base64 || base64.length < 100) {
+      reject(new Error("PDF base64 conversion failed"));
+      return;
+    }
+    resolve(base64);
+  };
+  reader.onerror = () => reject(new Error("FileReader error"));
+  reader.readAsDataURL(blob);
+});
+```
+
+### 6. JPEG 品質は 0.7 で十分
+
+```typescript
+const imgData = canvas.toDataURL("image/jpeg", 0.7);
+```
+
+0.85 だとファイルサイズが大きくなりすぎる。0.7 で視認性に問題なし。
+
+---
+
+## Power Automate フロー側の教訓
+
+### 7. ContentBytes は `base64ToBinary()` で渡す（最重要）
+
+**SendEmailV2 の Attachments.ContentBytes に `@{...}` 文字列補間で base64 を渡すと二重エンコードされる。**
+Power Automate は ContentBytes を「テキスト」と解釈し、さらに base64 エンコードしてしまう。
+結果、受信者が開くと base64 テキスト文字列が見えるだけで PDF として認識されない。
+
+```
+❌ NG: "ContentBytes": "@{json(...)['pdfBase64']}"
+         → 文字列補間 → PA が再 base64 → 二重エンコード → PDF 破損
+
+✅ OK: "ContentBytes": "@base64ToBinary(json(...)['pdfBase64'])"
+         → base64 をバイナリに変換 → PA がそのまま添付 → 正常な PDF
+```
+
+**Python フロー定義コード:**
+
+```python
+# ❌ NG
+"ContentBytes": f"@{{{J}?['pdfBase64']}}",
+
+# ✅ OK
+"ContentBytes": f"@base64ToBinary({J}?['pdfBase64'])",
+```
+
+### 8. メール本文の時刻は JST（convertTimeZone 必須）
+
+Power Automate の `utcNow()` は UTC を返す。日本のユーザー向けには JST に変換が必要。
+
+```
+❌ NG: @{utcNow('yyyy年MM月dd日 HH:mm')}
+         → UTC 時刻が表示される（日本時間より 9 時間ずれる）
+
+✅ OK: @{convertTimeZone(utcNow(),'UTC','Tokyo Standard Time','yyyy年MM月dd日 HH:mm')}
+         → JST で正しい時刻が表示される
+```
+
+**Python フロー定義コード:**
+
+```python
+# ❌ NG
+f"@{{utcNow('yyyy年MM月dd日 HH:mm')}}"
+
+# ✅ OK
+f"@{{convertTimeZone(utcNow(),'UTC','Tokyo Standard Time','yyyy年MM月dd日 HH:mm')}}"
+```
+
+> **注意**: `utcNow()` を Dataverse のタイムスタンプ列に書き込む場合は UTC のまま。
+> Dataverse が自動的にユーザーのタイムゾーンで表示する。JST 変換が必要なのは **表示用テキスト** のみ。
+
+### 9. Dataverse Memo フィールドの 1MB 制限
+
+`rcwr_pendingemailjson` (Memo, MaxLength=1048576) に JSON を書き込む。
+PDF base64 が含まれるため、`scale: 1.5` + `JPEG 0.7` でファイルサイズを抑制する必要がある。
+
+**見積もり:**
+
+| 帳票 | HTML 幅 | scale | JPEG 品質 | PDF base64 サイズ |
+|---|---|---|---|---|
+| 作業前確認書 (landscape) | 1100px | 1.5 | 0.7 | ~200-400KB |
+| 保守レポート (portrait) | 1000px | 1.5 | 0.7 | ~150-300KB |
+| JSON ヘッダー | - | - | - | ~1KB |
+
+1MB 制限内に収まる。`scale: 2` + `JPEG 0.85` だと 500KB-1MB 超で危険。
+
+---
+
+## データフロー全体像
+
+### Code Apps 側（sendEmail 関数）
+
+```typescript
+// 1. HTML テンプレート生成
+const html = generatePreWorkConfirmationHtml({ ... });
+
+// 2. PDF base64 変換
+const pdfBase64 = await htmlToPdfBase64(html);
+
+// 3. Dataverse Memo 列に JSON 書き込み（フローがトリガーされる）
+await client.updateRecordAsync("bookableresourcebookings", bookingId, {
+  rcwr_pendingemailjson: JSON.stringify({
+    documentType: "prework",
+    toEmail,
+    subject: "作業前確認書 — WO-001",
+    customerName: "株式会社○○",
+    workOrderName: "WO-001",
+    resourceName: "鈴木 正平",
+    pdfBase64,
+  }),
+});
+```
+
+### Power Automate 側（Dataverse トリガーフロー）
+
+```
+トリガー: bookableresourcebooking.rcwr_pendingemailjson 更新時
+  ↓
+条件: pendingemailjson が空でない
+  ↓
+SendEmailV2:
+  To: json(...)['toEmail']
+  Subject: json(...)['subject']
+  Body: HTML メールテンプレート
+  Attachments:
+    Name: 作業前確認書.pdf / 保守レポート.pdf（documentType で分岐）
+    ContentBytes: @base64ToBinary(json(...)['pdfBase64'])   ← ★ 必須
+  ↓
+Dataverse Update: タイムスタンプ更新 + pendingemailjson をクリア
+```
+
+---
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対策 |
+|---|---|---|
+| PDF が破損（開けない） | ContentBytes の二重 base64 エンコード | `@base64ToBinary()` を使う |
+| PDF 内に base64 テキストが見える | 同上 | 同上 |
+| PDF の右側が切れている | html2canvas のキャプチャ幅が HTML コンテナ幅より小さい | `detectContentWidth()` で動的調整 |
+| PDF が空白ページ | iframe 内で html2canvas が失敗 | DOMParser + hidden div 方式に変更 |
+| メール時刻が 9 時間ずれる | `utcNow()` が UTC | `convertTimeZone(...,'Tokyo Standard Time')` |
+| PDF ファイルサイズが大きすぎる | scale=2, JPEG 0.85 | scale=1.5, JPEG 0.7 に下げる |
+| Memo 列に書き込み失敗 | JSON が 1MB 超 | scale/JPEG 品質を下げる |
+
+---
+
+## 依存パッケージ
+
+```json
+{
+  "jspdf": "^4.2.1",
+  "html2canvas": "^1.4.1"
+}
+```

--- a/.github/skills/code-apps-mail/SKILL.md
+++ b/.github/skills/code-apps-mail/SKILL.md
@@ -108,6 +108,7 @@ function detectLandscape(html: string): boolean {
   return /size\s*:\s*A4\s+landscape/i.test(html);
 }
 
+const isLandscape = detectLandscape(html);
 const orientation = isLandscape ? "landscape" : "portrait";
 const pageWidth = isLandscape ? 297 : 210;   // mm
 const pageHeight = isLandscape ? 210 : 297;


### PR DESCRIPTION
## 概要

Code Apps から Power Automate フロー経由で PDF 添付メールを送信する際の検証済みパターンをスキル化。

## 追加内容

### .github/skills/code-apps-mail/SKILL.md (新規)
- HTML→PDF 変換: DOMParser + hidden div 方式（iframe 禁止）
- html2canvas + jsPDF パラメータ最適化 (scale: 1.5, JPEG 0.7)
- SendEmailV2 ContentBytes: @base64ToBinary() 必須（二重エンコード回避）
- UTC→JST: convertTimeZone() パターン
- Dataverse Memo フィールド 1MB 制限への対策
- Blob→FileReader による安全な base64 変換
- トラブルシューティングガイド

### .github/agents/GeekPowerCode.agent.md (更新)
- フェーズ別スキルテーブルに code-apps-mail を追加
- 絶対遵守ルール #58-#62 として教訓を追記