### PR TITLE
docs: SDK retrieveMultipleRecordsAsync の orderBy 配列形式と select 0件問題を追加

### DIFF
--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -166,3 +166,106 @@ function getMdaUrl(entityLogicalName: string, recordId: string): string {
 
 > **Note**: `appid` パラメータを省略すると、ユーザーのデフォルト MDA で開く。
 > 特定のアプリで開きたい場合は `&appid={app-guid}` を追加する。
+
+---
+
+## 6. `orderBy` は配列形式で指定する
+
+### 症状
+
+`retrieveMultipleRecordsAsync` で `orderBy` を文字列で指定するとソートが効かない、
+またはサイレントにエラーが発生してレコードが 0 件返る。
+
+### 原因
+
+Code Apps SDK の `retrieveMultipleRecordsAsync` options オブジェクトでは、
+`orderBy` は **文字列配列** (`string[]`) として渡す仕様。
+文字列を渡してもランタイムエラーにならないが、SDK 内部の OData クエリ構築で
+正しく処理されない場合がある。
+
+### 例
+
+```typescript
+// ❌ 文字列（ソートが効かない / 結果が不安定）
+const result = await client.retrieveMultipleRecordsAsync(
+  "rcwr_resourceareapriorities",
+  {
+    filter: `_rcwr_territoryid_value eq ${territoryId}`,
+    orderBy: "rcwr_priority asc",  // ← 文字列
+  }
+);
+
+// ✅ 配列（正しい形式）
+const result = await client.retrieveMultipleRecordsAsync(
+  "rcwr_resourceareapriorities",
+  {
+    filter: `_rcwr_territoryid_value eq ${territoryId}`,
+    orderBy: ["rcwr_priority asc"],  // ← 配列
+  }
+);
+```
+
+### 複数キーソートの例
+
+```typescript
+orderBy: ["rcwr_priority asc", "createdon desc"]
+```
+
+### チェックポイント
+
+- `select`, `filter` は文字列（または `select` は文字列配列）
+- `orderBy` は **必ず文字列配列**
+- `top` は数値
+
+---
+
+## 7. `$select` (select オプション) がカスタムテーブルで 0 件を返す
+
+### 症状
+
+`retrieveMultipleRecordsAsync` に `select` オプションを指定すると、
+フィルター条件に一致するレコードが存在するにもかかわらず結果が 0 件になる。
+`select` を省略すると正常にレコードが返る。
+
+### 原因
+
+一部のカスタムテーブル（特に Lookup 列が多い中間テーブルやリレーションテーブル）で、
+Code Apps SDK が `$select` 付き OData クエリを正しく処理できないケースがある。
+原因は SDK 内部の列名解決またはメタデータキャッシュに起因すると推測される。
+
+### 影響を受けやすいテーブルの特徴
+
+- カスタムの中間テーブル（N:N リレーション的な用途）
+- Lookup 列が 3 つ以上あるテーブル
+- ルックアップ値 (`_xxx_value`) をフィルター条件に使用している場合
+
+### 回避策
+
+```typescript
+// ❌ select 指定で 0 件になる場合がある
+const result = await client.retrieveMultipleRecordsAsync(
+  "rcwr_resourceareapriorities",
+  {
+    select: ["rcwr_name", "_rcwr_resourceid_value", "_rcwr_territoryid_value"],
+    filter: `_rcwr_territoryid_value eq ${territoryId} and rcwr_isactive eq true`,
+    orderBy: ["rcwr_priority asc"],
+  }
+);
+
+// ✅ select を省略して全列取得（確実に動作する）
+const result = await client.retrieveMultipleRecordsAsync(
+  "rcwr_resourceareapriorities",
+  {
+    filter: `_rcwr_territoryid_value eq ${territoryId} and rcwr_isactive eq true`,
+    orderBy: ["rcwr_priority asc"],
+  }
+);
+```
+
+### 注意
+
+- `select` を省略すると全列が返るため、レスポンスサイズが大きくなる。
+  レコード数が少ないマスタ系テーブルでは問題にならないが、
+  トランザクション系テーブルでは `top` と併用してレコード数を制限する。
+- **標準テーブル**（`bookableresourcebookings` 等）では `select` が正常に動作する。
+  問題が起きるのは主にカスタムテーブル。


### PR DESCRIPTION
## 概要

Code Apps SDK の `retrieveMultipleRecordsAsync` で発生する2つの問題をトラブルシューティングガイドに追加。

## 追加内容

### セクション 6: orderBy は配列形式で指定する

`orderBy` を文字列（`"field asc"`）で渡すとソートが効かない/結果が不安定になる。
配列形式（`["field asc"]`）が正しい。

### セクション 7: select オプションがカスタムテーブルで 0 件を返す

一部のカスタムテーブル（Lookup 列が多い中間テーブル等）で `select` オプションを指定すると、
条件に一致するレコードがあるにもかかわらず 0 件が返る。`select` を省略すると正常動作する。

## 背景

予約再割当モーダルで候補リソースが表示されない問題のデバッグで発見。
`rcwr_resourceareapriorities` テーブル（Lookup 3列のカスタム中間テーブル）で
`orderBy` が文字列だったことと、`select` 指定で 0 件になる現象の組み合わせが原因だった。
