### PR TITLE
feat: code-apps / dataverse スキルにトラブルシューティング参照ドキュメントを追加

### DIFF
--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -12,8 +12,9 @@ Code Apps（TypeScript + React）開発で頻出する問題と対処法。
 
 ### 原因
 
-Code Apps SDK の OData フィルターでは、GUID 値にシングルクォートを付けると一致しない。
-標準 OData は `eq 'guid-value'` だが、**Code Apps SDK では `eq guid-value`（クォートなし）** が正しい。
+Code Apps SDK の OData フィルターでは、GUID 値を文字列としてシングルクォートで囲むと一致しない。
+Dataverse Web API / Code Apps SDK では、GUID 比較は **`eq guid-value`（クォートなし）** の形式で書くのが適切。
+`eq 'guid-value'` のような書き方は GUID を文字列比較しているように見えやすく、Code Apps SDK では期待どおり動作しない。
 
 ### 例
 

--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -99,6 +99,8 @@ const result = await client.retrieveMultipleRecordsAsync(
   },
 );
 
+const record = result.data[0];
+
 // 表示名の取得
 const ownerName = record["_ownerid_value@OData.Community.Display.V1.FormattedValue"];
 // → "山田 太郎"

--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -2,6 +2,8 @@
 
 Code Apps（TypeScript + React）開発で頻出する問題と対処法。
 
+> 参考: このリファレンスは [Code Apps スキル一覧](../SKILL.md) から参照する想定です。関連資料や他のリファレンスは `SKILL.md` の冒頭一覧から確認できます。
+
 ---
 
 ## 1. Dataverse フィルターで GUID にシングルクォートを付けてはいけない

--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -1,0 +1,163 @@
+# Code Apps トラブルシューティング
+
+Code Apps（TypeScript + React）開発で頻出する問題と対処法。
+
+---
+
+## 1. Dataverse フィルターで GUID にシングルクォートを付けてはいけない
+
+### 症状
+
+`retrieveMultipleRecordsAsync` のフィルターでレコードが 0 件返る。エラーは出ない。
+
+### 原因
+
+Code Apps SDK の OData フィルターでは、GUID 値にシングルクォートを付けると一致しない。
+標準 OData は `eq 'guid-value'` だが、**Code Apps SDK では `eq guid-value`（クォートなし）** が正しい。
+
+### 例
+
+```typescript
+// ❌ レコードが返らない
+filter: `_parentaccountid_value eq '${accountId}'`
+
+// ✅ 正しい構文
+filter: `_parentaccountid_value eq ${accountId}`
+```
+
+### 影響範囲
+
+すべてのルックアップ列フィルター（`_xxx_value eq ...`）に共通。
+`retrieveMultipleRecordsAsync` / `retrieveRecordAsync` 両方に適用される。
+
+---
+
+## 2. power.config.json の未使用 connectionReferences でデプロイ 400 エラー
+
+### 症状
+
+`pac code push` / `npx power-apps push` で HTTP 400 エラー。
+
+### 原因
+
+`power.config.json` の `connectionReferences` に、環境に存在しない接続参照
+（削除済みフロー・Copilot Studio コネクタ等）が残っている。
+
+### 対処
+
+```jsonc
+// power.config.json — 使用していない connectionReferences を削除
+{
+  "connectionReferences": {
+    // ❌ 存在しないフロー接続 → 削除する
+    // "workflowDetails": { ... }
+  }
+}
+```
+
+### 予防
+
+コネクタやフローを削除した後は、`power.config.json` の `connectionReferences` から
+対応エントリを手動削除すること。
+
+---
+
+## 3. pac code push のテレメトリエラーは無視可能
+
+### 症状
+
+デプロイ後に以下のエラーが出力される:
+```
+CliLogger: failed to initialize OneDS telemetry writer Error: Network request failed
+```
+
+### 判断基準
+
+`App pushed successfully` が出力されていればデプロイは成功。
+テレメトリ初期化のタイムアウトは pac CLI 内部の telemetry 送信の問題であり、アプリには影響しない。
+
+---
+
+## 4. OData FormattedValue でルックアップ表示名を取得する
+
+### 課題
+
+ルックアップ列（`_ownerid_value` 等）の ID だけでは表示名がわからない。
+追加クエリで `systemuser` テーブルを引くのは N+1 問題になる。
+
+### 解決策
+
+`select` にルックアップ列名を含めると、SDK が自動的に OData アノテーションを返す。
+
+```typescript
+const result = await client.retrieveMultipleRecordsAsync(
+  "opportunities",
+  {
+    select: ["opportunityid", "name", "_ownerid_value"],  // ← ルックアップ列を含める
+    filter: `_parentaccountid_value eq ${accountId}`,
+  },
+);
+
+// 表示名の取得
+const ownerName = record["_ownerid_value@OData.Community.Display.V1.FormattedValue"];
+// → "山田 太郎"
+```
+
+### 利用可能なアノテーション
+
+| アノテーション | 内容 |
+|---|---|
+| `@OData.Community.Display.V1.FormattedValue` | ルックアップ先の表示名 |
+| `@Microsoft.Dynamics.CRM.lookuplogicalname` | ルックアップ先のテーブル論理名 |
+
+### 型定義の注意
+
+TypeScript の interface にアノテーション付きプロパティを含める場合:
+```typescript
+export interface Opportunity {
+  opportunityid: string;
+  name: string;
+  _ownerid_value?: string;
+  "_ownerid_value@OData.Community.Display.V1.FormattedValue"?: string;
+}
+```
+
+---
+
+## 5. MDA レコードフォームへのリンク URL パターン
+
+### 用途
+
+Code Apps から Dynamics 365 / モデル駆動型アプリのレコードフォームを開くリンクを生成する。
+
+### URL パターン
+
+```
+https://{org}.crm7.dynamics.com/main.aspx?pagetype=entityrecord&etn={entityLogicalName}&id={recordId}
+```
+
+### エンティティ論理名の対応表
+
+| 表示名 | 論理名 |
+|---|---|
+| 取引先企業 | `account` |
+| 営業案件 | `opportunity` |
+| 提案製品 | `opportunityproduct` |
+| サポート案件 | `incident` |
+| 作業指示書 | `msdyn_workorder` |
+| 顧客資産 | `msdyn_customerasset` |
+| IoT アラート | `msdyn_iotalert` |
+| 機能の場所 | `msdyn_functionallocation` |
+
+### 実装例
+
+```typescript
+const MDA_BASE = "https://{org}.crm7.dynamics.com/main.aspx";
+
+function getMdaUrl(entityLogicalName: string, recordId: string): string {
+  return `${MDA_BASE}?pagetype=entityrecord&etn=${entityLogicalName}&id=${recordId}`;
+}
+```
+
+> **Note**: `appid` パラメータを省略すると、ユーザーのデフォルト MDA で開く。
+> 特定のアプリで開きたい場合は `&appid={app-guid}` を追加する。

