### PR TITLE
feat(power-pages): デプロイ後のサイト再起動を必須化 + キャッシュクリア案内

### DIFF
--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -514,6 +514,15 @@ value: "https://login.microsoftonline.com/{tenant-id}/"
 > **⚠️ CRITICAL**: `pac pages upload-code-site` はクラシックページを復活させる変更を加えるため、
 > アップロード後に **必ず Post-Upload Fix を実行**する。手動デプロイは禁止。
 
+> **⚠️ MUST: デプロイ後は必ずサイト再起動する**
+> Dataverse のテーブル権限・サイト設定はランタイムに積極的にキャッシュされる。
+> 再起動しないと変更が反映されず **403 (EntityPermissionReadIsMissing)** 等の原因になる。
+> `deploy_site.py` は Phase 5 で自動的に再起動する（`--skip-restart` 非推奨）。
+>
+> **再起動後はブラウザキャッシュもクリアしてアクセスする:**
+> `Ctrl+Shift+Delete` → **[キャッシュされた画像とファイル]** → 削除
+> （またはシークレット / InPrivate ウィンドウで確認）
+
 ```bash
 # 標準デプロイ（ビルド + アップロード + Post-Upload Fix + Restart すべて自動）
 py .github/skills/power-pages/scripts/deploy_site.py
@@ -575,6 +584,36 @@ Phase 5: Restart (Power Platform API でキャッシュクリア)
 
 > **注意**: `upload-code-site` は毎回 `.powerpages-site/site-settings/*.yml` で Dataverse を上書きする。YAML ファイルが設定の正。
 
+#### Phase 5: Restart（キャッシュクリア）の詳細
+
+デプロイ後のサイト再起動は **MUST**。Power Platform API 経由で実行する。
+
+```python
+from auth_helper import get_token
+import requests
+
+token = get_token(scope='https://api.powerplatform.com/.default')
+h = {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
+
+# 1) /websites を GET して API 側のサイト ID を取得（Dataverse の ID とは別物！）
+r = requests.get(
+    f'https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites?api-version=2024-10-01',
+    headers=h)
+sid = next(s['id'] for s in r.json()['value'] if 'mysite' in s['name'].lower())
+
+# 2) restart を POST（200 で成功）
+requests.post(
+    f'https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites/{sid}/restart?api-version=2024-10-01',
+    headers=h)
+```
+
+| 落とし穴 | 対策 |
+|----------|------|
+| `admin.powerpages.microsoft.com` は存在しない（NXDOMAIN） | エンドポイントは **`api.powerplatform.com`** |
+| Power Platform API のサイト ID ≠ Dataverse `powerpagesiteid` | 必ず `/websites` を GET して name 一致で API 側 ID を取得 |
+| 認証 scope が Dataverse のままだと 401 | `get_token(scope='https://api.powerplatform.com/.default')` |
+| 再起動しても画面が変わらない | **ブラウザキャッシュをクリア**（`Ctrl+Shift+Delete` → キャッシュされた画像とファイル） |
+
 ---
 
 ### Step 6: 検証
@@ -588,6 +627,7 @@ Phase 5: Restart (Power Platform API でキャッシュクリア)
 | セッション切れ | — | `/Account/Login` にリダイレクト |
 
 > **管理者で OK でも一般ユーザーで 403 は頻出パターン**。必ず両方でテストする。
+> **403 が出たらまずサイト再起動 + ブラウザキャッシュクリア**を疑う（設定変更がランタイムに未反映なケースが多い）。
 
 ---
 

--- a/.github/skills/power-pages/scripts/deploy_site.py
+++ b/.github/skills/power-pages/scripts/deploy_site.py
@@ -332,13 +332,23 @@ def phase_post_upload_fix(config):
 # Phase 5: Restart
 # ---------------------------------------------------------------------------
 def phase_restart(config):
-    """サイト再起動（キャッシュクリア）."""
+    """サイト再起動（キャッシュクリア）.
+
+    ⚠️ デプロイ後のサイト再起動は MUST。Dataverse のテーブル権限・サイト設定は
+    ランタイムに積極的にキャッシュされるため、再起動しないと変更が反映されず
+    403 (EntityPermissionReadIsMissing) 等の原因になる。
+
+    Power Platform API のサイト ID は Dataverse の powerpagesiteid とは別物。
+    必ず /websites を GET して name 一致で API 側 ID を取得してから restart する。
+    """
     logger.info("=" * 60)
-    logger.info("Phase 5: Restart (cache clear)")
+    logger.info("Phase 5: Restart (cache clear) [MUST]")
     logger.info("=" * 60)
 
     if skip_restart:
-        logger.info("  (skipped via --skip-restart)")
+        logger.warning("  ⚠️ --skip-restart 指定: 再起動をスキップしました。")
+        logger.warning("     権限・設定変更が反映されない場合があります。")
+        logger.warning("     手動で再起動してください（admin.powerplatform.microsoft.com）。")
         return None
 
     token = get_token(scope='https://api.powerplatform.com/.default')
@@ -356,10 +366,15 @@ def phase_restart(config):
             rr = requests.post(
                 f'https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites/{sid}/restart?api-version=2024-10-01',
                 headers=h)
-            logger.info(f"  Restart: {rr.status_code}")
+            if rr.status_code < 400:
+                logger.info(f"  ✅ Restart triggered: {rr.status_code}")
+            else:
+                logger.error(f"  ❌ Restart FAILED: {rr.status_code} {rr.text[:200]}")
+                logger.error("     手動で再起動してください（admin.powerplatform.microsoft.com）。")
             break
     else:
-        logger.warning("  Site not found in PP API — manual restart needed")
+        logger.error("  ❌ Site not found in PP API — 再起動できませんでした。")
+        logger.error("     手動で再起動してください（admin.powerplatform.microsoft.com）。")
 
     return site_url
 
@@ -385,6 +400,10 @@ def main():
     if site_url:
         logger.info(f"   URL: {site_url}")
     logger.info("   (Allow 1-2 minutes for cache propagation)")
+    logger.info("")
+    logger.info("   ⚠️ ブラウザキャッシュをクリアしてからアクセスしてください:")
+    logger.info("      Ctrl+Shift+Delete → [キャッシュされた画像とファイル] → 削除")
+    logger.info("      （またはシークレット/InPrivate ウィンドウで確認）")
     logger.info("=" * 60)
 
 


### PR DESCRIPTION
## 概要
Power Pages Code Site のデプロイで、**設定変更がランタイムキャッシュにより反映されず 403 (EntityPermissionReadIsMissing) が頻発**する問題を踏まえ、「デプロイ後のサイト再起動」を **MUST** として標準化します。あわせて、再起動後にユーザーが行うべき **ブラウザキャッシュクリア手順** を案内するようにしました。

## 背景 / 根本原因
- Dataverse のテーブル権限・サイト設定（webroles 等）は **ランタイムに積極的にキャッシュ**される。
- 設定が完璧でも、**サイトを再起動するまで変更が反映されず** 403 になる。
- 再起動は **Power Platform API (\pi.powerplatform.com\)** 経由でのみ可能。\dmin.powerpages.microsoft.com\ は存在しない（NXDOMAIN）。
- API 側のサイト ID は **Dataverse の \powerpagesiteid\ とは別物**。\/websites\ を GET して name 一致で取得する必要がある。
- 再起動後も **ブラウザキャッシュ**が残ると変更が見えない。

## 変更内容
### \scripts/deploy_site.py\
- Phase 5 (Restart) を **MUST 化**。再起動失敗時は \ERROR\ で明示し手動再起動を促す。
- \--skip-restart\ 指定時は警告を強調表示。
- デプロイ完了メッセージに **\Ctrl+Shift+Delete\ → [キャッシュされた画像とファイル]** のクリア案内を追加。

### \SKILL.md\
- Step 5 に「**デプロイ後は必ずサイト再起動する (MUST)**」ルールとキャッシュクリア案内を追記。
- Power Platform API による再起動手順（scope・API 側 ID 取得）のコード例を追加。
- 落とし穴表（エンドポイント / サイト ID / scope / キャッシュ）を追加。
- Step 6 検証に「403 が出たらまず再起動 + キャッシュクリアを疑う」を追記。

## チェックリスト
- [x] 再起動を Power Platform API で実行（HTTP 200 確認済み）
- [x] 認証は auth_helper の \get_token(scope='https://api.powerplatform.com/.default')\ を使用
- [x] ブラウザキャッシュクリア案内を表示