### PR TITLE
docs(power-pages): Enhanced Data Model テーブル権限の教訓を追加

### DIFF
--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -19,6 +19,10 @@ triggers:
   - "table permissions"
   - "site settings"
   - "Web ロール"
+  - "Enhanced Data Model"
+  - "mspp_entitypermission"
+  - "powerpagecomponent"
+  - "403 Forbidden"
 ---
 
 # Power Pages 開発・デプロイスキル
@@ -33,6 +37,7 @@ React / Vue / Angular / Astro 等の静的 SPA フレームワークに対応。
 | [ビルドリファレンス](references/build-reference.md) | ビルド構成・フレームワーク別設定・出力形式 |
 | [デプロイリファレンス](references/deployment-reference.md) | pac pages コマンド詳細・CI/CD パイプライン構成 |
 | [トラブルシューティング](references/troubleshooting.md) | よくあるエラーと解決策 |
+| [Enhanced Data Model テーブル権限](references/enhanced-data-model-permissions.md) | Enhanced Data Model (v2.0) のテーブル権限設定・N:N バグ・ワークアラウンド |
 
 > **このスキルの位置づけ**: アーキテクチャ設計（`architecture`）で Power Pages 利用が確定した後、サイト開発→デプロイを担当する。Dataverse テーブル・テーブル権限・サイト設定は事前に `dataverse` スキルで構築しておくことを推奨。
 
@@ -72,128 +77,256 @@ project-root/
 
 ## 作業フロー（必ずこの順序で進める）
 
-> **重要: Power Pages は「先にデプロイ、後から開発」戦略を採用する。**
-> プロビジョニングに 10〜20 分かかるため、設計承認直後にプレースホルダー SPA をデプロイして
-> インフラ確保を開始し、並行して Dataverse テーブル構築・本番 SPA 開発を進める。
+> **戦略: 「先にデプロイ、後から開発」**
+> プロビジョニングに 10〜20 分かかるため、設計承認後にインフラ確保を即開始し、
+> 並行して Dataverse テーブル構築・SPA 開発を進める。
 
-### Step 0: サイト作成 + プレースホルダーデプロイ（最優先で実行）
+```
+Step 0: サイト作成（プロビジョニング開始）
+  ↓ 並行作業可
+Step 1: サイト設計（ユーザー承認）
+  ↓
+Step 2: SPA 開発
+  ↓
+Step 3: セキュリティ構成（Site Settings + Table Permissions）
+  ↓
+Step 4: 認証構成（Identity Provider + Web Template）
+  ↓
+Step 5: サイトアップロード + Restart
+  ↓
+Step 6: 検証（管理者 AND 一般ユーザーの両方）
+```
 
-**Phase 0（設計）の承認後、Phase 1（Dataverse 構築）の前に即実行する。**
+---
+
+### Step 0: サイト作成 + プレースホルダーデプロイ
+
+設計承認後、最優先で実行。Dataverse 構築と並行して進める。
 
 ```bash
-# サイト作成 + プロビジョニング待機 + プレースホルダーデプロイ
 python .github/skills/power-pages/scripts/deploy_placeholder.py \
   --create-site --site-name "サイト名" --subdomain "サブドメイン" --wait
 ```
 
-このスクリプトが以下を実行する:
-1. Power Platform API でサイト作成リクエスト送信
-2. プロビジョニング完了まで待機（最大 20 分）
-3. 完了後にプレースホルダー SPA（`template/`）をアップロード
-
-> **待機中に Dataverse テーブル構築（Phase 1）を並行で進める。**
-> プレースホルダー SPA は「サイト準備中」メッセージのみの最小静的ページ。
-
-### Step 1: 前提チェック（スクリプト利用可）
-
-```bash
-python .github/skills/power-pages/scripts/check_prerequisites.py
-```
-
-CLI・認証プロファイル・アーティファクトの存在を確認する。
+---
 
 ### Step 1: サイト設計（ユーザー承認必須）
 
-設計書を作成してユーザーに提示する。以下をすべて含める:
-
 | 項目 | 内容 |
 |------|------|
-| フレームワーク | React / Vue / Angular / Astro のいずれか |
-| ページ構成 | ルーティング・認証ページ・公開ページの一覧 |
-| テーブル権限 | 外部ユーザーがアクセスする Dataverse テーブルと権限レベル |
-| サイト設定 | 必要な site settings キー・値の一覧 |
-| Web ロール | ロール定義と割り当て方針 |
-| ビルド出力先 | `dist/` or `build/` → Power Pages へのマッピング |
+| フレームワーク | React / Vue / Angular / Astro |
+| ページ構成 | ルーティング・認証ページ・公開ページ |
+| テーブル権限 | テーブル × CRUD × スコープ × 対象ロール |
+| サイト設定 | Web API 有効化・認証プロバイダ |
+| Web ロール | Authenticated Users + 必要に応じてカスタムロール |
+| サイト種別 | PRIVATE（認証必須）or PUBLIC（匿名許可） |
 
