### PR TITLE
feat: Dataverse File 列アップロード（UpdateEntityFileImageFieldContent）の教訓をスキル化

### DIFF
--- a/.github/skills/power-automate/SKILL.md
+++ b/.github/skills/power-automate/SKILL.md
@@ -218,11 +218,11 @@ operationId の選択を間違えるとフロー有効化時に `InvalidOpenApiF
    → Draft 作成・有効化ともに成功（2026-04-27 検証済み）
 
 パラメータ:
-  entityName:          エンティティセット名（複数形。例: bookableresourcebookings）
+  entityName:          エンティティセット名（複数形。例: accounts）
   recordId:            対象レコードの GUID
-  fileImageFieldName:  File 型列の論理名（例: prefix_preworkconfirmationpdf）
+  fileImageFieldName:  File 型列の論理名（例: prefix_filecolumn）
   item:                ファイルのバイナリコンテンツ（@base64ToBinary(...) 等）
-  x-ms-file-name:     保存するファイル名（例: 作業前確認書.pdf）
+  x-ms-file-name:     保存するファイル名（例: document.pdf）
 ```
 
 ```python
@@ -236,9 +236,9 @@ operationId の選択を間違えるとフロー有効化時に `InvalidOpenApiF
             "connectionName": CONNREF_DATAVERSE,
         },
         "parameters": {
-            "entityName": "bookableresourcebookings",
-            "recordId": "@triggerOutputs()?['body/bookableresourcebookingid']",
-            "fileImageFieldName": f"{PREFIX}_pdffile",
+            "entityName": "accounts",
+            "recordId": "@triggerOutputs()?['body/accountid']",
+            "fileImageFieldName": f"{PREFIX}_filecolumn",    # File 型列の論理名
             "item": "@base64ToBinary(variables('pdfBase64'))",
             "x-ms-file-name": "document.pdf",
         },