--- a/.github/skills/dataverse/references/troubleshooting.md
+++ b/.github/skills/dataverse/references/troubleshooting.md
@@ -1,0 +1,155 @@
+# Dataverse OData API トラブルシューティング
+
+Dataverse Web API / OData 操作で頻出する問題と対処法。
+Python スクリプト（`auth_helper.py` 経由）および Code Apps SDK 共通。
+
+---
+
+## 1. ナビゲーションプロパティ名の大文字小文字が不正確で 400 エラー
+
+### 症状
+
+`PATCH` でルックアップ列にレコードを紐付ける際、HTTP 400 エラーが返る:
+```
+An undeclared property 'msdyn_iotalert' which only has property annotations
+in the payload but no property value was found in the payload.
+```
+
+### 原因
+
+`@odata.bind` のナビゲーションプロパティ名の **大文字小文字が正確でない**。
+OData のバインド構文では、スキーマ定義上の正確なプロパティ名が必要。
+
+```json
+// ❌ 小文字のみ — 400 エラー
+{ "msdyn_iotalert@odata.bind": "/msdyn_iotalerts(xxx)" }
+
+// ✅ スキーマ通りの大文字小文字 — 成功
+{ "msdyn_IoTAlert@odata.bind": "/msdyn_iotalerts(xxx)" }
+```
+
+### 正しいプロパティ名の調べ方
+
+EntityDefinitions API で `ManyToOneRelationships` を照会する:
+
+```python
+GET /api/data/v9.2/EntityDefinitions(LogicalName='{entity}')/ManyToOneRelationships
+  ?$filter=ReferencedEntity eq '{target_entity}'
+  &$select=SchemaName,ReferencingEntityNavigationPropertyName,ReferencingAttribute
+```
+
+**`ReferencingEntityNavigationPropertyName`** が `@odata.bind` で使うべき正確な名前。
+
+### よくある例
+
+| エンティティ | ルックアップ先 | ナビゲーションプロパティ名 |
+|---|---|---|
+| incident | msdyn_iotalert | `msdyn_IoTAlert` |
+| msdyn_workorder | msdyn_iotalert | `msdyn_IoTAlert` |
+| msdyn_iotalert | msdyn_customerasset | `msdyn_CustomerAsset` |
+| msdyn_iotalert | incident | `msdyn_Case` |
+
+---
+
+## 2. IoT アラートのリレーション構造（多経路データ取得）
+
+### 背景
+
+IoT アラートは複数のテーブルから参照されるため、1 つのクエリパスだけでは取得漏れが発生する。
+
+### リレーション構造
+
+```
+IoTAlert ──→ CustomerAsset   (_msdyn_customerasset_value)
+IoTAlert ──→ Incident         (_msdyn_case_value)
+Incident ──→ IoTAlert         (_msdyn_iotalert_value)
+WorkOrder ──→ IoTAlert        (_msdyn_iotalert_value)
+```
+
+### 完全な取得パターン（3 ルートマージ）
+
+```typescript
+// パス 1: 資産に直接紐づく IoT アラート
+const directAlerts = await getIoTAlertsByAsset(assetId);
+
+// パス 2: 作業指示書経由の IoT アラート ID
+const woIotIds = workOrders
+  .map(wo => wo._msdyn_iotalert_value)
+  .filter(Boolean);
+
+// パス 3: サポート案件経由の IoT アラート ID
+const incidentIotIds = incidents
+  .map(inc => inc._msdyn_iotalert_value)
+  .filter(Boolean);
+
+// 全 ID をマージして一括取得（重複排除）
+const allIds = [...new Set([...woIotIds, ...incidentIotIds])];
+const linkedAlerts = await getIoTAlertsByIds(allIds);
+
+// マージ（パス 1 + パス 2,3）
+const merged = new Map();
+directAlerts.forEach(a => merged.set(a.msdyn_iotalertid, a));
+linkedAlerts.forEach(a => { if (!merged.has(a.msdyn_iotalertid)) merged.set(a.msdyn_iotalertid, a); });
+```
+
+---
+
+## 3. エンティティリレーションシップの調査パターン
+
+### 特定テーブルのルックアップ列一覧を取得
+
+```python
+# ManyToOne（N:1）リレーションシップを取得
+GET /api/data/v9.2/EntityDefinitions(LogicalName='{entity}')/ManyToOneRelationships
+  ?$select=SchemaName,ReferencedEntity,ReferencingAttribute,
+           ReferencingEntityNavigationPropertyName,
+           ReferencedEntityNavigationPropertyName
+```
+
+### 特定テーブル間のリレーションシップを検索
+
+```python
+# incident → msdyn_iotalert の関係を調べる
+GET /api/data/v9.2/EntityDefinitions(LogicalName='incident')/ManyToOneRelationships
+  ?$filter=ReferencedEntity eq 'msdyn_iotalert'
+  &$select=SchemaName,ReferencingEntityNavigationPropertyName,ReferencingAttribute
+```
+
+### 逆方向（OneToMany）の確認
+
+```python
+GET /api/data/v9.2/EntityDefinitions(LogicalName='{entity}')/OneToManyRelationships
+  ?$filter=ReferencingEntity eq '{child_entity}'
+  &$select=SchemaName,ReferencedEntityNavigationPropertyName
+```
+
+---
+
+## 4. PowerShell + Python 実行時の f-string エスケープ問題
+
+### 症状
+
+PowerShell で `python -c "..."` を実行すると、Python の f-string 内の `{}`
+が PowerShell の ScriptBlock と解釈されてエラーになる:
+
+```
+python.exe: ScriptBlock should only be specified as a value of the Command parameter.
+```
+
+### 対処
+
+複雑な Python コードはインラインではなくスクリプトファイルを作成して実行する:
+
+```bash
+# ❌ インライン実行 — {} がPowerShellに解釈される
+python -c "print(f'value={x}')"
+
+# ✅ スクリプトファイル経由
+python scripts/check_data.py
+```
+
+### 適用範囲
+
+- Dataverse API 調査スクリプト
+- デモデータ投入スクリプト
+- エンティティメタデータ確認スクリプト