-### Step 2: SPA 開発・ビルド
+---
 
-選択したフレームワークでローカル開発し、静的ファイルとしてビルドする。
+### Step 2: SPA 開発
+
+#### 必須制約
+
+| 制約 | 理由 |
+|------|------|
+| 静的 SPA のみ | SSR / ISR 非対応 |
+| **Hash ルーティング必須** | History API モードは直接 URL アクセスで 404（サーバーリライト不可） |
+| `base: './'` (Vite) | Power Pages のパス構造に対応 |
+| `inlineDynamicImports: true` | コード分割するとロード順問題が発生 |
+
+#### Web API クライアント（必須パターン）
+
+```typescript
+// lib/dataverse.ts
+const BASE = "/_api";
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}/${path}`, {
+    ...init,
+    redirect: "manual",  // ← 必須: 未認証時の 302 チェーン防止
+    headers: {
+      Accept: "application/json",
+      "OData-MaxVersion": "4.0",
+      "OData-Version": "4.0",
+      ...init?.headers,
+    },
+  });
+
+  // セッション切れ検知
+  if (res.type === "opaqueredirect" || res.status === 0) {
+    window.location.href = "/Account/Login";
+    return new Promise(() => {});
+  }
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.error(`[API] ${path} → ${res.status}`, body);
+    throw new Error(`API ${res.status}: ${body}`);
+  }
+
+  return res.json();
+}
+```
+
+> **`redirect: "manual"` を省略すると**: 未認証時に `/_api/` → 302 → `/Account/Login` → 302 → `/ExternalLogin`(GET) → 500 というエラーチェーンが発生する。
+
+#### OData クエリのポイント
+
+| パターン | 正しい書式 | 誤り |
+|----------|-----------|------|
+| Lookup 列の参照 | `_geek_categoryid_value` | `geek_categoryid` |
+| Boolean フィルタ | `$filter=geek_approved eq true` | `eq 'true'` |
+| 日時フィルタ | `createdon gt 2024-01-01T00:00:00Z` | 引用符不要 |
+| 展開 | `$expand=geek_CategoryId($select=geek_name)` | — |
+
+#### 認証フック（PRIVATE サイト）
+
+```typescript
+// hooks/use-auth.ts
+export function useAuth() {
+  const pp = (window as any).__PP_USER__;
+  return {
+    isAuthenticated: !!(pp?.id),
+    user: pp ? { contactId: pp.id, fullName: pp.fullname, email: pp.emailaddress1 } : null,
+    login: () => { window.location.href = "/Account/Login"; },
+    logout: () => { window.location.href = "/Account/Login/LogOff"; },
+  };
+}
+```
+
+> PRIVATE サイトでは SPA ロード時点で必ず認証済み。`window.__PP_USER__` は Web Template の Liquid `{{ user | json }}` で注入される。
+
+---
+
+### Step 3: セキュリティ構成
+
+**Web API を有効化し、テーブル権限を設定する。このステップを飛ばすと 403 / 404 になる。**
+
+#### 3-A: Site Settings（API で自動化可能）
+
+```python
+# 各テーブルに対して enabled + fields を設定
+tables = ["geek_incident", "geek_knowledge", "geek_knowledgecategory"]
+for table in tables:
+    create_site_setting(f"Webapi/{table}/enabled", "true")
+    create_site_setting(f"Webapi/{table}/fields", "*")
+```
+
+> Site Settings がないとテーブルが Web API に公開されない（管理者でも 404）。
+
+#### 3-B: Table Permission レコード（API で自動化可能）
+
+powerpagecomponent type=18 を作成すると `mspp_entitypermission` が自動生成される。
+
+```python
+component = {
+    "powerpagecomponenttype": 18,
+    "name": f"{table_display} - Global Read",
+    "content": json.dumps({
+        "mspp_entityname": table_logical,
+        "mspp_scope": "756150000",  # Global
+        "mspp_read": "true",
+        "mspp_write": "false",
+        "mspp_create": "false",
+        "mspp_delete": "false",
+        "mspp_append": "true",
+        "mspp_appendto": "true",
+    }),
+    "powerpagesiteid@odata.bind": f"/powerpagesites({SITE_ID})",
+    "powerpagesitelanguageid@odata.bind": f"/powerpagesitelanguages({LANG_ID})",
+}
+```
+
+#### 3-C: Web Role 紐付け（Design Studio で手動 — 自動化不可）
+
+> **⚠️ CRITICAL**: Enhanced Data Model (v2.0) では `mspp_entitypermission_webrole` の N:N を Dataverse Web API で設定できない（プラットフォームバグ）。Design Studio のみが正しく設定可能。
+
+**手順:**
+1. https://make.powerpages.microsoft.com/ → 対象サイト
+2. セキュリティ → テーブルのアクセス許可
+3. 各レコードを開き → ロールに **Authenticated Users** を追加 → 保存
+
+> 管理者ユーザーはテーブル権限をバイパスするため、管理者で OK でも一般ユーザーでは 403 になる。Step 6 で必ず一般ユーザーテストを行うこと。
+
+#### セキュリティ構成チェックリスト
+
+| # | 設定 | 対象 | 自動化 |
+|---|------|------|--------|
+| 1 | `Webapi/{table}/enabled=true` | 全公開テーブル | ✅ API |
+| 2 | `Webapi/{table}/fields=*` | 全公開テーブル | ✅ API |
+| 3 | Table Permission (type=18) | 全公開テーブル | ✅ API |
+| 4 | Web Role 紐付け | 全 Table Permission | ❌ Design Studio |
+| 5 | Site Restart | — | ✅ API |
+
+---
+
+### Step 4: 認証構成（PRIVATE サイトの場合）
+
+#### 4-A: Identity Provider 有効化（手動）
+
+> Identity Provider は Power Pages Design Studio から手動設定が必須（API 不可）。
+
+1. make.powerpages.microsoft.com → セキュリティ → ID プロバイダー
+2. Microsoft Entra ID を有効化
+
+#### 4-B: Web Template に Liquid ユーザー注入
+
+```html
+<script>window.__PP_USER__ = {{ user | json }};</script>
+{{ page.adx_copy }}
+```
+
+#### 4-C: 自動リダイレクト設定（推奨）
+
+```yaml
+# LoginButtonAuthenticationType: ログインページをスキップして直接 IdP へ
+Authentication/Registration/LoginButtonAuthenticationType: "https://login.microsoftonline.com/{tenant-id}/"
+```
+
+> この設定を使用する場合、SPA の全 fetch に `redirect: "manual"` が**必須**。
+
+---
+
+### Step 5: サイトアップロード + Restart
 
 ```bash