--- a/.github/skills/power-automate/SKILL.md
+++ b/.github/skills/power-automate/SKILL.md
@@ -202,6 +202,51 @@ if not found and connector in FALLBACK_CONNECTIONS:
 ✅ timeout=120 を明示的に設定（デフォルトは無限待ち）
 ```
 
+### Dataverse File 列へのファイルアップロード（★ 検証済み教訓）
+
+Dataverse の File 型列（FileAttributeMetadata）にフローからファイルを保存する場合、
+operationId の選択を間違えるとフロー有効化時に `InvalidOpenApiFlow` で失敗する。
+
+```
+❌ operationId: "UploadFile"
+   → Dataverse コネクタに存在しない operationId
+   → フロー有効化時に WorkflowOperationInputsApiOperationNotFound エラー:
+     "The API operation 'UploadFile' could not be found in API 'commondataserviceforapps'."
+
+✅ operationId: "UpdateEntityFileImageFieldContent"
+   → Dataverse コネクタの正式な File/Image 列更新オペレーション
+   → Draft 作成・有効化ともに成功（2026-04-27 検証済み）
+
+パラメータ:
+  entityName:          エンティティセット名（複数形。例: bookableresourcebookings）
+  recordId:            対象レコードの GUID
+  fileImageFieldName:  File 型列の論理名（例: prefix_preworkconfirmationpdf）
+  item:                ファイルのバイナリコンテンツ（@base64ToBinary(...) 等）
+  x-ms-file-name:     保存するファイル名（例: 作業前確認書.pdf）
+```
+
+```python
+# ✅ File 列へのアップロードパターン
+"Upload_File": {
+    "type": "OpenApiConnection",
+    "inputs": {
+        "host": {
+            "apiId": "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps",
+            "operationId": "UpdateEntityFileImageFieldContent",  # ★ 正しい operationId
+            "connectionName": CONNREF_DATAVERSE,
+        },
+        "parameters": {
+            "entityName": "bookableresourcebookings",
+            "recordId": "@triggerOutputs()?['body/bookableresourcebookingid']",
+            "fileImageFieldName": f"{PREFIX}_pdffile",
+            "item": "@base64ToBinary(variables('pdfBase64'))",
+            "x-ms-file-name": "document.pdf",
+        },
+        "authentication": "@parameters('$authentication')",
+    },
+}
+```
+
 ### 環境 ID の解決（Flow API / PowerApps API で必要）
 
 PowerApps API での接続検索等には環境 ID が必要。DATAVERSE_URL から逆引きする。

--- a/.github/skills/power-automate/references/trigger-action-patterns.md
+++ b/.github/skills/power-automate/references/trigger-action-patterns.md
@@ -382,9 +382,9 @@ Dataverse の File 型列（FileAttributeMetadata）や Image 型列にフロー
             "connectionName": CONNREF_DATAVERSE,
         },
         "parameters": {
-            "entityName": "bookableresourcebookings",      # エンティティセット名（複数形）
-            "recordId": "@triggerOutputs()?['body/bookableresourcebookingid']",
-            "fileImageFieldName": f"{PREFIX}_pdffile",      # File 型列の論理名
+            "entityName": "accounts",      # エンティティセット名（複数形）
+            "recordId": "@triggerOutputs()?['body/accountid']",
+            "fileImageFieldName": f"{PREFIX}_filecolumn",    # File 型列の論理名
             "item": "@base64ToBinary(variables('pdfBase64'))",  # バイナリコンテンツ
             "x-ms-file-name": "document.pdf",               # 保存ファイル名
         },
@@ -411,11 +411,11 @@ Dataverse の File 型列（FileAttributeMetadata）や Image 型列にフロー
                     "connectionName": CONNREF_DATAVERSE,
                 },
                 "parameters": {
-                    "entityName": "bookableresourcebookings",
-                    "recordId": "@triggerOutputs()?['body/bookableresourcebookingid']",
-                    "fileImageFieldName": f"{PREFIX}_preworkconfirmationpdf",
+                    "entityName": "accounts",
+                    "recordId": "@triggerOutputs()?['body/accountid']",
+                    "fileImageFieldName": f"{PREFIX}_filecolumn1",
                     "item": "@base64ToBinary(variables('pdfBase64'))",
-                    "x-ms-file-name": "作業前確認書.pdf",
+                    "x-ms-file-name": "document1.pdf",
                 },
                 "authentication": "@parameters('$authentication')",
             },
@@ -432,11 +432,11 @@ Dataverse の File 型列（FileAttributeMetadata）や Image 型列にフロー
                         "connectionName": CONNREF_DATAVERSE,
                     },
                     "parameters": {
-                        "entityName": "bookableresourcebookings",
-                        "recordId": "@triggerOutputs()?['body/bookableresourcebookingid']",
-                        "fileImageFieldName": f"{PREFIX}_maintenancereportpdf",
+                        "entityName": "accounts",
+                        "recordId": "@triggerOutputs()?['body/accountid']",
+                        "fileImageFieldName": f"{PREFIX}_filecolumn2",
                         "item": "@base64ToBinary(variables('pdfBase64'))",
-                        "x-ms-file-name": "保守レポート.pdf",
+                        "x-ms-file-name": "document2.pdf",
                     },
                     "authentication": "@parameters('$authentication')",
                 },

--- a/.github/skills/power-automate/references/trigger-action-patterns.md
+++ b/.github/skills/power-automate/references/trigger-action-patterns.md
@@ -357,6 +357,107 @@ OneDrive ConvertFile の PDF 変換対応形式 (https://aka.ms/onedriveconversi
   ❌ ConvertFile は OneDrive 上のファイルのみ対応（SharePoint 直接は不可）
 ```
 