### PR DESCRIPTION
## 概要

Code Apps および Dataverse スキルに **troubleshooting.md** リファレンスドキュメントを追加します。
実際の開発で遭遇した問題と解決策をまとめたものです。

## 追加ファイル

### .github/skills/code-apps/references/troubleshooting.md
| # | トピック | 内容 |
|---|---------|------|
| 1 | GUID フィルター構文 | SDK の $filter で GUID を引用符で囲むと 400 エラーになる問題 |
| 2 | power.config.json エラー | 未使用フィールド参照によるランタイムエラー |
| 3 | pac telemetry | CI/CD での同意プロンプト回避 |
| 4 | FormattedValue アノテーション | Lookup 列の表示名取得パターン |
| 5 | MDA URL パターン | モデル駆動型アプリのレコードフォームへのリンク生成 |

### .github/skills/dataverse/references/troubleshooting.md
| # | トピック | 内容 |
|---|---------|------|
| 1 | ナビゲーションプロパティの大文字小文字 | バインド時の正確なケーシング |
| 2 | IoT マルチパスフェッチ | 複数経路で IoT データを取得するパターン |
| 3 | EntityDefinitions API | メタデータ探索のベストプラクティス |
| 4 | PowerShell + Python エスケープ | 特殊文字のエスケープ問題 |

## 動機

Field Service Mobile の Code Apps 開発中に実際に遭遇・解決した問題をナレッジとして蓄積し、Progressive Disclosure モデルの troubleshooting レイヤーとして提供します。