### PR TITLE
feat: Code Apps ログインユーザー識別のベストプラクティスを追加（CSP 安全な systemuserid 取得）

### DIFF
--- a/.github/agents/GeekPowerCode.agent.md
+++ b/.github/agents/GeekPowerCode.agent.md
@@ -177,15 +177,23 @@ argument-hint: "Power Platform の開発作業を指示してください（例:
 
 68. **SiteMap SubArea は `GenPageId` ではなく `Url` 属性を使う**。`GenPageId="{page-id}"` で GenPage を SiteMap に追加すると「新しいサブエリア」と表示され `<Titles>` が反映されないことがある。`Url="/main.aspx?pagetype=genux&amp;id={page-id}"` を使うと `<Titles>` が MDA メニューに正しく表示される（2026-04-24 検証済み）。既存エンティティ SubArea の直後に挿入し、`PublishXml` でアプリを公開する
 
+### Code Apps ログインユーザー識別
+
+69. **ログインユーザーの systemuserid は SDK `getContext()` + systemuser テーブルクエリで取得する（唯一の方法）**。`Xrm` オブジェクトは Code Apps で利用不可（undefined）。`fetch("/api/data/v9.2/WhoAmI")` は CSP `connect-src: 'none'` でブロック。`npx power-apps add-dataverse-api -n WhoAmI` で生成される `WhoAmIService` も内部で `executeAsync`（= fetch）を使うため CSP でブロック（`{"success":false,"error":{}}` を返す）。**`retrieveMultipleRecordsAsync` だけが postMessage ベースで CSP 安全**
+70. **SDK `getContext().user.objectId` は Entra AAD Object ID であり Dataverse systemuserid ではない**。`systemuser` テーブルの `azureactivedirectoryobjectid` 列で Entra objectId → systemuserid をマッピングする。`systemuser` はデータソースとして `npx power-apps add-data-source --api-id dataverse --resource-name systemuser --org-url {DATAVERSE_URL}` で追加する
+71. **GUID 比較は必ず `.toLowerCase()` で統一する**。Dataverse API は大文字小文字混在で GUID を返すことがある。`_resource_value`、`_userid_value`、`systemuserid` 等の比較時に大文字/小文字の不一致でフィルタが機能しなくなる
+72. **systemuserid 未取得時は空配列 `[]` を返す（null フォールバックで全データ表示しない）**。ユーザー ID が解決できなかった場合に全件表示するとセキュリティリスク。`if (!currentResourceId) return []` パターンで他ユーザーのデータを表示しない
+73. **`executeAsync` も CSP でブロックされる**。`add-dataverse-api` で生成したサービス（WhoAmI 等）は `executeAsync` を使うが、これも内部で `fetch()` を使用しており CSP でブロックされる。Code Apps で CSP 安全な SDK メソッドは `retrieveMultipleRecordsAsync` / `retrieveRecordAsync` / `createRecordAsync` / `updateRecordAsync` / `deleteRecordAsync` のみ（すべて postMessage ベース）
+
 ### 設計フェーズ（最重要 — 全フェーズ共通原則）
 
-69. **全フェーズで設計→ユーザー承認→実装の順序を守る**。Dataverse・Code Apps・Power Automate・Copilot Studio のいずれも、設計をユーザーに提示し「この設計で進めてよいですか？」と承認を得てから構築に進む
-70. **テーブル設計**: 全 Lookup リレーションシップを設計書に明記。漏れると Lookup が機能しない
-71. **テーブル設計**: デモデータは全テーブル（従属テーブル含む）に計画。コメント等の従属テーブルにもデモデータを用意
-72. **テーブル設計**: マスタテーブルは要件から網羅的に洗い出す。カテゴリ・場所・設備等、ユーザーが言及した分類はすべてマスタ化
-73. **Code Apps 設計**: `code-apps-design` スキルを読み、画面構成・コンポーネント選定・Lookup 名前解決パターンを設計。ユーザー承認後に `code-apps-dev` で実装
-74. **Power Automate 設計**: フロー名・トリガー・アクション・接続・通知先を設計書として提示。ユーザー承認後にデプロイスクリプトを作成
-75. **Copilot Studio 設計**: エージェント名・Instructions・推奨プロンプト・会話の開始のメッセージ・会話の開始のクイック返信・ナレッジ・ツール（MCP Server）を設計書として提示。ユーザー承認後に構築
+74. **全フェーズで設計→ユーザー承認→実装の順序を守る**。Dataverse・Code Apps・Power Automate・Copilot Studio のいずれも、設計をユーザーに提示し「この設計で進めてよいですか？」と承認を得てから構築に進む
+75. **テーブル設計**: 全 Lookup リレーションシップを設計書に明記。漏れると Lookup が機能しない
+76. **テーブル設計**: デモデータは全テーブル（従属テーブル含む）に計画。コメント等の従属テーブルにもデモデータを用意
+77. **テーブル設計**: マスタテーブルは要件から網羅的に洗い出す。カテゴリ・場所・設備等、ユーザーが言及した分類はすべてマスタ化
+78. **Code Apps 設計**: `code-apps-design` スキルを読み、画面構成・コンポーネント選定・Lookup 名前解決パターンを設計。ユーザー承認後に `code-apps-dev` で実装
+79. **Power Automate 設計**: フロー名・トリガー・アクション・接続・通知先を設計書として提示。ユーザー承認後にデプロイスクリプトを作成
+80. **Copilot Studio 設計**: エージェント名・Instructions・推奨プロンプト・会話の開始のメッセージ・会話の開始のクイック返信・ナレッジ・ツール（MCP Server）を設計書として提示。ユーザー承認後に構築
 
 ## 作業手順
 