+### Dataverse File / Image 列へのアップロード（UpdateEntityFileImageFieldContent）
+
+Dataverse の File 型列（FileAttributeMetadata）や Image 型列にフローからファイルをアップロードするパターン。
+
+```
+★ 重要ポイント:
+  ✅ operationId は "UpdateEntityFileImageFieldContent"（唯一の正解）
+  ❌ "UploadFile" は Dataverse コネクタに存在しない → InvalidOpenApiFlow エラー
+  ✅ item にはバイナリコンテンツを渡す（@base64ToBinary() 等）
+  ✅ x-ms-file-name でファイル名を指定（日本語ファイル名も可）
+  ✅ fileImageFieldName には File/Image 列の論理名を指定
+  ✅ Draft 作成・有効化ともに API で成功（2026-04-27 検証済み）
+```
+
+```python
+# ✅ Dataverse File 列に PDF をアップロード
+"Upload_PDF_File": {
+    "type": "OpenApiConnection",
+    "inputs": {
+        "host": {
+            "apiId": "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps",
+            "operationId": "UpdateEntityFileImageFieldContent",
+            "connectionName": CONNREF_DATAVERSE,
+        },
+        "parameters": {
+            "entityName": "bookableresourcebookings",      # エンティティセット名（複数形）
+            "recordId": "@triggerOutputs()?['body/bookableresourcebookingid']",
+            "fileImageFieldName": f"{PREFIX}_pdffile",      # File 型列の論理名
+            "item": "@base64ToBinary(variables('pdfBase64'))",  # バイナリコンテンツ
+            "x-ms-file-name": "document.pdf",               # 保存ファイル名
+        },
+        "authentication": "@parameters('$authentication')",
+    },
+}
+```
+
+```python
+# ✅ 条件分岐で documentType ごとに異なる File 列にアップロードする例
+"Check_Document_Type": {
+    "type": "If",
+    "runAfter": {"Send_Email": ["Succeeded"]},
+    "expression": {
+        "equals": ["@variables('documentType')", "prework"],
+    },
+    "actions": {
+        "Upload_PreWork_PDF": {
+            "type": "OpenApiConnection",
+            "inputs": {
+                "host": {
+                    "apiId": "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps",
+                    "operationId": "UpdateEntityFileImageFieldContent",
+                    "connectionName": CONNREF_DATAVERSE,
+                },
+                "parameters": {
+                    "entityName": "bookableresourcebookings",
+                    "recordId": "@triggerOutputs()?['body/bookableresourcebookingid']",
+                    "fileImageFieldName": f"{PREFIX}_preworkconfirmationpdf",
+                    "item": "@base64ToBinary(variables('pdfBase64'))",
+                    "x-ms-file-name": "作業前確認書.pdf",
+                },
+                "authentication": "@parameters('$authentication')",
+            },
+        },
+    },
+    "else": {
+        "actions": {
+            "Upload_Report_PDF": {
+                "type": "OpenApiConnection",
+                "inputs": {
+                    "host": {
+                        "apiId": "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps",
+                        "operationId": "UpdateEntityFileImageFieldContent",
+                        "connectionName": CONNREF_DATAVERSE,
+                    },
+                    "parameters": {
+                        "entityName": "bookableresourcebookings",
+                        "recordId": "@triggerOutputs()?['body/bookableresourcebookingid']",
+                        "fileImageFieldName": f"{PREFIX}_maintenancereportpdf",
+                        "item": "@base64ToBinary(variables('pdfBase64'))",
+                        "x-ms-file-name": "保守レポート.pdf",
+                    },
+                    "authentication": "@parameters('$authentication')",
+                },
+            },
+        },
+    },
+}
+```
+
+```
+前提条件:
+  ✅ Dataverse テーブルに File 型列（FileAttributeMetadata）が事前作成されていること
+  ✅ File 列の MaxSizeInKB が保存するファイルサイズ以上であること（推奨: 10240 = 10MB）
+  ✅ host.connectionName に Dataverse 接続参照の論理名を指定
+
+よくあるエラー:
+  ❌ operationId: "UploadFile" → WorkflowOperationInputsApiOperationNotFound
+  ❌ item に base64 文字列をそのまま渡す → @base64ToBinary() でバイナリに変換が必要
+  ❌ entityName を単数形で指定 → 複数形（エンティティセット名）を使用
+```
+
 ### AI Builder「プロンプトを実行する」
 
 ```python


### PR DESCRIPTION
## 概要

Power Automate フローから Dataverse の **File 型列** にファイルをアップロードする際の正しい operationId と検証済みパターンをスキルに追加。

## 背景

フローで `UploadFile` を operationId に指定すると、フロー有効化時に以下のエラーで失敗する:

> `WorkflowOperationInputsApiOperationNotFound`: The API operation 'UploadFile' could not be found in API 'commondataserviceforapps'.

正しい operationId は **`UpdateEntityFileImageFieldContent`** である。2026-04-27 に実環境で検証済み。

## 変更内容

### `.github/skills/power-automate/SKILL.md`
- 「Dataverse File 列へのファイルアップロード」セクションを絶対遵守ルールに追加
- ❌ `UploadFile` vs ✅ `UpdateEntityFileImageFieldContent` の比較
- パラメータ仕様（entityName, recordId, fileImageFieldName, item, x-ms-file-name）
- 基本コードパターン

### `.github/skills/power-automate/references/trigger-action-patterns.md`
- 「Dataverse File / Image 列へのアップロード」パターンを追加
- 基本パターン + documentType による条件分岐パターン
- 前提条件（File 列の事前作成、MaxSizeInKB 等）
- よくあるエラーと対策

## 検証環境

- Power Automate Dataverse コネクタ（`shared_commondataserviceforapps`）
- bookableresourcebooking テーブルの File 型列（`rcwr_preworkconfirmationpdf`, `rcwr_maintenancereportpdf`）
- フロー作成（Draft）・有効化ともに API で成功