### PR TITLE
feat: orderBy は配列必須 - code-apps トラブルシューティングに追加

### DIFF
--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -166,3 +166,51 @@ function getMdaUrl(entityLogicalName: string, recordId: string): string {
 
 > **Note**: `appid` パラメータを省略すると、ユーザーのデフォルト MDA で開く。
 > 特定のアプリで開きたい場合は `&appid={app-guid}` を追加する。
+
+---
+
+## 6. orderBy は必ず配列で渡す（文字列不可）
+
+### 症状
+
+`retrieveMultipleRecordsAsync` が `{ success: false, error: {} }` を返し、
+コンソールに以下のエラーが表示される:
+
+```
+Invalid operation parameters: orderBy must be an array of strings
+```
+
+### 原因
+
+Code Apps SDK の `orderBy` パラメータは **文字列の配列** のみ受け付ける。
+文字列を直接渡すとバリデーションエラーになり、クエリが実行されない。
+
+### 例
+
+```typescript
+// ❌ 文字列 → バリデーションエラー
+const result = await client.retrieveMultipleRecordsAsync(
+  "opportunities",
+  {
+    select: ["opportunityid", "name"],
+    filter: `_parentaccountid_value eq ${accountId}`,
+    orderBy: "createdon desc",  // ← string はダメ
+  },
+);
+
+// ✅ 配列 → 正常動作
+const result = await client.retrieveMultipleRecordsAsync(
+  "opportunities",
+  {
+    select: ["opportunityid", "name"],
+    filter: `_parentaccountid_value eq ${accountId}`,
+    orderBy: ["createdon desc"],  // ← string[] が必須
+  },
+);
+```
+
+### 補足
+
+- 複数カラムでソートする場合: `orderBy: ["createdon desc", "name asc"]`
+- TypeScript の型定義では `string[]` になっているが、コード補完時に文字列を渡しても tsc エラーにならないケースがあるため注意
+- このエラーは HTTP 400 ではなく SDK 内部のバリデーションで発生するため、ネットワークタブには何も出ない


### PR DESCRIPTION
## 概要

Code Apps SDK の `retrieveMultipleRecordsAsync` で `orderBy` を文字列で渡すと、SDK 内部バリデーションで失敗する問題をトラブルシューティングドキュメントに追加します。

## 追加内容

### Topic 6: orderBy は必ず配列で渡す（文字列不可）

| 項目 | 内容 |
|---|---|
| 症状 | `{ success: false, error: {} }` — HTTP エラーではなく SDK バリデーション |
| 原因 | `orderBy: "createdon desc"` のように文字列を渡している |
| 解決 | `orderBy: ["createdon desc"]` と配列にする |

## 経緯

Field Service Mobile の営業案件表示が動作しなくなった原因を調査。
コンソールログで `Invalid operation parameters: orderBy must be an array of strings` を確認し修正。
ネットワークタブに何も出ないため発見が遅れやすいパターン。
