### PR TITLE
feat: GenPage URL パラメータ渡しの教訓追加（ハッシュフラグメント方式）

### DIFF
--- a/.github/agents/GeekPowerCode.agent.md
+++ b/.github/agents/GeekPowerCode.agent.md
@@ -165,15 +165,19 @@ argument-hint: "Power Platform の開発作業を指示してください（例:
 64. **既存アプリの SiteMap は PATCH で XML を直接更新**。新しい SiteMap を作成して `AddAppComponents` で追加すると `0x80050111` (App can't have multiple site maps) エラー。既存 SiteMap を `appmodulecomponent?$filter=componenttype eq 62` で特定し、`PATCH sitemaps({id})` で `sitemapxml` を更新する
 65. **`appmodulecomponent` は `appmoduleidunique` でフィルタ不可**。プロパティが存在しない。`componenttype eq 62` で全件取得し `objectid` で照合する
 
+### Generative Page URL パラメータ
+
+66. **GenPage への URL パラメータ渡しはハッシュフラグメント（`#`）を使う**。MDA のクエリパラメータに `&date=2026-04-24` 等のカスタム値を追加すると MDA ルーティングエラーになる。`#date=2026-04-24` のようにハッシュフラグメントで渡し、GenPage 側で `window.location.hash` から読み取る
+
 ### 設計フェーズ（最重要 — 全フェーズ共通原則）
 
-66. **全フェーズで設計→ユーザー承認→実装の順序を守る**。Dataverse・Code Apps・Power Automate・Copilot Studio のいずれも、設計をユーザーに提示し「この設計で進めてよいですか？」と承認を得てから構築に進む
-67. **テーブル設計**: 全 Lookup リレーションシップを設計書に明記。漏れると Lookup が機能しない
-68. **テーブル設計**: デモデータは全テーブル（従属テーブル含む）に計画。コメント等の従属テーブルにもデモデータを用意
-69. **テーブル設計**: マスタテーブルは要件から網羅的に洗い出す。カテゴリ・場所・設備等、ユーザーが言及した分類はすべてマスタ化
-70. **Code Apps 設計**: `code-apps-design` スキルを読み、画面構成・コンポーネント選定・Lookup 名前解決パターンを設計。ユーザー承認後に `code-apps-dev` で実装
-71. **Power Automate 設計**: フロー名・トリガー・アクション・接続・通知先を設計書として提示。ユーザー承認後にデプロイスクリプトを作成
-72. **Copilot Studio 設計**: エージェント名・Instructions・推奨プロンプト・会話の開始のメッセージ・会話の開始のクイック返信・ナレッジ・ツール（MCP Server）を設計書として提示。ユーザー承認後に構築
+67. **全フェーズで設計→ユーザー承認→実装の順序を守る**。Dataverse・Code Apps・Power Automate・Copilot Studio のいずれも、設計をユーザーに提示し「この設計で進めてよいですか？」と承認を得てから構築に進む
+68. **テーブル設計**: 全 Lookup リレーションシップを設計書に明記。漏れると Lookup が機能しない
+69. **テーブル設計**: デモデータは全テーブル（従属テーブル含む）に計画。コメント等の従属テーブルにもデモデータを用意
+70. **テーブル設計**: マスタテーブルは要件から網羅的に洗い出す。カテゴリ・場所・設備等、ユーザーが言及した分類はすべてマスタ化
+71. **Code Apps 設計**: `code-apps-design` スキルを読み、画面構成・コンポーネント選定・Lookup 名前解決パターンを設計。ユーザー承認後に `code-apps-dev` で実装
+72. **Power Automate 設計**: フロー名・トリガー・アクション・接続・通知先を設計書として提示。ユーザー承認後にデプロイスクリプトを作成
+73. **Copilot Studio 設計**: エージェント名・Instructions・推奨プロンプト・会話の開始のメッセージ・会話の開始のクイック返信・ナレッジ・ツール（MCP Server）を設計書として提示。ユーザー承認後に構築
 
 ## 作業手順
 

--- a/.github/skills/generative-page-dev/SKILL.md
+++ b/.github/skills/generative-page-dev/SKILL.md
@@ -86,6 +86,29 @@ uuid: ^9.0.1
 25. **`pac model genpage upload` の新規ページ作成はタイムアウトしやすい** — 新規ページ（`--name` 指定）は既存ページ更新（`--page-id` 指定）より大幅に遅い。`--prompt` と `--agent-message` は **英語または最短の文字列** にすると成功率が上がる。日本語の長い文字列はサーバー側処理が重くなりタイムアウト（「タスクが取り消されました」）の原因になる。失敗したら英語の短い値でリトライする
 26. **`PublishXml` API はタイムアウトすることがある** — 公開処理は環境やサーバー応答状況によって完了まで時間がかかり、`PublishXml` がタイムアウトする場合がある。タイムアウトしたら、フォールバックとして `pac solution publish` を使う。PAC CLI 側の公開処理のほうが成功率が高い場合がある
 27. **SiteMap 更新処理の `PublishXml` がハングしたら `pac solution publish` で代替** — プロジェクト側で用意した SiteMap 更新スクリプト／手順で SiteMap XML PATCH が成功しても、最後の `PublishXml`（アプリ公開）でハングする場合がある。この場合、その処理を中断（Ctrl+C / kill）して `pac solution publish` を実行すれば公開される。SiteMap XML 更新自体は PATCH 時点で確定しているため、公開さえ通れば問題ない
+28. **URL パラメータ渡しはハッシュフラグメント（`#`）を使う** — MDA（モデル駆動型アプリ）の URL にカスタムクエリパラメータ（`&date=2026-04-24` 等）を追加すると、MDA ルーティングが不明なパラメータとしてエラーを返しページが開けない。**ハッシュフラグメント（`#date=2026-04-24`）を使う**。ハッシュはサーバーに送信されないため MDA ルーティングに干渉しない。GenPage 側では `window.location.hash` で読み取る
+
+```typescript
+// ❌ NG: クエリパラメータ → MDA ルーティングエラー
+// https://org.crm7.dynamics.com/main.aspx?appid=...&pagetype=genux&id=...&date=2026-04-24
+
+// ✅ OK: ハッシュフラグメント → MDA ルーティングに干渉しない
+// https://org.crm7.dynamics.com/main.aspx?appid=...&pagetype=genux&id=...#date=2026-04-24
+
+function getInitialDate(): string {
+  try {
+    var hash = window.location.hash || "";
+    var m = hash.match(/date=([\d]{4}-[\d]{2}-[\d]{2})/);
+    if (m) {
+      var parsed = new Date(m[1] + "T00:00:00");
+      if (!isNaN(parsed.getTime())) return m[1];
+    }
+  } catch (e) { /* ignore */ }
+  return todayStr();
+}
+```
+
+> **メール通知等で URL を生成する場合**: `approvalUrl = baseUrl + "#date=" + dateIso` のようにハッシュで日付を渡す。Power Automate フローのメール本文にリンクボタンとして埋め込む
 
 ## 開発フロー
 


### PR DESCRIPTION
## 概要\n\nGenerative Page（genux）に外部から日付等のパラメータを渡す際の検証済みパターンをスキルに追加。\n\n## 背景\n\n2026-04-24 に日報承認 GenPage へメール通知リンクから日付を渡す機能を実装した際、MDA のクエリパラメータ（&date=2026-04-24）がルーティングエラーを引き起こすことを発見。ハッシュフラグメント（#date=2026-04-24）で解決。\n\n## 変更内容\n\n### .github/skills/generative-page-dev/SKILL.md\n- **教訓 #28**: MDA はカスタムクエリパラメータ非対応。ハッシュフラグメント（#key=value）を使い、GenPage 側で window.location.hash から読み取る\n- getInitialDate() パターンのコード例を含む\n- メール通知 URL 生成時の注意事項\n\n### .github/agents/GeekPowerCode.agent.md\n- **絶対遵守ルール #66**: GenPage URL パラメータはハッシュフラグメント必須\n- 番号リナンバリング（66→67〜）\n\n## 教訓の詳細\n\n| 項目 | 詳細 |\n|------|------|\n| 問題 | &date=2026-04-24 を URL に追加 → MDA ルーティングエラー |\n| 原因 | MDA のサーバーサイドルーティングがカスタムクエリパラメータを認識できない |\n| 解決 | #date=2026-04-24 ハッシュフラグメントを使用（サーバーに送信されない） |\n| 読み取り | window.location.hash で GenPage ランタイムからアクセス可能 |