+# ビルド
 npm run build
+
+# アップロード
+pac pages upload-code-site --rootPath ./portal --siteName "サイト名"
+
+# サイト再起動（セキュリティ設定反映に必須）
+python .github/skills/power-pages/scripts/manage_portal.py --action restart
 ```
 
-> **重要**: Power Pages コードサイトは静的 SPA のみ対応。SSR / ISR は使用不可。
+> **注意**: `upload-code-site` は毎回 `.powerpages-site/site-settings/*.yml` で Dataverse を上書きする。YAML ファイルが設定の正。
 
-### Step 3: テーブル権限・サイト設定のデプロイ
+---
 
-Dataverse テーブル権限と Power Pages サイト設定は `dataverse` スキルで事前にデプロイする。
-外部ユーザーのアクセス制御に直接影響するため、テーブル権限の設定漏れがないか確認する。
+### Step 6: 検証
 
-### Step 4: サイトアップロード
+| 検証項目 | 確認者 | 期待結果 |
+|----------|--------|----------|
+| SPA ルーティング | — | Hash URL で全ページ表示 |
+| Web API GET | 管理者 | 200 + データ返却 |
+| Web API GET | **一般ユーザー** | 200 + データ返却 |
+| 認証フロー | 未認証 | IdP にリダイレクト → ログイン後 SPA 表示 |
+| セッション切れ | — | `/Account/Login` にリダイレクト |
 
-```bash
-# rootPath: サイトルート(.powerpages-site のあるディレクトリ)
-# compiledPath: ビルド出力ディレクトリ(rootPath からの相対)
-# siteName: Dataverse の adx_website.adx_name
-pac pages upload-code-site --rootPath ./site --compiledPath ./dist --siteName "サイト名"
-```
+> **管理者で OK でも一般ユーザーで 403 は頻出パターン**。必ず両方でテストする。
 
-> `--siteName` を省略すると環境内で一意のサイトが自動選択される。複数サイトがある場合は必ず指定する。
+## 必須制約
 
-### Step 5: サイトプロビジョニング（初回のみ）
-
-> **注意**: `pac pages provision-website` は PAC CLI 2.7.x では未実装。以下の代替手段を使用する。
-
-**方法 A: Power Platform API 経由（推奨）**
-```bash
-python .github/skills/power-pages/scripts/manage_portal.py --action create --name "サイト名" --subdomain "サブドメイン"
-```
-
-**方法 B: 管理画面から手動作成**
-```
-https://make.powerpages.microsoft.com/environments/{ENV_ID}/portals/home
-```
-
-既にプロビジョニング済みの場合は Step 4 のアップロードのみで更新される。
-
-### Step 6: デプロイスクリプト（一括実行）
-
-```bash
-python .github/skills/power-pages/scripts/deploy_site.py
-```
-
-前提チェック → アップロード → プロビジョニング（任意）を一括実行する。
-
-## 必須要件
-
-### サイト構成
-
-| ルール | 理由 |
-|--------|------|
-| **静的 SPA のみ** | Power Pages コードサイトは SSR / ISR 非対応 |
-| **`.powerpages-site` 必須** | pac pages がサイトを識別するマーカー |
-| **ビルド出力は静的ファイル** | `index.html` + JS/CSS/assets のみ |
-| **対応フレームワーク: React / Vue / Angular / Astro** | これら以外は動作保証外 |
-| **SPA ルーティングは Hash モード推奨** | History API モードはサーバーリライト不可のため注意 |
-
-### セキュリティ
-
-| ルール | 理由 |
-|--------|------|
-| **テーブル権限は最小権限の原則** | 外部ユーザーに不要なデータを公開しない |
-| **Web ロール設計は事前承認必須** | 権限設計ミスは情報漏洩に直結 |
-| **サイト設定に機密情報を格納しない** | サイト設定はクライアントから参照可能な場合がある |
-| **認証ページと公開ページを明確に分離** | 未認証ユーザーのアクセス制御を確実に |
-
-### デプロイ
-
-| ルール | 理由 |
-|--------|------|
-| **`pac auth list` で認証プロファイルを確認** | 未認証状態でのデプロイは失敗する |
-| **アップロード前にビルドを実行** | 古いビルド成果物のデプロイを防止 |
-| **プロビジョニングは初回のみ** | 2 回目以降は upload-code-site で更新 |
-| **デプロイ後に動作確認** | ルーティング・API 呼び出し・認証フローの確認 |
+| 制約 | 理由 |
+|------|------|
+| 静的 SPA のみ | SSR / ISR 非対応 |
+| Hash ルーティング必須 | サーバーリライト不可 → History API だと直接 URL で 404 |
+| `redirect: "manual"` 必須 | 未認証時の 302 → 500 チェーン防止 |
+| Vite `base: './'` + `inlineDynamicImports` | Power Pages パス構造対応 |
+| YAML が設定の正 | upload-code-site が毎回 YAML で Dataverse を上書き |
+| デプロイ後に必ず Restart | セキュリティ設定はキャッシュクリアまで反映されない |
+| 一般ユーザーでテスト必須 | 管理者はテーブル権限をバイパスする |
 
 ## 対応フレームワーク別ノート
 
@@ -257,37 +390,41 @@ python .github/skills/power-pages/scripts/manage_portal.py
 
 ## 検証済み教訓（Lessons Learned）
 
-### `.js` 拡張子ブロック問題
+### デプロイ系
 
-| 症状 | `pac pages upload-code-site` が 50% で停止、`PortalFileContentUploadFailed` |
-|------|------|
-| 原因 | Dataverse organization の `blockedattachments` に `.js` が含まれている |
-| 確認方法 | `GET /api/data/v9.2/organizations?$select=blockedattachments` |
-| 解決方法 | `.js` をリストから除外して PATCH で更新 |
+| 問題 | 原因 | 解決 |
+|------|------|------|
+| upload 後に site settings が消える | `upload-code-site` が YAML で上書き | YAML を正として管理。追加設定は upload 後に PATCH |
+| upload 後にページが白紙 / HTML ネスト | mspp_copy が `dist/index.html` 全文で上書き | deploy スクリプトで body-only に修正（Phase 3.6） |
+| upload が 50% で停止 | `.js` が blockedattachments に含まれる | `unblock_js.py` で解除 |
+| DNS 未解決 | ポータルインフラ停止 | Power Platform API で再プロビジョニング |
+| `pac pages provision-website` が動かない | PAC CLI 2.7.x に未実装 | Power Platform API or 管理画面 |
 
-```bash
-python .github/skills/power-pages/scripts/unblock_js.py
-```
+### セキュリティ系
 
-### DNS 未解決 = ポータルがデプロビジョン済み
+| 問題 | 原因 | 解決 |
+|------|------|------|
+| 管理者 OK / 一般ユーザー 403 | 管理者はテーブル権限バイパス | Design Studio で Web Role 紐付け |
+| API で N:N を設定しても反映しない | Enhanced Model の mspp_ N:N バグ | Design Studio のみ有効 |
+| `disableentitypermissions` が効かない | Enhanced Model では無視される | テーブル権限 + Role が必須 |
+| Site Settings あるのに 404 | `enabled=true` が未設定（`fields` のみでは不足） | 両方設定する |
 
-| 症状 | `Failed to resolve '{subdomain}.powerappsportals.com'` |
-|------|------|
-| 原因 | ポータルインフラがデプロビジョンされている（トライアル期限切れ or 停止） |
-| 確認方法 | Power Platform API の `websites` 一覧が空 / 管理画面で「停止」表示 |
-| 解決方法 | Create Website API で再プロビジョニング or 管理画面から開始 |
+### 認証系
 
-> **重要**: Dataverse の `adx_website` レコードが残っていてもインフラが停止していることがある。`pac pages list` はレコードを参照するため表示されるが、実際のサイトは利用不可。
+| 問題 | 原因 | 解決 |
+|------|------|------|
+| SPA fetch で 500 | `redirect: "manual"` なし + LoginButtonAuthenticationType | 全 fetch に `redirect: "manual"` |
+| ログインボタン2つ表示 | ビルトイン + カスタム OIDC 共存 | `AzureADLoginEnabled=false` |
+| "Sign in failed" | トラッキング防止が nonce Cookie ブロック | `Nonce=false` or ビルトインプロバイダー使用 |
+| ExternalLogin で 401 | form の provider 値が AuthenticationType と不一致 | 値を完全一致させる |
 
-### `pac pages provision-website` は PAC CLI 2.7.x に存在しない
+### ID 管理
 
-PAC CLI 2.7.4 時点では `provision-website` コマンドは未実装。代替手段:
-- Power Platform API の Create Website エンドポイント
-- Power Pages 管理画面: `https://make.powerpages.microsoft.com/environments/{ENV_ID}/portals/home`
-
-### Power Platform API の Website ID ≠ Dataverse adx_websiteid
-
-Power Platform API (`api.powerplatform.com`) で管理されるサイト ID は、Dataverse の `adx_websiteid` とは異なる場合がある。レガシーポータル（Power Pages サービス移行前に作成されたもの）は API に登録されておらず、一覧で 0 件が返る。
+| 問題 | 原因 | 解決 |
+|------|------|------|
+| Power Platform API の Website ID ≠ adx_websiteid | 管理レイヤーが異なる | 用途に応じて使い分け |
+| `pac pages list` で表示されるが実際は停止 | adx_ レコードとインフラの乖離 | PP API で状態確認 |
+| Restart が 200 だが反映されない | キャッシュクリアに 1〜2 分必要 | 待機してからテスト |
 
 ## 関連スキル
 

--- a/.github/skills/power-pages/references/enhanced-data-model-permissions.md
+++ b/.github/skills/power-pages/references/enhanced-data-model-permissions.md
@@ -1,0 +1,312 @@
+# Power Pages Enhanced Data Model — テーブル権限の教訓
+
+> **対象**: Enhanced Data Model（datamodelversion: 2.0）を使用する Power Pages サイト。
+> 2024年以降に作成されたサイトはデフォルトでこのモデルを使用する。
+
+## 概要
+
+Enhanced Data Model では、Power Pages ランタイムが **`mspp_` プレフィックスのテーブル**（mspp_entitypermission, mspp_webrole 等）を使用してセキュリティ評価を行う。一方で、Dataverse Web API 経由でのテーブル権限の N:N Web ロール紐付けにはプラットフォームバグが存在し、**API だけでは完全な自動化ができない**。
+
+---
+
+## アーキテクチャ: mspp_ vs adx_ テーブル
+
+| テーブルプレフィックス | 用途 | ランタイムが参照 |
+|---|---|---|
+| `mspp_` | Power Pages ランタイムのセキュリティ評価 | ✅ 参照する |
+| `adx_` | レガシー互換 / Design Studio 内部管理 | ❌ ランタイムは無視 |
+
+### 重要な関係
+
+```
+powerpagecomponent (type=18)
+  ↓ 自動作成
+mspp_entitypermission (ランタイムが参照)
+  ↔ mspp_entitypermission_webrole (N:N) ← ★ API で設定不可
+mspp_webrole (ランタイムが参照)
+```
+
+---
+
+## powerpagecomponent テーブル — type マッピング
+
+Power Pages Design Studio で管理されるコンポーネントの完全な type 一覧:
+
+| type | 名称 | 備考 |
+|------|------|------|
+| 1 | 公開状況 (Publishing State) | |
+| 2 | Web ページ (Web Page) | |
+| 3 | Web ファイル (Web File) | |
+| 4 | Web リンクセット (Web Link Set) | |
+| 5 | Web リンク (Web Link) | |
+| 6 | ページテンプレート (Page Template) | |
+| 7 | コンテンツスニペット (Content Snippet) | |
+| 8 | Web テンプレート (Web Template) | |
+| 9 | サイト設定 (Site Setting) | |
+| 10 | Web ページアクセス制御ルール (Web Page Access Control Rule) | content に `adx_webpageaccesscontrolrule_webrole` |
+| 11 | Web ロール (Web Role) | |
+| 12 | Web サイトのアクセス (Website Access) | content に `adx_websiteaccess_webrole` |
+| 13 | サイトマーカー (Site Marker) | |
+| 15 | 基本フォーム (Basic Form) | |
+| 17 | リスト (List) | |
+| **18** | **テーブルのアクセス許可 (Table Permission)** | **mspp_entitypermission を自動作成** |
+| 19 | 詳細フォーム (Advanced Form) | |
+| 28 | 列のアクセス許可プロファイル (Column Permission Profile) | |
+| 29 | 列のアクセス許可 (Column Permission) | |
+| 30 | リダイレクト (Redirect) | |
+| 32 | ショートカット (Shortcut) | |
+| 33 | クラウドフロー (Cloud Flow) | |
+| 34 | UX コンポーネント (UX Component) | |
+| 35 | サーバーロジック (Server Logic) | |
+
+---
+
+## ⚠️ CRITICAL: mspp_entitypermission_webrole N:N はAPI で設定不可
+
+### 問題
+
+`mspp_entitypermission_webrole` の N:N リレーションシップは、Dataverse Web API のすべての方法で設定を試みても**永続化しない**。
+
+### 試行結果
+
+| 方法 | HTTP レスポンス | 結果 |
+|------|----------------|------|
+| `$ref` POST（permission → role 方向） | 204 No Content | ❌ 永続化しない |
+| `$ref` POST（role → permission 方向） | 204 No Content | ❌ 永続化しない |
+| Deep Insert（permission 作成時に role を含める） | 500 NullReferenceException | ❌ サーバーエラー |
+| `$batch` リクエスト | 204 per item | ❌ 永続化しない |
+| powerpagecomponent content JSON に role ID を含める | 204 (更新成功) | ❌ N:N は作成されない |
+
+### 結論
+
+**Power Pages Design Studio（make.powerpages.microsoft.com）の UI のみが正しく N:N リンクを作成できる。** これは Design Studio が内部 API（Organization Service / 非公開エンドポイント）を使用しているためと推定される。
+
+### ワークアラウンド
+
+1. **管理者ユーザーはテーブル権限をバイパスする** — 管理者でアクセスする場合は N:N 不要
+2. **Design Studio で手動設定** — 一般ユーザー向けには必須
+3. **powerpagecomponent type=18 でレコードだけ先に作成** — Design Studio でロール紐付けのみ手動
+
+---
+
+## Web API 有効化に必要な設定（Enhanced Data Model）
+
+### 最小構成（管理者ユーザー向け）
+
+管理者（System Administrator ロール）は Table Permission をバイパスするため、以下の Site Settings のみで Web API にアクセス可能:
+
+```yaml
+# サイト設定（必須）
+Webapi/{table_logical_name}/enabled: "true"
+Webapi/{table_logical_name}/fields: "*"    # または列名カンマ区切り
+```
+
+### 完全構成（一般ユーザー向け）
+
+| # | 要素 | 設定方法 | 自動化可否 |
+|---|------|----------|-----------|
+| 1 | Site Settings (enabled/fields) | Dataverse Web API で作成 | ✅ 可能 |
+| 2 | Table Permission レコード | powerpagecomponent type=18 で作成 | ✅ 可能 |
+| 3 | **Web Role 紐付け (N:N)** | **Design Studio のみ** | ❌ 不可能 |
+| 4 | Site Restart | Power Platform API | ✅ 可能 |
+
+### Site Settings の作成パターン
+
+```python
+import json
+from auth_helper import get_token
+import requests
+
+DATAVERSE_URL = os.getenv("DATAVERSE_URL")
+token = get_token(f"{DATAVERSE_URL}.default")
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Content-Type": "application/json",
+    "OData-MaxVersion": "4.0",
+    "OData-Version": "4.0",
+}
+
+# テーブル Web API 有効化
+tables = ["geek_incident", "geek_knowledge"]
+for table in tables:
+    for suffix, value in [("/enabled", "true"), ("/fields", "*")]:
+        setting = {
+            "adx_name": f"Webapi/{table}{suffix}",
+            "adx_value": value,
+            "adx_websiteid@odata.bind": f"/adx_websites({WEBSITE_ID})",
+        }
+        requests.post(
+            f"{DATAVERSE_URL}api/data/v9.2/adx_sitesettings",
+            headers=headers, json=setting
+        )
+```
+
+---
+
+## powerpagecomponent type=18 でテーブル権限を作成
+
+type=18 の powerpagecomponent を作成すると、対応する `mspp_entitypermission` レコードが**自動的に作成される**。ただし Web Role の N:N リンクは含まれない。
+
+### content JSON のフォーマット
+
+```json
+{
+  "mspp_entityname": "geek_knowledge",
+  "mspp_scope": "756150000",
+  "mspp_read": "true",
+  "mspp_write": "false",
+  "mspp_create": "false",
+  "mspp_delete": "false",
+  "mspp_append": "true",
+  "mspp_appendto": "true"
+}
+```
+
+### mspp_scope の値
+
+| 値 | スコープ |
+|---|---|
+| 756150000 | Global |
+| 756150001 | Contact |
+| 756150002 | Account |
+| 756150003 | Parent |
+| 756150004 | Self |
+
+### 作成スクリプト例
+
+```python
+component = {
+    "powerpagecomponenttype": 18,
+    "name": f"{display_name} - Global Read",
+    "content": json.dumps({
+        "mspp_entityname": table_logical_name,
+        "mspp_scope": "756150000",
+        "mspp_read": "true",
+        "mspp_write": "false",
+        "mspp_create": "false",
+        "mspp_delete": "false",
+        "mspp_append": "true",
+        "mspp_appendto": "true",
+    }),
+    "powerpagesiteid@odata.bind": f"/powerpagesites({POWERPAGESITE_ID})",
+    "powerpagesitelanguageid@odata.bind": f"/powerpagesitelanguages({LANG_ID})",
+}
+requests.post(
+    f"{DATAVERSE_URL}api/data/v9.2/powerpagecomponents",
+    headers=headers, json=component
+)
+```
+
+---
+
+## disableentitypermissions は Enhanced Data Model で無効
+
+| Site Setting | Standard Model | Enhanced Model |
+|---|---|---|
+| `Webapi/{table}/disableentitypermissions` | ✅ 有効 — 権限チェックをスキップ | ❌ 無効 — 無視される |
+| `Webapi/{table}/disabletablepermissions` | ❌ 存在しない | ❌ 存在しない |
+
+> Enhanced Data Model では `disableentitypermissions=true` を設定しても 403 は解消されない。テーブル権限 + Web Role の紐付けが必須。
+
+---
+
+## 管理者ユーザーによるバイパス
+
+Power Pages の管理者ユーザー（Dataverse の System Administrator ロール）は、**テーブル権限の設定に関わらず** Web API にアクセスできる。
+
+| ユーザー種別 | Table Permission 必要 | Web Role 紐付け必要 |
+|---|---|---|
+| System Administrator | ❌ 不要 | ❌ 不要 |
+| Authenticated Users (一般) | ✅ 必要 | ✅ 必要 |
+| Anonymous (未認証) | ✅ 必要 | ✅ 必要 (Anonymous Users role) |
+
+### 開発時の注意
+
+管理者で動作確認して OK でも、一般ユーザーでテストしないと 403 が発見できない。**必ず一般ユーザーでもテストすること。**
+
+---
+
+## 推奨ワークフロー: テーブル権限の設定
+
+```
+Step 1: Site Settings を API で作成（Webapi/{table}/enabled, fields）
+    ↓
+Step 2: powerpagecomponent type=18 を API で作成（scope, CRUD 設定）
+    ↓
+Step 3: Design Studio で Web Role 紐付け（手動）
+    ↓
+Step 4: Site Restart（API）
+    ↓
+Step 5: 一般ユーザーでテスト
+```
+
+### Design Studio での紐付け手順
+
+1. https://make.powerpages.microsoft.com/ にアクセス
+2. 対象サイトを選択
+3. **セキュリティ** → **テーブルのアクセス許可** に移動
+4. 対象のテーブル権限を開く（Step 2 で自動作成済み）
+5. **ロール** セクションで **Authenticated Users** を追加
+6. **保存**
+
+---
+
+## サイト再起動 API
+
+セキュリティ設定変更後は必ずサイトを再起動してキャッシュをクリアする。
+
+```python
+from auth_helper import get_token
+import requests
+
+ENV_ID = os.getenv("ENV_ID")
+token = get_token("https://api.powerplatform.com/.default")
+headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+# サイト一覧取得
+r = requests.get(
+    f"https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites?api-version=2024-10-01",
+    headers=headers
+)
+site_id = r.json()["value"][0]["id"]
+
+# 再起動
+r = requests.post(
+    f"https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites/{site_id}/restart?api-version=2024-10-01",
+    headers=headers
+)
+# 200 OK = 成功
+```
+
+---
+
+## トラブルシューティング
+
+### 403 "You don't have permission to read the {table} table"
+
+| チェック項目 | 確認方法 |
+|---|---|
+| Site Settings が存在するか | `adx_sitesettings?$filter=adx_name eq 'Webapi/{table}/enabled'` |
+| mspp_entitypermission が存在するか | `mspp_entitypermissions?$filter=mspp_entityname eq '{table}'` |
+| Web Role が紐付いているか | `mspp_entitypermissions({id})/mspp_entitypermission_webrole` |
+| ユーザーが管理者か | 管理者なら権限不要で通る — 一般ユーザーでテスト |
+| サイト再起動したか | 設定変更後は必ず restart |
+
+### 403 が管理者で発生する場合
+
+Site Settings (`Webapi/{table}/enabled=true`) が未設定。管理者でも Site Settings は必須。
+
+### 403 が一般ユーザーのみで発生する場合
+
+Web Role の N:N 紐付けが欠落。Design Studio で設定する。
+
+---
+
+## 関連する既知の制限事項
+
+| 制限 | 詳細 |
+|---|---|
+| mspp_ N:N は Web API 不可 | 本ドキュメント参照 |
+| adx_ テーブルはランタイムが無視 | Enhanced Model では mspp_ のみ参照 |
+| type=18 content に role を含めても無効 | 試行済み: `mspp_entitypermission_webrole`, `adx_entitypermission_webrole` どちらも不可 |
+| pac paportal / pac pages はmspp_を操作しない | YAML 経由で adx_ テーブルを操作するため Enhanced Model では不完全 |

--- a/.github/skills/power-pages/references/troubleshooting.md
+++ b/.github/skills/power-pages/references/troubleshooting.md
@@ -109,6 +109,23 @@ for p in permissions.get("value", []):
 
 ---
 
+### E005a: Enhanced Data Model で 403（管理者 OK / 一般ユーザー NG）
+
+**症状:** 管理者ユーザーでは Web API が動作するが、一般ユーザーで 403 が返る。
+
+**原因:** Enhanced Data Model (datamodelversion: 2.0) では `mspp_entitypermission_webrole` の N:N リレーションが Dataverse Web API で設定不可能（プラットフォームバグ）。管理者はテーブル権限をバイパスするため問題が顕在化しない。
+
+**解決策:**
+1. Power Pages Design Studio（make.powerpages.microsoft.com）で手動設定
+2. セキュリティ → テーブルのアクセス許可 → 対象レコードを開く → ロールに Authenticated Users を追加
+3. サイト再起動
+
+> **注意:** `disableentitypermissions=true` は Enhanced Data Model で無効。API での $ref POST は 204 を返すが永続化しない。
+
+**詳細:** [Enhanced Data Model テーブル権限リファレンス](enhanced-data-model-permissions.md)
+
+---
+
 ### E006: CORS エラー
 
 **症状:** ブラウザコンソールに CORS エラーが表示される。


### PR DESCRIPTION
## 概要

Power Pages Enhanced Data Model (datamodelversion: 2.0) でテーブル権限（Table Permissions）を設定する際に発見した教訓・プラットフォームバグ・ワークアラウンドを文書化。

## 追加内容

### 新規ファイル
- \.github/skills/power-pages/references/enhanced-data-model-permissions.md\
  - Enhanced Data Model アーキテクチャ（mspp_ vs adx_）
  - powerpagecomponent type マッピング完全一覧（type 1〜35）
  - **CRITICAL**: mspp_ N:N Web Role 紐付けが Web API で不可能（プラットフォームバグ）
  - Web API 有効化の最小構成 vs 完全構成
  - powerpagecomponent type=18 による自動作成パターン
  - disableentitypermissions が Enhanced Model で無効
  - 管理者バイパスの挙動
  - 推奨ワークフロー（API + Design Studio ハイブリッド）
  - トラブルシューティングチェックリスト

### 更新ファイル
- \.github/skills/power-pages/SKILL.md\
  - サブリファレンスに Enhanced Data Model リファレンスを追加
  - triggers に Enhanced Data Model 関連キーワードを追加
  - Lessons Learned に 4 項目追加:
    - mspp_ N:N API 不可
    - disableentitypermissions 無効
    - 管理者 vs 一般ユーザーの挙動差
    - type=18 事前作成パターン
- \.github/skills/power-pages/references/troubleshooting.md\
  - E005a: Enhanced Data Model 固有の 403 トラブルシューティングを追加

## 背景

実際のプロジェクトで Enhanced Data Model サイトのテーブル権限を API で自動化しようとした結果、以下を発見:
1. \$ref\ POST → 204 を返すが永続化しない
2. Deep Insert → 500 NullReferenceException
3. \$batch\ → 204 を返すが永続化しない
4. content JSON に role ID を含めても N:N は作成されない
5. \disableentitypermissions=true\ は Enhanced Model で無視される
6. 管理者ユーザーはテーブル権限をバイパスする（開発時に見逃しやすい）

**結論: Design Studio の UI のみが正しく N:N リンクを作成できる。**