--- a/.github/skills/code-apps-dev/SKILL.md
+++ b/.github/skills/code-apps-dev/SKILL.md
@@ -252,6 +252,146 @@ Power Apps ランタイムは厳格な CSP を適用し、**外部 API への `f
 
 **CodeAppsStarter テンプレートにはデモ用の外部 API 呼び出しが含まれる**ため、必ず削除すること。
 
+### ログインユーザーの systemuserid 取得（検証済 2026-04-25）
+
+Code Apps でログインユーザーの Dataverse `systemuserid` を取得するには、以下の **唯一の確実な方法** を使う。
+
+```
+❌ Xrm.Utility.getGlobalContext().userSettings.userId
+   → Code Apps では Xrm オブジェクトは利用不可（undefined）
+
+❌ fetch("/api/data/v9.2/WhoAmI")
+   → CSP connect-src: 'none' でブロックされる（Code Apps はデフォルトで全 fetch を禁止）
+
+❌ WhoAmIService.WhoAmI()（npx power-apps add-dataverse-api -n WhoAmI で生成）
+   → executeAsync は内部的に fetch を使うため、CSP でブロックされる
+   → {"success":false,"error":{}} が返る
+
+❌ SDK getContext().user.objectId をそのまま使う
+   → これは Entra AAD Object ID であり、Dataverse systemuserid ではない
+   → bookableresource._userid_value 等と一致しない
+
+✅ SDK getContext() → Entra objectId 取得 → systemuser テーブルクエリで systemuserid を解決
+   → retrieveMultipleRecordsAsync は postMessage ベースのため CSP 制約を受けない
+```
+
+**前提: systemuser をデータソースに追加**
+
+```bash
+npx power-apps add-data-source --api-id dataverse \
+  --resource-name systemuser \
+  --org-url {DATAVERSE_URL}
+```
+
+`src/generated/appschemas/dataSourcesInfo.ts` に `systemusers` エントリが自動追加される。
+追加されない場合は手動で追記:
+
+```typescript
+"systemusers": {
+  "tableId": "systemuser",
+  "version": "",
+  "primaryKey": "systemuserid",
+  "dataSourceType": "Dataverse",
+  "apis": {}
+}
+```
+
+**実装パターン（最小構成）:**
+
+```typescript
+// src/services/booking-service.ts（または user-service.ts）
+
+// --- SDK App Context ---
+// @ts-ignore - resolved at runtime by Power Apps host
+import { getContext } from "@microsoft/power-apps/app";
+import type { IContext } from "@microsoft/power-apps/app";
+
+let _sdkContext: IContext | null = null;
+async function getSdkContext(): Promise<IContext | null> {
+  if (_sdkContext) return _sdkContext;
+  try {
+    _sdkContext = await getContext();
+    return _sdkContext;
+  } catch { return null; }
+}
+
+/**
+ * ログインユーザーの Dataverse systemuserid を取得する。
+ * SDK getContext() で Entra objectId を取得し、systemuser テーブルから systemuserid を解決。
+ * retrieveMultipleRecordsAsync は postMessage ベースのため CSP の影響を受けない。
+ */
+export async function getCurrentUserId(): Promise<string | null> {
+  try {
+    const ctx = await getSdkContext();
+    if (ctx?.user?.objectId) {
+      const entraId = ctx.user.objectId;
+      console.log("[getCurrentUserId] Entra objectId:", entraId);
+
+      const client = await getClient();  // SDK DataClient
+      const result = await client.retrieveMultipleRecordsAsync(
+        "systemusers",
+        {
+          select: ["systemuserid"],
+          filter: `azureactivedirectoryobjectid eq '${entraId}'`,
+          top: 1,
+        }
+      );
+      if (result?.success && result.data?.length > 0) {
+        const uid = result.data[0]?.systemuserid;
+        if (uid) return uid.toLowerCase();
+      }
+    }
+  } catch (e) {
+    console.warn("[getCurrentUserId] failed:", e);
+  }
+  return null;
+}
+```
+
+**TanStack React Query フック:**
+
+```typescript
+// src/hooks/use-bookings.ts（または use-user.ts）
+export function useCurrentUserId() {
+  return useQuery({
+    queryKey: ["currentUserId"],
+    queryFn: getCurrentUserId,
+    staleTime: Infinity,  // ユーザー ID はセッション中変わらない
+    retry: 2,
+  });
+}
+```
+
+**ページでの使用パターン（予約フィルタ）:**
+
+```typescript
+export default function BookingsPage() {
+  const { data: bookings = [] } = useBookings();
+  const { data: resources = [] } = useBookableResources();
+  const { data: currentUserId } = useCurrentUserId();
+
+  // systemuserid → bookableresourceid を解決
+  const currentResourceId = useMemo(() => {
+    if (!currentUserId) return null;
+    const uid = currentUserId.toLowerCase();
+    const res = resources.find((r) => r._userid_value?.toLowerCase() === uid);
+    return res?.bookableresourceid ?? null;
+  }, [currentUserId, resources]);
+
+  // 自分の予約のみ表示（未解決時は空配列）
+  const myBookings = useMemo(() => {
+    if (!currentResourceId) return [];
+    return bookings.filter((b) => b._resource_value === currentResourceId);
+  }, [bookings, currentResourceId]);
+}
+```
+
+**重要な教訓:**
+- **GUID の大文字/小文字は統一する**: Dataverse API は大文字小文字混在で返すことがある。比較時は必ず `.toLowerCase()` を使う
+- **systemuserid が取れない場合は空配列を返す**: null フォールバックで全データ表示しない（セキュリティリスク）
+- **`IContext.user.objectId` は Entra AAD Object ID**: Dataverse の `systemuserid` とは異なる値。`azureactivedirectoryobjectid` 列でマッピングが必要
+- **`executeAsync` も CSP でブロックされる**: `add-dataverse-api` で生成した WhoAmI サービスは `executeAsync` を使うが、これも内部で `fetch()` を使用しておりCSPでブロックされる。`retrieveMultipleRecordsAsync` だけが postMessage ベースで CSP 安全
+
 ### 基本設計方針: モーダル操作 + z-index ルール
 
 **新規作成・編集・削除はすべてモーダル（Dialog / AlertDialog）で操作する。**


### PR DESCRIPTION
## 概要

Code Apps でログインユーザーの Dataverse `systemuserid` を取得する方法の **検証済みベストプラクティス** をスキル化。

## 背景

Code Apps はデフォルト CSP（`connect-src: 'none'`）により、すべての `fetch()` / `XMLHttpRequest` がブロックされます。
このため、WhoAmI API・Xrm オブジェクト等の従来の方法ではログインユーザーの `systemuserid` を取得できません。

2026-04-25 に以下のアプローチを検証し、唯一動作するパターンを確立しました：

| 方法 | 結果 | 原因 |
|---|---|---|
| `Xrm.Utility.getGlobalContext()` | ❌ undefined | Code Apps では Xrm 利用不可 |
| `fetch("/api/data/v9.2/WhoAmI")` | ❌ CSP ブロック | `connect-src: 'none'` |
| `WhoAmIService.WhoAmI()` (SDK 生成) | ❌ `{success:false}` | `executeAsync` 内部で fetch 使用 → CSP ブロック |
| SDK `getContext()` → systemuser クエリ | ✅ 動作 | `retrieveMultipleRecordsAsync` は postMessage ベース |

## 変更内容

### 更新: `.github/skills/code-apps-dev/SKILL.md`

「CSP 違反の回避」セクション直後に **ログインユーザー識別** セクションを新設：
- 失敗するアプローチ 4 パターン（Xrm / fetch WhoAmI / SDK WhoAmI / objectId 直接使用）
- systemuser データソース追加手順
- `getCurrentUserId()` の最小実装コード（SDK getContext → Entra objectId → systemuser クエリ）
- TanStack React Query フックパターン（`useCurrentUserId`）
- ページでの使用パターン（予約フィルタ / bookableresource 経由）
- 重要な教訓（GUID 大文字小文字 / null 時の安全な空配列 / objectId ≠ systemuserid）

### 更新: `.github/agents/GeekPowerCode.agent.md`

絶対遵守ルールに教訓 #69-#73 を追加（既存 #69-#75 は #74-#80 に繰り下げ）：
- #69: systemuserid 取得は SDK getContext + systemuser テーブルクエリが唯一の方法
- #70: `objectId` は Entra AAD ID であり systemuserid ではない（`azureactivedirectoryobjectid` でマッピング）
- #71: GUID 比較は `.toLowerCase()` で統一
- #72: systemuserid 未取得時は空配列（全データ表示はセキュリティリスク）
- #73: `executeAsync` も CSP でブロック（CSP 安全なのは CRUD 系メソッドのみ）

## トリガー条件

以下のキーワードで `code-apps-dev` スキルが自動読み込みされた際に参照される：
- ログインユーザー / 現在のユーザー / ユーザー識別
- systemuserid / WhoAmI / getContext
- ユーザーフィルタ / 自分の予約 / 自分のデータ
