### PR TITLE
docs: デザインテンプレート先行デプロイ + PUBLIC サイト SPA 認証パターン

### DIFF
--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -40,6 +40,7 @@ React / Vue / Angular / Astro 等の静的 SPA フレームワークに対応。
 | [デプロイリファレンス](references/deployment-reference.md) | pac pages コマンド詳細・CI/CD パイプライン構成 |
 | [トラブルシューティング](references/troubleshooting.md) | よくあるエラーと解決策 |
 | [認証リファレンス](references/authentication-reference.md) | 認証サービス・anti-forgery・Entra ID |
+| [PUBLIC サイト SPA 認証](references/public-site-spa-auth.md) | PUBLIC サイトの form POST 認証・Liquid 注入・post_upload_fix パターン |
 | [Enhanced Data Model テーブル権限](references/enhanced-data-model-permissions.md) | Enhanced Data Model (v2.0) のテーブル権限設定・N:N バグ・ワークアラウンド |
 
 ## ワークフロー概要（microsoft/power-platform-skills 準拠）

--- a/.github/skills/power-pages/references/public-site-spa-auth.md
+++ b/.github/skills/power-pages/references/public-site-spa-auth.md
@@ -1,0 +1,264 @@
+# PUBLIC サイト SPA 認証パターン
+
+> PRIVATE サイトでは SPA ロード時点で認証済みだが、**PUBLIC サイト**ではユーザーが SPA 内のログインボタンから能動的に認証フローを開始する。
+
+## アーキテクチャ
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ PUBLIC Power Pages Site                                     │
+│                                                             │
+│  ┌──────────────┐      ┌──────────────────────────────┐    │
+│  │ Web Template │      │ SPA (React + HashRouter)      │    │
+│  │ (Liquid)     │      │                              │    │
+│  │              │      │  未認証: ホーム + ログインBtn  │    │
+│  │ {% if user %}│─────▶│  認証済: 全機能利用可能       │    │
+│  │   __PP_USER__│      │                              │    │
+│  │ {% endif %}  │      │  login() → form POST         │    │
+│  │              │      │  logout() → /LogOff redirect │    │
+│  │ {{ page. }}  │      └──────────────────────────────┘    │
+│  └──────────────┘                                           │
+└────────────────────────┬────────────────────────────────────┘
+                         │ form POST
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ /Account/Login/ExternalLogin                                │
+│   provider = Authority URL                                  │
+│   __RequestVerificationToken = from /_layout/tokenhtml      │
+│   returnUrl = /                                             │
+└────────────────────────┬────────────────────────────────────┘
+                         │ 302
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Microsoft Entra ID (login.microsoftonline.com)              │
+│   → 認証完了 → callback → session cookie set → returnUrl    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## PRIVATE vs PUBLIC サイト比較
+
+| 項目 | PRIVATE | PUBLIC |
+|------|---------|--------|
+| ページアクセス | 認証必須 | 匿名でアクセス可 |
+| SPA ロード時 | 必ず認証済み | 未認証の場合あり |
+| ユーザー情報 | `window.__PP_USER__` は常に存在 | `{% if user %}` で条件出力 |
+| ログインフロー | Platform が自動リダイレクト | SPA から form POST |
+| `LoginButtonAuthenticationType` | 有効（自動リダイレクト） | 効かない場合あり（ホスト overlay の影響） |
+| 推奨パターン | `use-auth.ts` + `redirect: 'manual'` | ExternalLogin form POST |
+
+## 実装パターン
+
+### 1. Web テンプレート（Liquid ユーザー注入）
+
+```liquid
+{% if user %}
+<script>
+window.__PP_USER__ = {
+  userName: "{{ user.fullname | escape }}",
+  firstName: "{{ user.firstname | escape }}",
+  lastName: "{{ user.lastname | escape }}",
+  email: "{{ user.emailaddress1 | escape }}",
+  contactId: "{{ user.id }}",
+  userRoles: ["Authenticated Users"]
+};
+</script>
+{% endif %}
+<div id="root"></div>
+<script type="module" src="/assets/{hash}.js"></script>
+```
+
+> **重要**: `{{ user | json }}` は簡潔だが、出力に制御文字が含まれる場合がある。
+> 個別フィールドを `| escape` 付きで出力するほうが安全。
+
+### 2. authService.ts（SPA 側認証サービス）
+
+```typescript
+interface PowerPagesUser {
+  userName: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  contactId?: string;
+  userRoles?: string[];
+}
+
+declare global {
+  interface Window {
+    __PP_USER__?: PowerPagesUser;
+  }
+}
+
+/**
+ * ユーザー検出: Liquid 注入データを読み取る
+ */
+export function getCurrentUser(): PowerPagesUser | null {
+  const user = window.__PP_USER__;
+  if (user && user.userName) return user;
+  return null;
+}
+
+/**
+ * Anti-forgery トークン取得
+ * Power Pages は /_layout/tokenhtml エンドポイントで提供
+ */
+async function fetchAntiForgeryToken(): Promise<string | null> {
+  try {
+    const res = await fetch("/_layout/tokenhtml");
+    const html = await res.text();
+    const match = html.match(/value="([^"]+)"/);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * ログイン: ExternalLogin に form POST
+ * LoginButtonAuthenticationType が効かない場合のフォールバック
+ */
+export async function login(returnUrl?: string): Promise<void> {
+  const token = await fetchAntiForgeryToken();
+  if (!token) {
+    // フォールバック: 通常リダイレクト
+    window.location.href = `/Account/Login?returnUrl=${encodeURIComponent(returnUrl ?? "/")}`;
+    return;
+  }
+
+  const form = document.createElement("form");
+  form.method = "POST";
+  form.action = "/Account/Login/ExternalLogin";
+
+  const fields: Record<string, string> = {
+    __RequestVerificationToken: token,
+    provider: "https://login.windows.net/{tenant-id}/",  // ← Authority URL
+    returnUrl: returnUrl ?? "/",
+  };
+
+  for (const [name, value] of Object.entries(fields)) {
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  }
+
+  document.body.appendChild(form);
+  form.submit();
+}
+
+/**
+ * ログアウト
+ */
+export function logout(): void {
+  window.location.href = "/Account/Login/LogOff?returnUrl=/";
+}
+```
+
+### 3. provider 値の特定方法
+
+`provider` は Entra ID の Authority URL と完全一致が必要:
+
+| パターン | Authority URL |
+|----------|--------------|
+| ビルトイン AzureAD | `https://login.windows.net/{tenant-id}/` |
+| カスタム OpenIdConnect | `Authentication/OpenIdConnect/{name}/Authority` の値 |
+
+> **`login.windows.net` ≠ `login.microsoftonline.com`** — 厳密一致が必須。
+> 確認方法: `/_layout/tokenhtml` の同一ページにある hidden input の `provider` 値を参照。
+
+### 4. LoginButtonAuthenticationType が効かない場合
+
+| 原因 | 対策 |
+|------|------|
+| Power Pages ホスト overlay がキャッシュ | form POST で直接 ExternalLogin |
+| サイト再起動未完了 | restart API → 60 秒待機 |
+| 複数プロバイダー登録 | 不要なプロバイダーを無効化 |
+| PUBLIC サイトで匿名アクセス | form POST が確実 |
+
+## テンプレート上書き対策（post_upload_fix パターン）
+
+### 問題
+
+`pac pages upload-code-site` は毎回 Web テンプレートの `source` フィールドを上書きする。
+Liquid ユーザー注入コードが消えてしまう。
+
+### 解決: post_upload_fix.py
+
+デプロイ後に Dataverse API でテンプレートを再パッチするスクリプト:
+
+```python
+"""Post-upload: verify page copy, re-patch template if needed, restart."""
+import glob, os, json, requests
+
+# アセットファイル名を自動検出
+assets_dir = './portal/dist/assets'
+js_name = os.path.basename(glob.glob(f'{assets_dir}/index-*.js')[0])
+css_name = os.path.basename(glob.glob(f'{assets_dir}/index-*.css')[0])
+
+# Liquid ユーザー注入 + SPA テンプレート
+USER_SCRIPT = '{% if user %}<script>window.__PP_USER__={userName:"{{ user.fullname | escape }}",firstName:"{{ user.firstname | escape }}",lastName:"{{ user.lastname | escape }}",email:"{{ user.emailaddress1 | escape }}",contactId:"{{ user.id }}",userRoles:["Authenticated Users"]};</script>{% endif %}'
+
+SPA_TEMPLATE = (
+    '<link rel="stylesheet" href="/assets/' + css_name + '" />\n'
+    + USER_SCRIPT + '\n'
+    + '<div id="root"></div>\n'
+    + '<script type="module" src="/assets/' + js_name + '"></script>'
+)
+
+# Dataverse PATCH でテンプレート復元
+def patch_template(template_id: str, source: str):
+    content = json.dumps({"source": source, "websiteid": WEBSITE_ID})
+    r = requests.patch(
+        f'{DATAVERSE_URL}/api/data/v9.2/powerpagecomponents({template_id})',
+        headers=headers,
+        json={"content": content}
+    )
+    assert r.status_code == 204
+
+# アップロード後に毎回実行
+patch_template(ENHANCED_TEMPLATE_ID, SPA_TEMPLATE)
+patch_template(STANDARD_TEMPLATE_ID, SPA_TEMPLATE)
+```
+
+### デプロイパイプライン
+
+```
+npm run build:pages
+  → dist-pages/ に出力
+
+Copy dist-pages → portal/dist
+  → portal/dist/index.html = '<div id="root"></div>' のみ
+
+pac pages upload-code-site --rootPath ./portal --compiledPath ./dist
+  ⚠️ テンプレートが上書きされる
+
+python scripts/post_upload_fix.py
+  → テンプレート再パッチ + サイト再起動
+```
+
+## サイト設定（PUBLIC サイト用）
+
+| Site Setting | Value | 目的 |
+|---|---|---|
+| `Authentication/Registration/LocalLoginEnabled` | `false` | ローカルログイン無効 |
+| `Authentication/Registration/ExternalLoginEnabled` | `true` | 外部 IdP 有効 |
+| `Authentication/Registration/AzureADLoginEnabled` | `true` | ビルトイン Entra ID 有効 |
+| `Authentication/Registration/LoginButtonAuthenticationType` | Authority URL | ログインページ自動リダイレクト（効く場合） |
+
+## ブラウザ関連の既知問題（修正不可）
+
+| エラー | 原因 | 対策 |
+|--------|------|------|
+| `Tracking Prevention blocked access to storage` | Edge/Safari のトラッキング防止 | 無視（機能に影響なし） |
+| `$ is not defined` on login page | Power Pages の jQuery 未読込 | Platform 側の問題。form POST で回避 |
+| Power Pages host overlay (`@microsoft/powerpages-host`) | Design Studio スクリプトの自動注入 | 制御不可。form POST で中間ページをバイパス |
+
+## 教訓まとめ
+
+1. **form POST が最も確実** — `LoginButtonAuthenticationType` より安定
+2. **`/_layout/tokenhtml`** — Anti-forgery トークン取得エンドポイント
+3. **Liquid `{% if user %}` で条件注入** — PUBLIC サイトでは未認証ユーザーもいる
+4. **テンプレートは毎回上書きされる** — post_upload_fix パターン必須
+5. **`returnUrl` にハッシュ(#)を含めない** — Power Pages が正しく処理しない
+6. **provider 値は Authority URL と厳密一致** — `login.windows.net` ≠ `login.microsoftonline.com`
+7. **サイト再起動後 60 秒待つ** — キャッシュ反映に時間がかかる

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -53,6 +53,67 @@
 
 ## 新しいプロジェクトの始め方
 
+### 推奨: デザインテンプレート先行デプロイ → シナリオ差し替え
+
+> **戦略**: デザインテンプレートをまずデプロイし動作確認した後、ユーザーの業務シナリオに置き換える。
+> デザイン（レイアウト・コンポーネント・テーマ）はそのまま維持し、中身だけ差し替える。
+
+```
+Phase 1: テンプレートデプロイ（デザイン確認）
+  ├── git clone → npm install → .env 設定
+  ├── npm run build:pages → pac pages upload
+  ├── ブラウザでデザイン確認（サンプルデータ表示）
+  └── ✅ Power Pages / Code Apps 上で動作する SPA を確認
+         ↓
+Phase 2: シナリオ差し替え（ドメイン変更）
+  ├── GeekPowerCode エージェントに業務要件を伝える
+  ├── src/types/ → 新しい型定義
+  ├── src/services/ → 新しい CRUD サービス
+  ├── src/hooks/ → 新しい React Query フック
+  ├── src/pages/ → 新しいページ群
+  └── ✅ レイアウト・コンポーネント・認証はそのまま
+         ↓
+Phase 3: Dataverse + バックエンド構築
+  ├── setup_dataverse.py でテーブル構築
+  ├── deploy_agent.py でエージェント構築
+  ├── deploy_flow.py でフロー構築
+  └── ✅ End-to-End 動作確認
+```
+
+#### Phase 2 で差し替える対象（4 層のみ）
+
+| 層 | ファイル | 差し替え内容 |
+|----|----------|-------------|
+| **型定義** | `src/types/{domain}.ts` | エンティティ型・ラベル・カラーマップ |
+| **サービス** | `src/services/{domain}-service.ts` | Dataverse CRUD (テーブル名・列名) |
+| **フック** | `src/hooks/use-{domain}.ts` | React Query (useQuery/useMutation) |
+| **ページ** | `src/pages/*.tsx` | 画面 UI (KPI・一覧・詳細・ボード等) |
+
+#### Phase 2 で差し替え **ない** もの（デザインテンプレートとして維持）
+
+| パス | 内容 |
+|------|------|
+| `src/pages/_layout.tsx` | ナビ構造・ヘッダー・フッター・テーマ切替 |
+| `src/components/` | ListTable, FormModal, KPI, DataTable 等の共通 UI |
+| `src/providers/` | PowerProvider, ThemeProvider, QueryProvider |
+| `src/services/authService.ts` | Power Pages 認証 (form POST + Liquid) |
+| `src/router.tsx` | ルート定義（パス名のみ変更） |
+| `styles/` | Tailwind CSS テーマ |
+| `vite.config.ts` | ビルド構成 |
+| `scripts/post_upload_fix.py` | テンプレート再パッチ + サイト再起動 |
+
+#### ページパターンの踏襲
+
+新しいシナリオでも以下のページパターンをそのまま適用:
+
+| パターン | 構成 | 例 |
+|----------|------|-----|
+| **一覧** | KPI カード + ListTable + フィルタ + FormModal | incidents.tsx |
+| **詳細** | カード群 + コメントスレッド + 編集モード | incident-detail.tsx |
+| **ボード** | @dnd-kit カンバン（5列） | board.tsx |
+| **ダッシュボード** | KPI + Recharts (Pie/Bar) + 直近一覧 | dashboard.tsx |
+| **マスタ** | シンプル CRUD (ListTable + FormModal) | categories.tsx |
+
 ### 方法 1: テンプレートとしてクローン
 
 ```bash
@@ -63,10 +124,14 @@ cd my-project
 cp .env.example .env
 # DATAVERSE_URL, TENANT_ID, SOLUTION_NAME, PUBLISHER_PREFIX を編集
 
-# 2. GitHub Copilot / Claude Code に指示（GeekPowerCode エージェント）
-# Copilot: @GeekPowerCode {あなたのアプリ}を作成してください
+# 2. デザインテンプレートをまずデプロイして動作確認
+npm install && npm run build:pages
+# → ブラウザで確認（サンプルデータでデザインが正しく表示される）
+
+# 3. GitHub Copilot / Claude Code に指示（GeekPowerCode エージェント）
+# Copilot: @GeekPowerCode {あなたのアプリ}に置き換えてください
 # Claude Code: GeekPowerCode エージェントを選択して同じ指示を入力
-# → エージェントが setup_dataverse.py 等を自動生成
+# → エージェントが types → services → hooks → pages を自動生成
 ```
 
 ### 方法 2: 開発標準だけ導入（既存プロジェクトに追加）
@@ -86,18 +151,30 @@ $base = "https://raw.githubusercontent.com/geekfujiwara/CodeAppsDevelopmentStand
 
 ## サンプルの置き換え手順
 
-1. **GeekPowerCode エージェントに要件を伝える**
+1. **デザインテンプレートをまずデプロイ**
+   - `npm run build:pages` → `pac pages upload-code-site` → `post_upload_fix.py`
+   - ブラウザでデザインが正しく表示されることを確認
+   - 認証フロー（ログイン/ログアウト）が動作することを確認
+
+2. **GeekPowerCode エージェントに業務要件を伝える**
    - エージェントが Phase 0（設計）から自動でガイド
    - テーブル設計・UI 設計・エージェント設計をそれぞれ提案 → 承認後に実装
 
-2. **エージェントが以下を自動で行う**
+3. **エージェントが自動で行う差し替え**
+   - `src/types/` — 新ドメインの型定義（ラベル・カラーマップ含む）
+   - `src/services/` — Dataverse CRUD サービス
+   - `src/hooks/` — React Query フック
+   - `src/pages/` — 業務画面（同じページパターンで新コンテンツ）
+   - `src/router.tsx` — ルート定義のパス名変更
+   - `src/pages/_layout.tsx` — ナビグループ（navGroups）の項目変更
    - `setup_dataverse.py` を要件に合わせて新規生成
    - `deploy_agent.py` のエージェント名・Instructions を更新
    - `deploy_flow.py` のフロー定義を更新
-   - `src/pages/` をプロジェクトの画面設計に合わせて実装
 
-3. **手動で行うこと**
+4. **手動で行うこと**
    - `.env` の設定
+   - Power Pages admin center で Identity Provider 有効化
    - Copilot Studio UI でのエージェント作成
    - Power Automate 接続の事前作成
+   - Design Studio で Table Permission → Web Role 紐付け
    - ナレッジ・MCP Server の UI での追加


### PR DESCRIPTION
## 概要

Power Pages + SPA 開発セッションで得られた教訓をスキルに反映。

### 変更内容

#### 1. PUBLIC サイト SPA 認証パターン (新規)
- \eferences/public-site-spa-auth.md\ — PUBLIC サイトで SPA からログインする場合の完全ガイド
  - form POST to \/Account/Login/ExternalLogin\ (中間ページをバイパス)
  - \/_layout/tokenhtml\ からの Anti-forgery トークン取得
  - Liquid \{% if user %}\ による条件付きユーザー注入
  - \post_upload_fix.py\ テンプレート再パッチパターン
  - PRIVATE vs PUBLIC サイトの認証フロー比較
  - ブラウザ既知問題 (Tracking Prevention, jQuery, host overlay)

#### 2. SAMPLES.md — デザインテンプレート先行アプローチ
- **Phase 1**: テンプレートをまずデプロイし動作確認
- **Phase 2**: types → services → hooks → pages の 4 層だけ差し替え（デザインは維持）
- **Phase 3**: Dataverse + バックエンド構築
- ページパターン踏襲の考え方を明記 (一覧/詳細/ボード/ダッシュボード/マスタ)

### 背景
営業管理 → インシデント管理へのシナリオ変更を実施し、レイアウト・コンポーネント・認証を維持したまま中身だけ差し替える方法論を確立。その知見をドキュメント化。