### PR TITLE
docs(power-pages): adx_website 削除禁止・孤立レコード対策の教訓を追加

### DIFF
--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -432,6 +432,8 @@ export default defineConfig({
 | `Object reference not set` + `FetchSolutions` | `adx_website` レコードが存在しない | 下記「adx_website は絶対に削除してはいけない」参照 |
 | `Object reference not set` + `ToOrganizationService` | ポータル App User の CRM 接続失敗 | サイトの Application User がロール付きで存在するか確認 |
 | 起動エラー全般（500）| 孤立レコードが原因の可能性 | 下記「孤立レコード問題」参照 |
+| 初回アクセスが 60 秒タイムアウト | プロビジョニング直後のコールドスタート | 正常。2〜3 分後に 120 秒タイムアウトで再試行 |
+| サイトが修復不能（500 が解消しない）| adx_website 削除等で環境が壊れた | 新サブドメインで新規作成（下記「リカバリ手順」）|
 
 ---
 
@@ -497,6 +499,42 @@ Code Site は `pac pages upload-code-site` でのみ作成可能。
 6. **`adx_website` レコードは EDM 2.0 でもランタイムに必須** — upload-code-site が初回に自動作成。削除禁止
 7. **孤立レコードは `FetchSolutions` の NullRef を引き起こす** — ただし削除対象を間違えるとさらに悪化する
 8. **デプロイ失敗時のリカバリは「再 upload-code-site」が最善** — 手動レコード操作はリスクが高い
+9. **壊れたサイトは修復より新規作成が早い** — `.powerpages-site/` 削除 → `siteName` 変更 → upload-code-site で新サイト作成（下記手順参照）
+10. **初回プロビジョニング後のコールドスタートには 2〜3 分かかる** — 最初の HTTP リクエストが 60 秒タイムアウトするのは正常。120秒タイムアウトで再試行すること
+
+---
+
+## 壊れたサイトのリカバリ手順（新規サイト再作成）
+
+`adx_website` 削除や孤立レコードで修復不能になった場合、新しいサブドメインで作り直すのが最速:
+
+```bash
+# 1. 旧サイトバインディングを削除
+cd portal
+rm -rf .powerpages-site .powerpages-site-backup .paportal
+
+# 2. powerpages.config.json の siteName を変更
+#    例: "IncidentPortal" → "IncidentPortal02"
+
+# 3. ビルド & アップロード（新サイト作成）
+npm run build
+pac pages upload-code-site --rootPath .
+
+# 4. アクティブ化（PP API）
+#    POST /powerpages/environments/{ENV_ID}/websites?api-version=2024-10-01
+#    body: { websiteRecordId, subdomain, dataModel: "Enhanced", ... }
+
+# 5. リスタート
+#    POST .../websites/{id}/restart?api-version=2024-10-01
+
+# 6. 2〜3分待ってアクセス確認
+```
+
+**ポイント:**
+- `.powerpages-site/` を削除することで `upload-code-site` が「初回」として新サイトを作成する
+- 旧サイトの `siteName` と異なる名前を使う（同名だと旧サイトに紐付く可能性）
+- アクティブ化の `subdomain` も新しいものにする（旧サブドメインは DNS 的に残る）
+- プロビジョニングは約 15 秒で完了するが、初回コールドスタートに 2〜3 分必要
 
 ---
 

--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -32,6 +32,8 @@ triggers:
 3. **2回目以降は upload-code-site → restart の2ステップだけ**
 4. **Post-Upload Fix は不要** — `upload-code-site` が header/footer/page を正しく構成する
 5. **`.powerpages-site/` は upload-code-site が自動管理する** — 手動作成・編集しない
+6. **`adx_website` レコードは絶対に削除しない** — EDM 2.0 でもランタイムが起動時に参照する
+7. **環境のクリーンアップ時は PP API のサイト一覧と照合してから削除する** — 誤削除で 500 エラー
 
 ## ワークフロー
 
@@ -427,14 +429,74 @@ export default defineConfig({
 | SPA が表示されずクラシックページ表示 | サイトが Code Site として作成されていない | **削除して `upload-code-site` で再作成**（変換不可） |
 | ログイン後にブランクページ | `ProfileRedirectEnabled=true` | `false` に設定 |
 | 設定変更が反映されない | サイトキャッシュ | PP API で restart + ブラウザキャッシュクリア |
+| `Object reference not set` + `FetchSolutions` | `adx_website` レコードが存在しない | 下記「adx_website は絶対に削除してはいけない」参照 |
+| `Object reference not set` + `ToOrganizationService` | ポータル App User の CRM 接続失敗 | サイトの Application User がロール付きで存在するか確認 |
+| 起動エラー全般（500）| 孤立レコードが原因の可能性 | 下記「孤立レコード問題」参照 |
 
-### 重要な教訓
+---
+
+## 危険操作（絶対にやってはいけないこと）
+
+### 1. `adx_website` レコードを削除してはいけない
+
+**EDM 2.0 Code Site であっても** ポータルランタイム (Adxstudio) は `adx_website` レコードを参照する。
+`upload-code-site` が初回アップロード時に自動作成するこのレコードを削除すると:
+
+- ランタイムが起動時に `NullReferenceException` → 500 エラー
+- スタックトレース: `ToOrganizationService` → `FetchSolutions`
+- サイトが完全にアクセス不能になる
+
+**復旧方法**: `adx_website` を POST で再作成 → restart
+
+```python
+# 最低限のフィールドで再作成
+body = {
+    "adx_name": f"{SITE_NAME} - {SUBDOMAIN}",
+    "adx_primarydomainname": f"{SUBDOMAIN}.powerappsportals.com",
+    "adx_website_language": 1033,  # or 1041 for Japanese
+}
+requests.post(f"{DATAVERSE_URL}api/data/v9.2/adx_websites", headers=headers, json=body)
+```
+
+### 2. PP API `POST /websites` で Code Site を作ってはいけない
+
+PP API の `POST /powerpages/environments/{envId}/websites` は**常にクラシックポータル**を作成する。
+Code Site は `pac pages upload-code-site` でのみ作成可能。
+
+### 3. 孤立レコードのクリーンアップ時の注意
+
+環境に複数のテスト/失敗サイトレコードが残った場合:
+
+| テーブル | 安全に削除可能? | 注意 |
+|---------|----------------|------|
+| `powerpagesites` | ⚠ 慎重に | 対応する PP API サイトが存在しないもののみ |
+| `adx_websites` | ❌ 基本削除禁止 | ランタイムが参照。削除すると 500 エラー |
+| `adx_websitelanguages` | ❌ 削除禁止 | サイトの言語バインディング |
+| `adx_webtemplates` | ❌ 削除禁止 | Header/Footer のレンダリングに必須 |
+
+**クリーンアップ前に必ず確認すること:**
+1. PP API (`GET /websites?api-version=2024-10-01`) で現在アクティブなサイト一覧を取得
+2. 各サイトの `websiteRecordId` (= `powerpagesiteid`) を確認
+3. アクティブサイトに紐付く `powerpagesiteid` を持つレコードは絶対に消さない
+4. `adx_websites` は基本的に消さない（どのサイトに紐付くか明確でない場合が多い）
+
+### 4. 環境内に 1つの Code Site しか作成しない
+
+同じ環境に複数の Code Site を作ると `adx_website` の紐付けが曖昧になる。
+1 環境 = 1 Code Site を推奨。
+
+---
+
+## 重要な教訓
 
 1. **Code Site は最初から Code Site として作成する必要がある** — 既存のクラシックサイトを Code Site に変換することはできない
 2. **`pac pages upload-code-site` が正しいサイト作成方法** — PP API の `POST /websites` で作ったサイトはクラシックポータル
 3. **Enhanced Data Model (v2.0) が自動的に使われる** — upload-code-site で作成されたサイトは EDM
 4. **Standard Data Model のサイトでは `adx_sitesettings` / `adx_websites` テーブルを使用** — `mspp_` プレフィックスは EDM (powerpagecomponent) のみ
 5. **サイト設定は `adx_sitesettings` に `adx_websiteid` をリンクして作成** — websiteId が異なると無視される
+6. **`adx_website` レコードは EDM 2.0 でもランタイムに必須** — upload-code-site が初回に自動作成。削除禁止
+7. **孤立レコードは `FetchSolutions` の NullRef を引き起こす** — ただし削除対象を間違えるとさらに悪化する
+8. **デプロイ失敗時のリカバリは「再 upload-code-site」が最善** — 手動レコード操作はリスクが高い
 
 ---
 


### PR DESCRIPTION
## 概要

Power Pages Code Site デプロイで発見した重大な教訓を SKILL.md に追加。
実際に IncidentPortal01 で環境が壊れ、IncidentPortal02 として新規作成で解決した経験を反映。

## 問題の経緯

1. 孤立レコードのクリーンアップで `adx_website` レコードを誤って削除
2. EDM 2.0 Code Site でもポータルランタイム (Adxstudio) が `adx_website` を参照
3. 削除後、`FetchSolutions` で `NullReferenceException` → サイト完全停止 (500)
4. adx_website を POST で再作成しても解消せず → **新サブドメインで再作成が最速解**

## 追加内容

### 核心原則に追加 (2項目)
- `adx_website` レコードは絶対に削除しない
- 環境クリーンアップ時は PP API と照合してから削除する

### 「危険操作」セクション（新規）
1. adx_website 削除禁止 — 復旧方法付き
2. PP API で Code Site を作ってはいけない — クラシックポータルしか作れない
3. 孤立レコードクリーンアップの安全チェックリスト
4. 1環境 = 1 Code Site 推奨

### 「壊れたサイトのリカバリ手順」セクション（新規）
- .powerpages-site 削除 → siteName 変更 → upload-code-site → Activate → Restart
- 旧サイトと異なる名前/サブドメインを使う理由
- コールドスタートに 2-3 分かかる注意

### トラブルシューティング表に追加 (5項目)
- `Object reference not set` + `FetchSolutions`
- `Object reference not set` + `ToOrganizationService`
- 起動エラー全般の孤立レコード可能性
- 初回アクセスのタイムアウト（コールドスタート正常動作）
- 修復不能サイトの新規作成誘導

### 重要な教訓に追加 (教訓 6-10)
- adx_website 必須性
- 孤立レコード問題
- リカバリ最善手
- 壊れたら修復より再作成
- 初回コールドスタート 2-3分
