### PR TITLE
fix: SKILL.md refresh + Web API lessons

### DIFF
--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -19,11 +19,14 @@ triggers:
   - "Enhanced Data Model"
   - "powerpagecomponent"
   - "403 Forbidden"
+  - "404 Resource not found"
+  - "9004010C"
 ---
 
 # Power Pages Code Site (SPA) 開発・デプロイスキル
 
 > **公式リファレンス**: [Power Pages でシングルページ アプリケーションを作成して展開する | Microsoft Learn](https://learn.microsoft.com/ja-jp/power-pages/configure/create-code-sites)
+> **新スキル参照**: [microsoft/power-platform-skills - power-pages](https://github.com/microsoft/power-platform-skills/tree/main/plugins/power-pages)
 
 ## 核心原則
 
@@ -31,15 +34,17 @@ triggers:
 2. **初回は Inactive Sites に作成される** → Power Pages ポータル or PP API でアクティブ化
 3. **2回目以降は upload-code-site → restart の2ステップだけ**
 4. **Post-Upload Fix は不要** — `upload-code-site` が header/footer/page を正しく構成する
-5. **`.powerpages-site/` は upload-code-site が自動管理する** — 手動作成・編集しない
+5. **`.powerpages-site/` は upload-code-site が自動管理する** — ただし `site-settings/` YAML は手動追加して永続化できる（下記参照）
 6. **`adx_website` レコードは絶対に削除しない** — EDM 2.0 でもランタイムが起動時に参照する
 7. **環境のクリーンアップ時は PP API のサイト一覧と照合してから削除する** — 誤削除で 500 エラー
+8. **`credentials: "same-origin"` を使う** — `"include"` ではない（same-site Cookie 認証）
+9. **powerpagecomponent type=18 には `powerpagesitelanguageid` が必須** — 未設定だと 404 になる
 
 ## ワークフロー
 
 ```
 初回:
-  npm run build → pac pages upload-code-site → Activate → Restart
+  npm run build → pac pages upload-code-site → Activate → setup_contact_webapi.py → Restart
 
 2回目以降:
   npm run build → pac pages upload-code-site → Restart
@@ -74,153 +79,452 @@ portal/
 │   │   ├── mode-toggle.tsx       ← ダーク/ライト切替
 │   │   └── ui/                   ← shadcn/ui コンポーネント
 │   ├── hooks/
-│   │   └── use-auth.ts           ← SSO 認証フック (★デフォルト実装)
+│   │   └── use-auth.ts           ← SSO 認証フック
 │   ├── lib/
+│   │   ├── api.ts                ← ★ Web API 共有クライアント (apiGet/apiPost/apiPatch)
 │   │   └── utils.ts              ← cn() ユーティリティ
 │   └── pages/
 │       ├── home.tsx              ← ランディングページ
-│       └── profile.tsx           ← プロフィール編集 (★デフォルト実装)
+│       └── profile.tsx           ← プロフィール編集 (★ api.ts を使用)
 ├── dist-site/                    ← ビルド出力 (compiledPath)
-│   ├── index.html
-│   └── assets/
+├── .powerpages-site/             ← upload-code-site が管理 + site-settings YAML 手動追加可
+│   └── site-settings/            ← Webapi/* 設定を YAML で永続化
 ├── powerpages.config.json        ← CLI 設定ファイル (必須)
 ├── package.json
 ├── vite.config.ts
 └── scripts/
-    └── deploy.py                 ← デプロイスクリプト (Build→Upload→Restart)
+    ├── deploy.py                 ← デプロイスクリプト (Build→Upload→Restart)
+    └── setup_contact_webapi.py   ← Contact Web API 有効化 (EDM 2.0 対応)
 ```
-
-> **`.powerpages-site/` は upload-code-site が自動生成・管理する。手動作成不要。**
 
 ---
 
-## ★ デフォルト実装: SSO ログイン + プロフィール編集
+## ★ Web API 共有クライアント (api.ts)
 
-**すべての Code Site プロジェクトに最初から含める必須機能:**
+**すべての `/_api/` 呼び出しはこの共有クライアントを通す。**
+microsoft/power-platform-skills の `/integrate-webapi` パターンに準拠。
 
-1. Entra ID SSO ログイン（`/SignIn` 直行方式）
-2. プロフィール編集ページ（`/_api/contacts` 経由で PATCH）
-3. ヘッダー右上のプロフィールアバターアイコン + ドロップダウン
-4. `RequireAuth` ガードコンポーネント
-5. Contact 自動作成（Power Pages のデフォルト動作）
+```typescript
+/**
+ * Power Pages Web API (`/_api/`) クライアント
+ *
+ * 認証: ブラウザのセッション Cookie（same-origin）。Bearer トークン不要。
+ * 書き込み (POST/PATCH/DELETE): anti-forgery token が必須。
+ */
+const BASE = "/_api";
 
-**実体は `templates/corporate-lp/` にそのまま含まれている。** 新規プロジェクトはこのテンプレートをコピーして使う:
-
-| 機能 | テンプレートファイル |
-|---|---|
-| SSO 認証フック | [`templates/corporate-lp/src/hooks/use-auth.ts`](templates/corporate-lp/src/hooks/use-auth.ts) |
-| Web API クライアント（`/_api/` + anti-forgery token） | [`templates/corporate-lp/src/lib/dataverse.ts`](templates/corporate-lp/src/lib/dataverse.ts) |
-| 認証ガード | [`templates/corporate-lp/src/components/require-auth.tsx`](templates/corporate-lp/src/components/require-auth.tsx) |
-| プロフィール編集ページ | [`templates/corporate-lp/src/pages/profile.tsx`](templates/corporate-lp/src/pages/profile.tsx) |
-| ヘッダーのプロフィールドロップダウン | [`templates/corporate-lp/src/components/site-layout.tsx`](templates/corporate-lp/src/components/site-layout.tsx) |
-| `/profile` ルート（`RequireAuth` でガード） | [`templates/corporate-lp/src/App.tsx`](templates/corporate-lp/src/App.tsx) |
-
-**実装の核心:**
-- `login()` は `/SignIn?returnUrl=...`。Entra ID が唯一の IdP なら自動で SSO に直行する
-- ユーザー情報は `window.Microsoft.Dynamic365.Portal.User`（標準注入）または Liquid `window.__PP_USER__`
-- 読み取りは `credentials: 'same-origin'`、書き込みは `/_layout/tokenhtml` の anti-forgery token を付与
-- コード詳細・設計判断は [`references/authentication-reference.md`](references/authentication-reference.md) を参照
-
-### ★ SSO 自動リダイレクト設定（ログインボタンで直接 Entra ID に飛ばす）
-
-**これがないと `/SignIn` でクラシックなログイン画面（Username/Password フォーム + Entra ID ボタン）が表示される。**
-
-以下の Site Settings を `adx_sitesettings` テーブルに作成する:
-
-| Site Setting | 値 | 効果 |
-|---|---|---|
-| `Authentication/Registration/LocalLoginEnabled` | `false` | Username/Password フォームを非表示 |
-| `Authentication/Registration/ExternalLoginEnabled` | `true` | 外部 IdP (Entra ID) を有効化 |
-| `Authentication/Registration/AzureADLoginEnabled` | `false` | 旧式 Azure AD ボタンの重複を防止 |
-| `Authentication/Registration/LoginButtonAuthenticationType` | `https://login.microsoftonline.com/{TENANT_ID}/` | **IdP が1つの場合、ログインページをスキップして直接リダイレクト** |
-| `Authentication/Registration/ProfileRedirectEnabled` | `false` | ログイン後に `/profile` へのリダイレクトを防止 |
-| `Authentication/Registration/OpenRegistrationEnabled` | `false` | Entra ID ユーザーのみ（セルフ登録無効） |
-
-> ⚠️ **`LoginButtonAuthenticationType` の値は Authority URL** (`https://login.microsoftonline.com/{TENANT_ID}/`)
-> **`https://sts.windows.net/{TENANT_ID}/`（OIDC Issuer）ではない！** Issuer を設定すると自動リダイレクトが動作しない。
-
-```python
-# setup_auth.py で一括設定
-TENANT_ID = os.environ["TENANT_ID"]
-AUTHORITY = f"https://login.microsoftonline.com/{TENANT_ID}/"
-ADX_WEBSITE_ID = "..."  # adx_websites テーブルの ID
-
-SETTINGS = {
-    "Authentication/Registration/LoginButtonAuthenticationType": AUTHORITY,
-    "Authentication/Registration/LocalLoginEnabled": "false",
-    "Authentication/Registration/ExternalLoginEnabled": "true",
-    "Authentication/Registration/AzureADLoginEnabled": "false",
-    "Authentication/Registration/ProfileRedirectEnabled": "false",
-    "Authentication/Registration/OpenRegistrationEnabled": "false",
+export interface ODataCollection<T> {
+  value: T[];
+  "@odata.count"?: number;
 }
 
-for name, value in SETTINGS.items():
-    upsert_adx_sitesetting(name, value, ADX_WEBSITE_ID)
+export class ApiAuthError extends Error {
+  constructor(public status: number) {
+    super(`Authentication required (${status})`);
+    this.name = "ApiAuthError";
+  }
+}
 
-# 設定反映にはサイト再起動が必要
-restart_site(ENV_ID, SUBDOMAIN)
+/** anti-forgery token のキャッシュ */
+let cachedToken: string | null = null;
+
+async function getRequestVerificationToken(): Promise<string> {
+  if (cachedToken) return cachedToken;
+
+  // 1. DOM から取得（ページにトークンが埋め込まれている場合）
+  const input = document.querySelector<HTMLInputElement>(
+    'input[name="__RequestVerificationToken"]',
+  );
+  if (input?.value) {
+    cachedToken = input.value;
+    return cachedToken;
+  }
+
+  // 2. /_layout/tokenhtml から取得（SPA フォールバック）
+  try {
+    const res = await fetch("/_layout/tokenhtml", { credentials: "same-origin" });
+    const html = await res.text();
+    const match = html.match(/value="([^"]+)"/);
+    if (match?.[1]) {
+      cachedToken = match[1];
+      return cachedToken;
+    }
+  } catch { /* fall through */ }
+  return "";
+}
+
+function baseHeaders(): Record<string, string> {
+  return {
+    Accept: "application/json",
+    "OData-MaxVersion": "4.0",
+    "OData-Version": "4.0",
+    Prefer: 'odata.include-annotations="*"',
+  };
+}
+
+async function handleResponse<T>(res: Response, path: string): Promise<T> {
+  if (res.redirected && res.url.includes("/Account/Login")) {
+    throw new ApiAuthError(302);
+  }
+  if (res.status === 401 || res.status === 403) {
+    throw new ApiAuthError(res.status);
+  }
+  if (!res.ok) {
+    const body = await res.text();
+    console.error(`[API] ${res.status} (${path}):`, body);
+    throw new Error(`API ${res.status}: ${body}`);
+  }
+  if (res.status === 204) return undefined as T;
+  return res.json();
+}
+
+export async function apiGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${BASE}/${path}`, {
+    method: "GET",
+    credentials: "same-origin",  // ★ "include" ではなく "same-origin"
+    headers: baseHeaders(),
+  });
+  return handleResponse<T>(res, path);
+}
+
+export async function apiPost<T>(path: string, body: unknown): Promise<T> {
+  const token = await getRequestVerificationToken();
+  const res = await fetch(`${BASE}/${path}`, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {
+      ...baseHeaders(),
+      "Content-Type": "application/json",
+      __RequestVerificationToken: token,
+    },
+    body: JSON.stringify(body),
+  });
+  return handleResponse<T>(res, path);
+}
+
+export async function apiPatch(path: string, body: unknown): Promise<void> {
+  const token = await getRequestVerificationToken();
+  const res = await fetch(`${BASE}/${path}`, {
+    method: "PATCH",
+    credentials: "same-origin",
+    headers: {
+      ...baseHeaders(),
+      "Content-Type": "application/json",
+      __RequestVerificationToken: token,
+    },
+    body: JSON.stringify(body),
+  });
+  await handleResponse<void>(res, path);
+}
 ```
 
-**設定後の動作:**
-1. ユーザーが `/SignIn?returnUrl=/` にアクセス
-2. Power Pages はログイン画面を表示せず、直接 `https://login.microsoftonline.com/{TENANT_ID}/oauth2/authorize?...` にリダイレクト
-3. Entra ID でSSO認証（既にセッションがあれば自動的にログイン完了）
-4. `returnUrl=/` にリダイレクトされ SPA がロード
+**ポイント:**
+- `credentials: "same-origin"` — Power Pages は same-site なので `include` は不要
+- `Prefer: odata.include-annotations="*"` — lookup の FormattedValue を取得
+- `handleResponse` でリダイレクト検出 + 詳細エラーログ出力
+- anti-forgery token は DOM → `/_layout/tokenhtml` フォールバックでキャッシュ
+- lookup の書き込みには `@odata.bind` を使用: `"geek_inquirerid@odata.bind": "/contacts(...)"`
 
-> Site Settings 変更後は **PP API で restart が必須**（最大15分キャッシュが残る）。
+---
 
-### Contact 自動作成
+## ★ SSO + プロフィール編集 (デフォルト実装)
 
-Power Pages では **Entra ID 経由で初回ログインした時に Contact レコードが自動作成される**。
-サイト設定 `Authentication/Registration/OpenRegistrationEnabled = false` でも、Entra ID 経由なら Contact は自動作成される。
-追加のコードは不要。
+### use-auth.ts
 
-### Contact テーブルの Web API 有効化
+```typescript
+import { useState, useEffect, useCallback } from "react";
 
-プロフィール編集には `contact` テーブルの Web API アクセスが必要。
-**3 つのレイヤーすべてを設定しないと 404 になる:**
+export interface AuthUser {
+  contactId: string;
+  fullName: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+}
 
-1. **Site Settings** (`adx_sitesettings`) — `Webapi/contact/enabled` + `fields`
-2. **テーブル権限** (`powerpagecomponent` type=18 / Enhanced。Standard なら `mspp_entitypermission`) — Contact Self スコープ
-3. **Web Role 紐付け** (N:N) — 認証ユーザーへの権限付与
+export function useAuth() {
+  const [state, setState] = useState<{
+    isAuthenticated: boolean;
+    user: AuthUser | null;
+    loading: boolean;
+  }>({ isAuthenticated: false, user: null, loading: true });
 
-`scripts/setup_permissions.py` がこの 3 レイヤーをべき等に一括設定する。手順・スコープ値・モデル別の注意点（`powerpagesites` vs `adx_websites` のバインド先など）は [`references/dataverse-connection-reference.md`](references/dataverse-connection-reference.md) を参照。
+  useEffect(() => {
+    const portalUser = (window as any)["Microsoft"]?.Dynamic365?.Portal?.User;
+    const contactId = portalUser?.contactId || portalUser?.id || "";
 
-> ⚠️ **よくあるミス:** Site Settings の `adx_websiteid` は `adx_websites` に、テーブル権限の `powerpagesiteid` は `powerpagesites` に紐付ける（バインド先が異なる）。
+    if (contactId) {
+      setState({
+        isAuthenticated: true,
+        user: {
+          contactId,
+          fullName: portalUser?.fullName || portalUser?.fullname || "",
+          email: portalUser?.emailAddress || portalUser?.emailaddress1 || "",
+          firstName: portalUser?.firstName || portalUser?.firstname || "",
+          lastName: portalUser?.lastName || portalUser?.lastname || "",
+          phone: portalUser?.telephone1 || "",
+        },
+        loading: false,
+      });
+    } else {
+      setState({ isAuthenticated: false, user: null, loading: false });
+    }
+  }, []);
 
-### ★ 初回デプロイ後の必須手順
+  const login = useCallback(() => {
+    const returnUrl = encodeURIComponent(window.location.pathname + window.location.hash);
+    window.location.href = `/SignIn?returnUrl=${returnUrl}`;
+  }, []);
 
-デプロイ直後に以下を実行し、SSO + Web API が動作する状態にする:
+  const logout = useCallback(() => {
+    window.location.href = "/Account/Login/LogOff?returnUrl=%2F";
+  }, []);
 
-```bash
-# 1. SSO 自動リダイレクト設定（/SignIn で直接 Entra ID にリダイレクト）
-py scripts/setup_auth.py
-
-# 2. Web API テーブル権限設定（/_api/ エンドポイント有効化）
-py scripts/setup_permissions.py
-
-# 3. サイトリスタート（設定反映）— 上記スクリプト内で自動実行される
+  return { ...state, login, logout };
+}
 ```
 
-**スクリプト実行に必要な .env:**
-```env
-DATAVERSE_URL=https://your-org.crm.dynamics.com/
-ENV_ID=your-environment-id
-TENANT_ID=your-tenant-id
-PP_SUBDOMAIN=your-site-subdomain
+### profile.tsx（api.ts を使用）
+
+```tsx
+import { useState, useEffect } from "react";
+import { useAuth } from "@/hooks/use-auth";
+import { apiGet, apiPatch, ApiAuthError } from "@/lib/api";
+
+interface ContactProfile {
+  firstname: string;
+  lastname: string;
+  emailaddress1: string;
+  telephone1: string;
+}
+
+export default function ProfilePage() {
+  const { user } = useAuth();
+  const [profile, setProfile] = useState<ContactProfile>({
+    firstname: "", lastname: "", emailaddress1: "", telephone1: "",
+  });
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  useEffect(() => {
+    if (!user?.contactId) return;
+    fetchProfile();
+  }, [user?.contactId]);
+
+  async function fetchProfile() {
+    const path = `contacts(${user!.contactId})?$select=firstname,lastname,emailaddress1,telephone1`;
+    try {
+      const data = await apiGet<ContactProfile>(path);
+      setProfile({
+        firstname: data.firstname || "",
+        lastname: data.lastname || "",
+        emailaddress1: data.emailaddress1 || "",
+        telephone1: data.telephone1 || "",
+      });
+    } catch (e) {
+      if (e instanceof ApiAuthError) {
+        setMessage({ type: "error", text: `認証エラー (${e.status})。再ログインしてください。\nGET /_api/${path}` });
+      } else {
+        setMessage({ type: "error", text: `取得失敗。\nGET /_api/${path}\n${e instanceof Error ? e.message : String(e)}` });
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    const path = `contacts(${user!.contactId})`;
+    try {
+      await apiPatch(path, {
+        firstname: profile.firstname,
+        lastname: profile.lastname,
+        telephone1: profile.telephone1,
+      });
+      setMessage({ type: "success", text: "プロフィールを更新しました" });
+    } catch (e) {
+      if (e instanceof ApiAuthError) {
+        setMessage({ type: "error", text: `認証エラー (${e.status})。\nPATCH /_api/${path}` });
+      } else {
+        setMessage({ type: "error", text: `更新失敗。\nPATCH /_api/${path}\n${e instanceof Error ? e.message : String(e)}` });
+      }
+    }
+  }
+  // ... UI は省略（詳細はテンプレート参照）
+}
 ```
 
-**`/_api/contacts` が 404 を返す原因**:
-- Site Settings (`Webapi/contact/enabled`) が未設定 → `setup_permissions.py` で解決
-- テーブル権限が未設定 → 同スクリプトで解決
-- Web Role リンクなし → 同スクリプトで解決
+**旧実装との差分:**
+- ❌ 旧: 生 `fetch` + `credentials: "include"` + 手動トークン取得
+- ✅ 新: `apiGet`/`apiPatch` + `credentials: "same-origin"` + 自動トークン + 詳細エラー表示
 
-**ログイン画面が表示される（自動リダイレクトしない）原因**:
-- `LoginButtonAuthenticationType` が未設定 or 値が間違い → `setup_auth.py` で解決
-- ❌ `https://sts.windows.net/{TENANT_ID}/` → 動作しない
-- ✅ `https://login.microsoftonline.com/{TENANT_ID}/` → 正しい Authority URL
+---
 
-### powerpages.config.json（必須）
+## ★ Contact テーブル Web API 有効化 (EDM 2.0)
+
+### 重大な教訓: 404 "Resource not found for the segment contact"
+
+**エラーコード 9004010C** が発生する場合、以下の **4 つのレイヤーすべて** が正しく設定されている必要がある:
+
+| # | レイヤー | テーブル | 紐付け先 |
+|---|---------|---------|---------|
+| 1 | `adx_sitesettings` | `Webapi/contact/enabled=true` | `adx_websites` |
+| 2 | `adx_sitesettings` | `Webapi/contact/fields=*` | `adx_websites` |
+| 3 | `powerpagecomponent` type=18 | テーブル権限 (Self) | `powerpagesites` + **`powerpagesitelanguages`** |
+| 4 | `powerpagecomponent_powerpagecomponent` N:N | 権限→Web ロール紐付け | type=11 (Authenticated Users) |
+
+### ⚠️ 致命的な落とし穴: `powerpagesitelanguageid`
+
+```
+根本原因: powerpagecomponent type=18 に powerpagesitelanguageid が null だと、
+         Power Pages ランタイムがテーブル権限を認識せず 404 を返す。
+
+確認方法:
+GET /api/data/v9.2/powerpagecomponents({perm_id})?$select=_powerpagesitelanguageid_value
+
+修正方法:
+PATCH /api/data/v9.2/powerpagecomponents({perm_id})
+{
+  "powerpagesitelanguageid@odata.bind": "/powerpagesitelanguages({lang_id})"
+}
+```
+
+### powerpagecomponent type=18 の正しい content 形式
+
+```json
+{
+  "entitylogicalname": "contact",
+  "entityname": "contact - Self Read Write",
+  "scope": 756150001,
+  "read": true,
+  "write": true,
+  "create": false,
+  "delete": false,
+  "append": false,
+  "appendto": false
+}
+```
+
+**注意:**
+- ❌ `mspp_entityname`, `mspp_scope: "756150001"` (文字列) — 古いフォーマット、動作しない場合がある
+- ✅ `entitylogicalname`, `scope: 756150001` (整数), `read: true` (bool) — system format
+
+### scope 値一覧
+
+| 値 | スコープ | 用途 |
+|---|---------|------|
+| 756150000 | Global | 全レコード読み取り |
+| 756150001 | Self (Contact) | 自分の Contact レコードのみ |
+| 756150002 | Account | 自分の Account 配下 |
+| 756150003 | Parent | 親権限に紐づくレコード |
+
+### setup_contact_webapi.py（正しい実装）
+
+```python
+# 1. adx_sitesettings (→ adx_websites にバインド)
+create_site_setting("Webapi/contact/enabled", "true", website_id)
+create_site_setting("Webapi/contact/fields", "*", website_id)  # system table は * 推奨
+
+# 2. powerpagecomponent type=18 (★ powerpagesitelanguageid 必須)
+content = json.dumps({
+    "entitylogicalname": "contact",
+    "entityname": "contact - Self Read Write",
+    "scope": 756150001,
+    "read": True, "write": True, "create": False,
+    "delete": False, "append": False, "appendto": False,
+})
+body = {
+    "powerpagecomponenttype": 18,
+    "name": "contact - Self Read Write",
+    "content": content,
+    "powerpagesiteid@odata.bind": f"/powerpagesites({site_id})",
+    "powerpagesitelanguageid@odata.bind": f"/powerpagesitelanguages({lang_id})",  # ★ 必須！
+}
+
+# 3. Authenticated Users (type=11) への N:N リンク
+POST /powerpagecomponents({perm_id})/powerpagecomponent_powerpagecomponent/$ref
+{"@odata.id": "/api/data/v9.2/powerpagecomponents({role_id})"}
+```
+
+> ⚠️ **よくあるミス（修正済み）:**
+> - `powerpagesitelanguageid` が null → ランタイムが権限を無視して 404
+> - content に `mspp_` プレフィックスの文字列値 → 整数・bool 値が正しい
+> - `credentials: "include"` → 正しくは `"same-origin"`
+> - `Webapi/<table>/fields` に明示リストのみ → system table は `*` を使う
+
+---
+
+## ★ デバッグ用 Site Settings
+
+### Webapi/error/innererror
+
+開発・デバッグ中は以下を有効にする:
+
+```python
+# Dataverse API で直接追加
+body = {
+    "adx_name": "Webapi/error/innererror",
+    "adx_value": "true",
+    "adx_websiteid@odata.bind": f"/adx_websites({website_id})",
+}
+requests.post(f"{DV}/api/data/v9.2/adx_sitesettings", headers=h, json=body)
+```
+
+これにより `/_api/` のエラーレスポンスに `innererror` が含まれ、デバッグが容易になる。
+
+> ⚠️ **本番環境では `false` に戻す** — 内部エラー情報が漏洩するリスクがある。
+
+---
+
+## ★ `.powerpages-site/site-settings/` による永続化
+
+`pac pages upload-code-site` は `.powerpages-site/` フォルダの内容を同期する。
+`site-settings/` に Webapi 設定の YAML を配置すると、デプロイ時に自動反映される。
+
+### YAML フォーマット
+
+```yaml
+# .powerpages-site/site-settings/Webapi-contact-enabled.sitesetting.yml
+id: <既存レコードの adx_sitesettingid>
+name: Webapi/contact/enabled
+source: 0
+value: "true"
+```
+
+```yaml
+# .powerpages-site/site-settings/Webapi-contact-fields.sitesetting.yml
+id: <既存レコードの adx_sitesettingid>
+name: Webapi/contact/fields
+source: 0
+value: "*"
+```
+
+```yaml
+# .powerpages-site/site-settings/Webapi-error-innererror.sitesetting.yml
+id: <新規 GUID>
+name: Webapi/error/innererror
+source: 0
+value: "true"
+```
+
+**ID の取得方法:** Dataverse から `adx_sitesettings` をクエリして `adx_sitesettingid` を取得。
+新規の場合は任意の GUID を生成。
+
+---
+
+## エラーコード早見表
+
+| HTTP | OData Code | メッセージ | 原因 | 対策 |
+|------|-----------|---------|------|------|
+| 404 | 9004010C | Resource not found for the segment `<table>` | テーブル権限未設定 or `powerpagesitelanguageid` が null | `setup_contact_webapi.py` 実行 |
+| 400 | 9004010A | Invalid column name | `$select` に存在しないカラム名 | `EntityDefinitions` でカラム名確認 |
+| 403 | — | Forbidden | `Webapi/<table>/fields` にカラムが含まれていない | fields を `*` に設定、または具体カラム追加 |
+| 302 | — | Login redirect | 未認証 | SSO ログインさせる |
+
+---
+
+## powerpages.config.json（必須）
 
 ```json
 {
@@ -229,12 +533,6 @@ PP_SUBDOMAIN=your-site-subdomain
   "defaultLandingPage": "index.html"
 }
 ```
-
-| フィールド | 説明 |
-|-----------|------|
-| `siteName` | Power Pages サイトの表示名。初回 upload 時にこの名前でサイトが作成される |
-| `compiledPath` | ビルド出力ディレクトリ（`vite.config.ts` の `outDir` と一致させる） |
-| `defaultLandingPage` | ランディングページファイル名 |
 
 ---
 
@@ -259,7 +557,7 @@ export default defineConfig({
 |------|------|
 | `base: "./"` | Power Pages のパス構造に対応 |
 | `inlineDynamicImports: true` | コード分割するとロード順問題が発生 |
-| **Hash ルーティング必須** | History API モードは直接 URL アクセスで 404（サーバーリライト不可） |
+| **Hash ルーティング必須** | History API モードは直接 URL アクセスで 404 |
 | 静的 SPA のみ | SSR / ISR 非対応 |
 
 ### package.json scripts
@@ -294,72 +592,20 @@ npm run build
 pac pages upload-code-site --rootPath .
 ```
 
-これだけで:
-- Dataverse に Code Site レコードが作成される (Enhanced Data Model 2.0)
-- ビルド済みアセット (JS/CSS) が Web File としてアップロードされる
-- Home page / Header / Footer テンプレートが SPA 用に構成される
-- サイトは **Inactive** 状態で作成される
-
 ### 2-C: サイトのアクティブ化
 
-#### 方法 A: Power Pages ポータル（推奨）
+Power Pages ポータルの Inactive sites から **再アクティブ化** をクリック。
 
-1. [Power Pages](https://make.powerpages.microsoft.com/) に移動
-2. **Inactive sites** でサイトを見つける
-3. **再アクティブ化** をクリック
+### 2-D: Contact Web API 有効化（★初回必須）
 
-#### 方法 B: Power Platform API
-
-```python
-import requests
-from auth_helper import get_token
-
-ENV_ID = os.environ["ENV_ID"]
-token = get_token(scope="https://api.powerplatform.com/.default")
-headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-
-# Organization ID を取得
-dv_token = get_token()
-org = requests.get(
-    f"{DATAVERSE_URL}/api/data/v9.2/organizations?$select=organizationid",
-    headers={"Authorization": f"Bearer {dv_token}", "Accept": "application/json"},
-)
-org_id = org.json()["value"][0]["organizationid"]
-
-# websiteRecordId を取得 (powerpagesites テーブルから)
-sites = requests.get(
-    f"{DATAVERSE_URL}/api/data/v9.2/powerpagesites?$select=powerpagesiteid,name&$orderby=createdon desc&$top=1",
-    headers={"Authorization": f"Bearer {dv_token}", "Accept": "application/json"},
-)
-website_record_id = sites.json()["value"][0]["powerpagesiteid"]
-
-# プロビジョニング
-body = {
-    "dataverseOrganizationId": org_id,
-    "name": "MySite",
-    "selectedBaseLanguage": 1041,
-    "subdomain": "mysite01",
-    "templateName": "DefaultPortalTemplate",
-    "websiteRecordId": website_record_id,
-    "dataModel": "Enhanced",
-}
-r = requests.post(
-    f"https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites?api-version=2024-10-01",
-    headers=headers, json=body,
-)
-# 202 Accepted → プロビジョニング開始（3〜5分で完了）
+```bash
+py portal/scripts/setup_contact_webapi.py
 ```
 
-### 2-D: アクティブ化後の初回リスタート
+### 2-E: サイト再起動
 
-```python
-# PP API でサイト ID を取得してリスタート
-base = f"https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites"
-r = requests.get(f"{base}?api-version=2024-10-01", headers=headers)
-for s in r.json()["value"]:
-    if s["subdomain"] == "mysite01":
-        requests.post(f"{base}/{s['id']}/restart?api-version=2024-10-01", headers=headers)
-        break
+```bash
+py .github/skills/standard/scripts/_restart.py
 ```
 
 > アクティブ化後、URL にアクセスできるまで **60〜90秒** かかる。
@@ -372,195 +618,34 @@ for s in r.json()["value"]:
 cd portal
 npm run build
 pac pages upload-code-site --rootPath .
-# → サイト再起動（API or deploy.py）
-```
-
-または Python スクリプトで一括:
-
-```bash
-py portal/scripts/deploy.py
-```
-
-### deploy.py（推奨デプロイスクリプト）
-
-```python
-"""Power Pages Code Site: Build → Upload → Restart"""
-import os, sys, subprocess
-# ... (auth_helper / requests をインポート)
-
-def main():
-    # [1/3] Build
-    subprocess.run("npm run build", shell=True, cwd=PORTAL_DIR, check=True)
-
-    # [2/3] Upload
-    subprocess.run(f'pac pages upload-code-site --rootPath "{PORTAL_DIR}"',
-                   shell=True, check=True)
-
-    # [3/3] Restart
-    token = get_token(scope="https://api.powerplatform.com/.default")
-    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-    base = f"https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites"
-    r = requests.get(f"{base}?api-version=2024-10-01", headers=headers)
-    for s in r.json()["value"]:
-        if s["subdomain"] == SUBDOMAIN:
-            requests.post(f"{base}/{s['id']}/restart?api-version=2024-10-01", headers=headers)
-            break
-
-    print(f"DONE. URL: https://{SUBDOMAIN}.powerappsportals.com")
-    print("(60-90秒後にアクセス可能)")
+# → サイト再起動
+py ../.github/skills/standard/scripts/_restart.py
 ```
 
 ---
 
-## Step 4: 認証と承認
+## 既知の無害な警告
 
-> **SSO ログイン + プロフィール編集は「★ デフォルト実装」セクションのコードをそのまま使う。**
-> 以下は技術的な背景と追加カスタマイズ用のリファレンス。
+Power Pages ホスト (React 17) と SPA (React 19) の共存により以下が発生するが、**機能に影響なし**:
 
-### 認証方式の選択
-
-| 方式 | 推奨度 | 説明 |
-|------|--------|------|
-| `/SignIn` 直行 (SSO) | ★推奨 | `LoginButtonAuthenticationType` 設定済みなら自動でSSO。ログイン画面が表示されない |
-| PRIVATE サイト | ◎ | 全ページ認証必須。SPA ロード時点で認証済み。最もシンプル |
-| `/Account/Login/ExternalLogin` POST | ○ | 複数 IdP がある場合に特定プロバイダーを指定 |
-| `/Account/Login` リダイレクト | △ | クラシックログインページ。SPA 体験が途切れる |
-
-> `/SignIn` 方式で自動リダイレクトが動作するには **Site Settings の設定が必須**。
-> 上記「★ SSO 自動リダイレクト設定」セクションの `setup_auth.py` を初回デプロイ後に実行する。
-
-### 実装の要点
-
-- **Site Settings のバインド**: `adx_sitesettings` は `adx_websiteid@odata.bind` で最新の `adx_websites` レコードに紐付ける。`scripts/setup_auth.py` が upsert する。詳細は [`references/operations-and-pitfalls.md`](references/operations-and-pitfalls.md)。
-- **ユーザーコンテキスト**: `window.Microsoft.Dynamic365.Portal.User`（`use-auth.ts` が正規化）。
-- **Anti-Forgery Token**: 書き込みは `/_layout/tokenhtml` から `__RequestVerificationToken` を取得（`lib/dataverse.ts` が実装）。
-- **ID プロバイダー**: [Power Pages](https://make.powerpages.microsoft.com/) → サイト → セキュリティ → ID プロバイダー → Microsoft Entra ID を有効化（新規サイトはデフォルト設定済み）。
-- 認証フロー・コード詳細は [`references/authentication-reference.md`](references/authentication-reference.md)。
-
----
-
-## Step 5: Power Pages Web API
-
-```typescript
-// /_api/ を使用して Dataverse テーブルにアクセス
-const response = await fetch("/_api/geek_incidents", { credentials: "same-origin" });
-const data = await response.json();
-const records = data.value;
+```
+Unsatisfied version 16.14.0 from @microsoft/powerpages-host of shared singleton module react-dom (required ^17.0.0)
+Some icons were re-registered...
 ```
 
-`/_api/` が動くには **3 レイヤー**（① `adx_sitesettings` で API 公開 + ② `powerpagecomponent` type=18 のテーブル権限 + ③ N:N Web Role 紐付け）すべてが必要。`scripts/setup_permissions.py` の `TABLES` に公開テーブルを追加して実行すれば一括設定できる。
-
-> 管理者はテーブル権限をバイパスする。**必ず一般ユーザーでもテストする。**
-
-手順・スコープ値・OData クエリの書式・モデル別の注意点は [`references/dataverse-connection-reference.md`](references/dataverse-connection-reference.md) と [`references/enhanced-data-model-permissions.md`](references/enhanced-data-model-permissions.md) を参照。
+SPA は独自の React 19 バンドルで動作するため、ホスト側の React 17 とは干渉しない。
 
 ---
 
-## Step 6: ローカル開発
+## チェックリスト
 
-`vite.config.ts` にプロキシを追加して localhost から Web API を呼べるようにする:
-
-```typescript
-export default defineConfig({
-  server: {
-    proxy: {
-      "/_api": {
-        target: "https://mysite01.powerappsportals.com",
-        changeOrigin: true,
-        secure: true,
-      },
-    },
-  },
-});
-```
-
-> Bearer 認証には Entra AD v1 エンドポイント + ADAL.js を使用。MSAL は非互換。
-
----
-
-## 既存 Power Pages サイトとの違い
-
-| 項目 | SPA Code Site |
-|------|--------------|
-| ルーティング | クライアント側（Hash Router）。ハードリフレッシュはルートにフォールバック |
-| Liquid テンプレート | 非サポート。Web API + フレームワークテンプレートを使用 |
-| ページワークスペース | 非サポート。クライアントルーティングを使用 |
-| スタイル | フレームワークの CSS/Tailwind を使用 |
-| ローカライゼーション | クライアント側リソース読み込みで実装 |
-| SEO | 限定的（CSR のため） |
-
----
-
-## Power Platform API
-
-| 操作 | エンドポイント |
-|------|------|
-| 一覧取得 | `GET /powerpages/environments/{envId}/websites?api-version=2024-10-01` |
-| 作成/アクティブ化 | `POST /powerpages/environments/{envId}/websites?api-version=2024-10-01` |
-| 再起動 | `POST .../websites/{id}/restart?api-version=2024-10-01` |
-| 開始 | `POST .../websites/{id}/start?api-version=2024-10-01` |
-| 停止 | `POST .../websites/{id}/stop?api-version=2024-10-01` |
-
-**Base URL**: `https://api.powerplatform.com`
-**認証スコープ**: `https://api.powerplatform.com/.default`
-
----
-
-## トラブルシューティング
-
-| 問題 | 原因 | 対策 |
-|------|------|------|
-| upload-code-site で `.js blocked` | 環境で JS ブロック | `scripts/unblock_js.py`（管理センターで `js` を許可） |
-| サイト URL が 503 | 未プロビジョニング/未アクティブ | Inactive Sites でアクティブ化。60-90秒待つ |
-| Web API が 403 / 404 | 3 レイヤーのいずれか未設定 | `setup_permissions.py` 実行 |
-| `/SignIn` でログインフォーム表示 | `LoginButtonAuthenticationType` 未設定/値誤り | `setup_auth.py` 実行（Authority URL） |
-| 設定変更が反映されない | サイトキャッシュ | PP API で restart + ブラウザキャッシュクリア |
-
-> 症状別の完全な一覧（500 エラー、孤立レコード、コールドスタート、復旧不能時など）は [`references/operations-and-pitfalls.md`](references/operations-and-pitfalls.md)。
-
----
-
-## サブリファレンス
-
-| リファレンス | 内容 |
-|---|---|
-| [認証リファレンス](references/authentication-reference.md) | SSO フロー・use-auth/dataverse 実装・anti-forgery・Entra ID |
-| [Dataverse 接続リファレンス](references/dataverse-connection-reference.md) | `/_api/` を確実に通す 3 レイヤー設定・OData クエリ・モデル別注意点 |
-| [Enhanced Data Model テーブル権限](references/enhanced-data-model-permissions.md) | テーブル権限設定・自動化パターン |
-| [Web API 実装パターン](references/web-api-implementation.md) | `/_api/` クライアント実装・CSRF・403 対処 |
-| [運用上の落とし穴とリカバリ](references/operations-and-pitfalls.md) | 危険操作・検証済み教訓・リカバリ手順・トラブルシュート全集 |
-| [デザインシステム](references/design-system.md) | カラートークン・コンポーネントパターン |
-
-## 自動化スクリプト
-
-| スクリプト | 用途 |
-|---|---|
-| `scripts/setup_auth.py` | SSO 自動リダイレクト設定（Site Settings + restart） |
-| `scripts/setup_permissions.py` | Web API テーブル権限（Site Settings + powerpagecomponent + N:N リンク） |
-| `scripts/check_prerequisites.py` | 環境前提条件チェック |
-| `scripts/unblock_js.py` | JS ファイルブロック解除 |
-
-### 初回デプロイの完全手順（ゼロから動作するまで）
-
-```bash
-# 0. 前提: pac CLI ログイン済み + .env 設定済み
-pac auth list
-
-# 1. ビルド & アップロード（サイト作成）
-npm run build
-pac pages upload-code-site --rootPath .
-
-# 2. Power Pages ポータルでサイトをアクティブ化
-#    https://make.powerpages.microsoft.com/ → Inactive Sites → 再アクティブ化
-
-# 3. SSO 設定（ログイン画面スキップ → 直接 Entra ID）
-py scripts/setup_auth.py
-
-# 4. Web API 権限設定（/_api/ エンドポイント有効化）
-py scripts/setup_permissions.py
-
-# 5. 動作確認（60-90秒後にアクセス可能）
-#    https://{subdomain}.powerappsportals.com/
-#    → /SignIn にアクセス → 自動で Entra ID にリダイレクト → ログイン完了
-#    → /_api/contacts で JSON レスポンス確認
-```
+- [ ] `powerpages.config.json` が存在する
+- [ ] `vite.config.ts` で `base: "./"` + `inlineDynamicImports: true`
+- [ ] HashRouter を使用している
+- [ ] `api.ts` で `credentials: "same-origin"` を使用
+- [ ] `Webapi/<table>/enabled = true` が設定済み
+- [ ] `Webapi/<table>/fields` が設定済み（system table は `*`）
+- [ ] `powerpagecomponent` type=18 に `powerpagesitelanguageid` が設定済み
+- [ ] `powerpagecomponent_powerpagecomponent` N:N が Authenticated Users にリンク済み
+- [ ] `Webapi/error/innererror = true` が開発環境で有効
+- [ ] `.powerpages-site/site-settings/` に Webapi YAML が配置済み

--- a/portal/.powerpages-site/site-settings/Webapi-contact-enabled.sitesetting.yml
+++ b/portal/.powerpages-site/site-settings/Webapi-contact-enabled.sitesetting.yml
@@ -1,0 +1,4 @@
+id: b9c9f22b-635e-f111-a826-000d3a5ca3e9
+name: Webapi/contact/enabled
+source: 0
+value: "true"

--- a/portal/.powerpages-site/site-settings/Webapi-contact-fields.sitesetting.yml
+++ b/portal/.powerpages-site/site-settings/Webapi-contact-fields.sitesetting.yml
@@ -1,0 +1,4 @@
+id: bac9f22b-635e-f111-a826-000d3a5ca3e9
+name: Webapi/contact/fields
+source: 0
+value: "*"

--- a/portal/.powerpages-site/site-settings/Webapi-error-innererror.sitesetting.yml
+++ b/portal/.powerpages-site/site-settings/Webapi-error-innererror.sitesetting.yml
@@ -1,0 +1,4 @@
+id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+name: Webapi/error/innererror
+source: 0
+value: "true"

--- a/portal/.powerpages-site/site-settings/Webapi-geek_incident-enabled.sitesetting.yml
+++ b/portal/.powerpages-site/site-settings/Webapi-geek_incident-enabled.sitesetting.yml
@@ -1,0 +1,4 @@
+id: 8cd053a6-705e-f111-a826-000d3a5ca3e9
+name: Webapi/geek_incident/enabled
+source: 0
+value: "true"

--- a/portal/.powerpages-site/site-settings/Webapi-geek_incident-fields.sitesetting.yml
+++ b/portal/.powerpages-site/site-settings/Webapi-geek_incident-fields.sitesetting.yml
@@ -1,0 +1,4 @@
+id: 8dd053a6-705e-f111-a826-000d3a5ca3e9
+name: Webapi/geek_incident/fields
+source: 0
+value: "*"

--- a/portal/scripts/setup_contact_webapi.py
+++ b/portal/scripts/setup_contact_webapi.py
@@ -1,17 +1,21 @@
 """Power Pages: Contact テーブルの Web API 有効化 + テーブル権限設定
 
-修正版: レガシー mspp_entitypermission/mspp_webrole + powerpagecomponent N:N 両方を設定。
-Power Pages ランタイムは両方のテーブルを参照するため、両方必要。
+EDM 2.0 Code Site 対応版:
+- adx_sitesettings: Webapi/contact/enabled, Webapi/contact/fields
+- powerpagecomponent type=18: テーブル権限 (Self scope)
+  ※ powerpagesitelanguageid の設定が必須！（未設定だとランタイムが権限を認識しない）
+- powerpagecomponent_powerpagecomponent N:N: テーブル権限→Web ロール紐付け
+- Webapi/error/innererror: デバッグ用詳細エラー有効化
 
 重要ポイント:
-- mspp_websiteid は powerpagesites テーブルを参照する（adx_websites ではない）
-- powerpagecomponent_powerpagecomponent N:N でテーブル権限→Web ロールを紐付ける
-- mspp_entitypermission_webrole N:N もレガシー互換のため設定する
+- powerpagecomponent type=18 には powerpagesitelanguageid を必ず設定する
+- content JSON は {"entitylogicalname", "scope" (int), "read" (bool)} 形式
+- adx_sitesettings は adx_websites にバインドする
 
 Usage:
     py portal/scripts/setup_contact_webapi.py
 """
-import json, os, sys
+import json, os, re, sys
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PORTAL_DIR = os.path.dirname(SCRIPT_DIR)
@@ -27,11 +31,16 @@ ENV_ID = os.environ["ENV_ID"]
 SITE_NAME = "IncidentPortal02"
 SUBDOMAIN = "incidentportal02"
 
+# contact テーブル設定
+TABLE_LOGICAL = "contact"
+PERM_NAME = "contact - Self Read Write"
+SCOPE_SELF = 756150001
+FIELDS = "*"  # system table は * 推奨
 
-def get_headers():
-    token = auth_helper.get_token()
+
+def h():
     return {
-        "Authorization": f"Bearer {token}",
+        "Authorization": f"Bearer {auth_helper.get_token()}",
         "Content-Type": "application/json",
         "Accept": "application/json",
         "OData-MaxVersion": "4.0",
@@ -39,226 +48,179 @@ def get_headers():
     }
 
 
-def get_site_id():
-    """powerpagesites から Site ID を取得"""
-    h = get_headers()
-    r = requests.get(
-        f"{DV}/api/data/v9.2/powerpagesites"
-        f"?$select=powerpagesiteid,name"
-        f"&$filter=contains(name,'{SITE_NAME}')",
-        headers=h,
-    )
-    r.raise_for_status()
-    sites = r.json().get("value", [])
-    if not sites:
-        print(f"ERROR: {SITE_NAME} が powerpagesites に見つかりません")
-        sys.exit(1)
-    site_id = sites[0]["powerpagesiteid"]
-    print(f"  Site ID: {site_id}")
-    return site_id
+def api(path):
+    return f"{DV}/api/data/v9.2/{path}"
 
 
-def get_or_create_website(site_id):
-    """adx_websites から website ID を取得。なければ作成"""
-    h = get_headers()
-    r = requests.get(
-        f"{DV}/api/data/v9.2/adx_websites?$select=adx_websiteid,adx_name,adx_primarydomainname",
-        headers=h,
-    )
-    r.raise_for_status()
-    for site in r.json().get("value", []):
-        if SUBDOMAIN in (site.get("adx_primarydomainname") or ""):
-            ws_id = site["adx_websiteid"]
-            print(f"  Website ID (adx): {ws_id}")
-            return ws_id
-
-    print(f"  adx_website が存在しません。作成します...")
-    body = {
-        "adx_name": f"{SITE_NAME} - {SUBDOMAIN}",
-        "adx_primarydomainname": f"{SUBDOMAIN}.powerappsportals.com",
-        "adx_website_language": 1033,
-    }
-    r2 = requests.post(f"{DV}/api/data/v9.2/adx_websites", headers=h, json=body)
-    r2.raise_for_status()
-    ws_id = r2.headers.get("OData-EntityId", "").split("(")[-1].rstrip(")")
-    print(f"  [CREATE] adx_website: {ws_id}")
-    return ws_id
-
-
-def create_site_setting(name, value, website_id):
-    """adx_sitesettings にレコードを作成（既存なら更新）"""
-    h = get_headers()
-    r = requests.get(
-        f"{DV}/api/data/v9.2/adx_sitesettings?$select=adx_sitesettingid,adx_value"
-        f"&$filter=adx_name eq '{name}' and _adx_websiteid_value eq '{website_id}'",
-        headers=h,
-    )
-    r.raise_for_status()
-    existing = r.json().get("value", [])
-
-    if existing:
-        sid = existing[0]["adx_sitesettingid"]
-        if existing[0].get("adx_value") == value:
-            print(f"  [SKIP] {name} = {value}")
-            return
-        r2 = requests.patch(
-            f"{DV}/api/data/v9.2/adx_sitesettings({sid})",
-            headers=h,
-            json={"adx_value": value},
-        )
-        r2.raise_for_status()
-        print(f"  [UPDATE] {name} = {value}")
-    else:
-        body = {
-            "adx_name": name,
-            "adx_value": value,
-            "adx_websiteid@odata.bind": f"/adx_websites({website_id})",
-        }
-        r2 = requests.post(f"{DV}/api/data/v9.2/adx_sitesettings", headers=h, json=body)
-        r2.raise_for_status()
-        print(f"  [CREATE] {name} = {value}")
-
-
-def get_or_create_webrole(site_id):
-    """mspp_webrole (Authenticated Users) を取得/作成。
-    重要: mspp_websiteid は powerpagesites を参照する"""
-    h = get_headers()
-    r = requests.get(
-        f"{DV}/api/data/v9.2/mspp_webroles"
-        f"?$select=mspp_webroleid,mspp_name,mspp_authenticatedusersrole"
-        f"&$filter=_mspp_websiteid_value eq '{site_id}'",
-        headers=h,
-    )
-    r.raise_for_status()
-    roles = r.json().get("value", [])
-
-    for role in roles:
-        if role.get("mspp_authenticatedusersrole"):
-            print(f"  [SKIP] {role['mspp_name']}: {role['mspp_webroleid']}")
-            return role["mspp_webroleid"]
-
-    body = {
-        "mspp_name": "Authenticated Users",
-        "mspp_authenticatedusersrole": True,
-        "mspp_anonymoususersrole": False,
-        "mspp_websiteid@odata.bind": f"/powerpagesites({site_id})",
-    }
-    r2 = requests.post(f"{DV}/api/data/v9.2/mspp_webroles", headers=h, json=body)
-    r2.raise_for_status()
-    role_id = r2.headers.get("OData-EntityId", "").split("(")[-1].rstrip(")")
-    print(f"  [CREATE] mspp_webrole: {role_id}")
-    return role_id
-
-
-def get_or_create_entity_permission(site_id):
-    """mspp_entitypermission (Contact Self) を取得/作成"""
-    h = get_headers()
-    r = requests.get(
-        f"{DV}/api/data/v9.2/mspp_entitypermissions"
-        f"?$select=mspp_entitypermissionid,mspp_entitylogicalname"
-        f"&$filter=mspp_entitylogicalname eq 'contact' and _mspp_websiteid_value eq '{site_id}'",
-        headers=h,
-    )
-    r.raise_for_status()
-    existing = r.json().get("value", [])
-
-    if existing:
-        perm_id = existing[0]["mspp_entitypermissionid"]
-        print(f"  [SKIP] entity permission: {perm_id}")
-        return perm_id
-
-    body = {
-        "mspp_entitylogicalname": "contact",
-        "mspp_entityname": "Contact - Self",
-        "mspp_scope": 756150001,  # Self (Contact)
-        "mspp_read": True,
-        "mspp_write": True,
-        "mspp_create": False,
-        "mspp_delete": False,
-        "mspp_websiteid@odata.bind": f"/powerpagesites({site_id})",
-    }
-    r2 = requests.post(f"{DV}/api/data/v9.2/mspp_entitypermissions", headers=h, json=body)
-    r2.raise_for_status()
-    perm_id = r2.headers.get("OData-EntityId", "").split("(")[-1].rstrip(")")
-    print(f"  [CREATE] mspp_entitypermission: {perm_id}")
-    return perm_id
-
-
-def link_permission_to_role(perm_id, role_id):
-    """テーブル権限→Web ロール紐付け (mspp N:N + powerpagecomponent N:N)"""
-    h = get_headers()
-
-    # 1. Legacy mspp N:N
-    url = f"{DV}/api/data/v9.2/mspp_entitypermissions({perm_id})/mspp_entitypermission_webrole/$ref"
-    body = {"@odata.id": f"{DV}/api/data/v9.2/mspp_webroles({role_id})"}
-    r = requests.post(url, headers=h, json=body)
-    if r.status_code == 204:
-        print(f"  [LINK] mspp_entitypermission_webrole 完了")
-    elif r.status_code == 409 or "already exists" in r.text.lower():
-        print(f"  [SKIP] mspp N:N 既に紐付け済み")
-    else:
-        print(f"  [WARN] mspp N:N: {r.status_code} - {r.text[:200]}")
-
-    # 2. powerpagecomponent N:N (perm → role, 同じ ID で同期される)
-    url2 = f"{DV}/api/data/v9.2/powerpagecomponents({perm_id})/powerpagecomponent_powerpagecomponent/$ref"
-    body2 = {"@odata.id": f"{DV}/api/data/v9.2/powerpagecomponents({role_id})"}
-    r2 = requests.post(url2, headers=h, json=body2)
-    if r2.status_code == 204:
-        print(f"  [LINK] powerpagecomponent N:N 完了")
-    elif r2.status_code == 409 or "already exists" in r2.text.lower():
-        print(f"  [SKIP] powerpagecomponent N:N 既に紐付け済み")
-    else:
-        print(f"  [INFO] powerpagecomponent N:N: {r2.status_code}")
-
-    # 3. 既存 Authenticated Users (powerpagecomponent) にもリンク
-    r3 = requests.get(
-        f"{DV}/api/data/v9.2/powerpagecomponents"
-        f"?$select=powerpagecomponentid,name,content"
-        f"&$filter=powerpagecomponenttype eq 11",
-        headers=h,
-    )
-    for role in r3.json().get("value", []):
-        rid = role["powerpagecomponentid"]
-        if rid == role_id:
-            continue
-        content = role.get("content", "")
-        if "authenticatedusersrole" in content and '"authenticatedusersrole": true' in content.lower().replace(" ", ""):
-            body3 = {"@odata.id": f"{DV}/api/data/v9.2/powerpagecomponents({rid})"}
-            r4 = requests.post(url2, headers=h, json=body3)
-            if r4.status_code in (204, 409):
-                print(f"  [LINK] -> {role.get('name', 'unknown')} ({rid[:8]}...)")
+def log(msg):
+    print(msg, flush=True)
 
 
 def main():
-    print("=" * 60)
-    print("Contact テーブル Web API 有効化")
-    print("=" * 60)
+    log("=" * 60)
+    log("Contact テーブル Web API 有効化 (EDM 2.0)")
+    log("=" * 60)
 
-    # 1. サイト情報取得
-    print("\n[1/5] サイト情報取得")
-    site_id = get_site_id()
-    website_id = get_or_create_website(site_id)
+    # --- 1. サイト情報取得 ---
+    log("\n[1/6] サイト情報取得")
+    r = requests.get(api(f"powerpagesites?$filter=contains(name,'{SITE_NAME}')&$select=powerpagesiteid,name"), headers=h())
+    r.raise_for_status()
+    sites = r.json()["value"]
+    if not sites:
+        log(f"ERROR: {SITE_NAME} が powerpagesites に見つかりません")
+        sys.exit(1)
+    site_id = sites[0]["powerpagesiteid"]
+    log(f"  powerpagesite: {sites[0]['name']} ({site_id})")
 
-    # 2. Site Settings
-    print("\n[2/5] Site Settings (Web API 有効化)")
-    create_site_setting("Webapi/contact/enabled", "true", website_id)
-    create_site_setting("Webapi/contact/fields", "firstname,lastname,emailaddress1,telephone1,fullname", website_id)
+    # adx_website
+    r = requests.get(api(f"adx_websites?$filter=contains(adx_primarydomainname,'{SUBDOMAIN}')&$select=adx_websiteid,adx_name"), headers=h())
+    r.raise_for_status()
+    ws = r.json()["value"]
+    if not ws:
+        log("ERROR: adx_website not found")
+        sys.exit(1)
+    website_id = ws[0]["adx_websiteid"]
+    log(f"  adx_website: {ws[0]['adx_name']} ({website_id})")
 
-    # 3. mspp_webrole
-    print("\n[3/5] mspp_webrole (Authenticated Users)")
-    role_id = get_or_create_webrole(site_id)
+    # site language (CRITICAL: must be set on powerpagecomponent type=18)
+    r = requests.get(api(f"powerpagesitelanguages?$filter=_powerpagesiteid_value eq {site_id}&$select=powerpagesitelanguageid"), headers=h())
+    r.raise_for_status()
+    langs = r.json()["value"]
+    if not langs:
+        log("ERROR: powerpagesitelanguage not found - required for table permissions")
+        sys.exit(1)
+    lang_id = langs[0]["powerpagesitelanguageid"]
+    log(f"  language: {lang_id}")
 
-    # 4. mspp_entitypermission
-    print("\n[4/5] mspp_entitypermission (Contact Self)")
-    perm_id = get_or_create_entity_permission(site_id)
+    # --- 2. Site Settings ---
+    log("\n[2/6] Site Settings (Web API 有効化)")
+    for suffix, value in [("/enabled", "true"), ("/fields", FIELDS)]:
+        name = f"Webapi/{TABLE_LOGICAL}{suffix}"
+        r = requests.get(
+            api(f"adx_sitesettings?$filter=adx_name eq '{name}' and _adx_websiteid_value eq '{website_id}'&$select=adx_sitesettingid,adx_value"),
+            headers=h(),
+        )
+        existing = r.json().get("value", [])
+        if existing:
+            if existing[0].get("adx_value") == value:
+                log(f"  [SKIP] {name} = {value}")
+            else:
+                requests.patch(api(f"adx_sitesettings({existing[0]['adx_sitesettingid']})"), headers=h(), json={"adx_value": value})
+                log(f"  [UPDATE] {name} = {value}")
+        else:
+            body = {"adx_name": name, "adx_value": value, "adx_websiteid@odata.bind": f"/adx_websites({website_id})"}
+            requests.post(api("adx_sitesettings"), headers=h(), json=body)
+            log(f"  [CREATE] {name} = {value}")
 
-    # 5. 紐付け
-    print("\n[5/5] テーブル権限 → Web ロール 紐付け")
-    link_permission_to_role(perm_id, role_id)
+    # innererror for debugging
+    name = "Webapi/error/innererror"
+    r = requests.get(api(f"adx_sitesettings?$filter=adx_name eq '{name}' and _adx_websiteid_value eq '{website_id}'&$select=adx_sitesettingid"), headers=h())
+    if not r.json().get("value"):
+        requests.post(api("adx_sitesettings"), headers=h(), json={"adx_name": name, "adx_value": "true", "adx_websiteid@odata.bind": f"/adx_websites({website_id})"})
+        log(f"  [CREATE] {name} = true")
+    else:
+        log(f"  [SKIP] {name}")
 
-    print("\n" + "=" * 60)
-    print("DONE. pac pages upload-code-site --rootPath . でキャッシュ更新してください。")
-    print("=" * 60)
+    # --- 3. powerpagecomponent type=18 (テーブル権限) ---
+    log("\n[3/6] Table Permission (powerpagecomponent type=18, Self scope)")
+    content = json.dumps({
+        "entitylogicalname": TABLE_LOGICAL,
+        "entityname": PERM_NAME,
+        "scope": SCOPE_SELF,
+        "read": True,
+        "write": True,
+        "create": False,
+        "delete": False,
+        "append": False,
+        "appendto": False,
+    })
+
+    # 既存確認 (contact のものを探す)
+    r = requests.get(
+        api(f"powerpagecomponents?$filter=powerpagecomponenttype eq 18 and _powerpagesiteid_value eq {site_id}&$select=powerpagecomponentid,name,content"),
+        headers=h(),
+    )
+    existing_perm = None
+    for p in r.json().get("value", []):
+        c = p.get("content", "")
+        if '"contact"' in c and ("entitylogicalname" in c or "mspp_entityname" in c):
+            existing_perm = p
+            break
+
+    if existing_perm:
+        perm_id = existing_perm["powerpagecomponentid"]
+        patch_body = {
+            "content": content,
+            "name": PERM_NAME,
+            "powerpagesitelanguageid@odata.bind": f"/powerpagesitelanguages({lang_id})",
+        }
+        r = requests.patch(api(f"powerpagecomponents({perm_id})"), headers=h(), json=patch_body)
+        log(f"  [UPDATE] {PERM_NAME} ({perm_id}) - {r.status_code}")
+    else:
+        body = {
+            "powerpagecomponenttype": 18,
+            "name": PERM_NAME,
+            "content": content,
+            "powerpagesiteid@odata.bind": f"/powerpagesites({site_id})",
+            "powerpagesitelanguageid@odata.bind": f"/powerpagesitelanguages({lang_id})",
+        }
+        r = requests.post(api("powerpagecomponents"), headers=h(), json=body)
+        if r.status_code == 204:
+            loc = r.headers.get("OData-EntityId", "")
+            m = re.search(r"powerpagecomponents\(([0-9a-fA-F-]+)\)", loc)
+            perm_id = m.group(1) if m else None
+        else:
+            perm_id = r.json().get("powerpagecomponentid") if r.status_code in (200, 201) else None
+        log(f"  [CREATE] {PERM_NAME} ({perm_id}) - {r.status_code}")
+        if r.status_code not in (200, 201, 204):
+            log(f"  ERROR: {r.text[:300]}")
+            sys.exit(1)
+
+    # --- 4. Authenticated Users (type=11) 取得 ---
+    log("\n[4/6] Authenticated Users (powerpagecomponent type=11)")
+    r = requests.get(
+        api(f"powerpagecomponents?$filter=powerpagecomponenttype eq 11 and _powerpagesiteid_value eq {site_id}&$select=powerpagecomponentid,name"),
+        headers=h(),
+    )
+    roles = r.json().get("value", [])
+    auth_role = next((x for x in roles if "authenticated" in x.get("name", "").lower()), None)
+    if not auth_role:
+        log("  ERROR: Authenticated Users ロールが見つかりません")
+        sys.exit(1)
+    role_id = auth_role["powerpagecomponentid"]
+    log(f"  Role: {auth_role['name']} ({role_id})")
+
+    # --- 5. N:N リンク ---
+    log("\n[5/6] テーブル権限 → Web ロール N:N リンク")
+    lr = requests.get(api(f"powerpagecomponents({perm_id})/powerpagecomponent_powerpagecomponent?$select=powerpagecomponentid"), headers=h())
+    linked = [x["powerpagecomponentid"] for x in lr.json().get("value", [])] if lr.status_code == 200 else []
+
+    if role_id in linked:
+        log(f"  [SKIP] Already linked to {auth_role['name']}")
+    else:
+        rr = requests.post(
+            api(f"powerpagecomponents({perm_id})/powerpagecomponent_powerpagecomponent/$ref"),
+            headers=h(),
+            json={"@odata.id": api(f"powerpagecomponents({role_id})")},
+        )
+        log(f"  [LINK] {rr.status_code}")
+
+    # --- 6. サイト再起動 ---
+    log("\n[6/6] サイト再起動")
+    try:
+        from pathlib import Path
+        restart_script = Path(ROOT_DIR) / ".github" / "skills" / "standard" / "scripts" / "_restart.py"
+        if restart_script.exists():
+            import subprocess
+            subprocess.run([sys.executable, str(restart_script)], cwd=str(restart_script.parent), check=True)
+        else:
+            log("  [SKIP] _restart.py not found, restart manually")
+    except Exception as e:
+        log(f"  [WARN] restart failed: {e}")
+
+    log("\n" + "=" * 60)
+    log("DONE. 60-90秒後にプロフィールページをテストしてください。")
+    log("=" * 60)
 
 
 if __name__ == "__main__":

--- a/portal/src/lib/api.ts
+++ b/portal/src/lib/api.ts
@@ -1,112 +1,168 @@
-// ── Power Pages Web API クライアント ──
+/**
+ * Power Pages Web API (`/_api/`) クライアント
+ *
+ * 認証: ブラウザのセッション Cookie（same-origin）。Bearer トークン不要。
+ * 書き込み (POST/PATCH/DELETE): anti-forgery token が必須。
+ */
 const BASE = "/_api";
 
-const REDIRECT_KEY = "__pp_login_redirect_ts";
-function shouldRedirectToLogin(): boolean {
-  const last = sessionStorage.getItem(REDIRECT_KEY);
-  if (last && Date.now() - Number(last) < 10000) return false;
-  sessionStorage.setItem(REDIRECT_KEY, String(Date.now()));
-  return true;
+const IS_DEV =
+  typeof window !== "undefined" &&
+  (window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1");
+
+export interface ODataCollection<T> {
+  value: T[];
+  "@odata.count"?: number;
 }
 
-export async function apiFetch<T>(
-  path: string,
-  init?: RequestInit,
-): Promise<T> {
-  const url = `${BASE}/${path}`;
-  console.log(`[API] ${init?.method ?? "GET"} ${url}`);
+export class ApiAuthError extends Error {
+  constructor(public status: number) {
+    super(`Authentication required (${status})`);
+    this.name = "ApiAuthError";
+  }
+}
 
-  const res = await fetch(url, {
-    ...init,
-    redirect: "manual",
-    credentials: "same-origin",
-    headers: {
-      Accept: "application/json",
-      "OData-MaxVersion": "4.0",
-      "OData-Version": "4.0",
-      ...init?.headers,
-    },
-  });
+/** anti-forgery token のキャッシュ */
+let cachedToken: string | null = null;
 
-  if (res.type === "opaqueredirect" || res.status === 0) {
-    console.warn("[API] Session expired (opaqueredirect)");
-    if (shouldRedirectToLogin()) {
-      window.location.href = "/Account/Login";
-      return new Promise(() => {});
-    }
-    throw new Error("認証が必要です。ページを再読み込みしてください。");
+async function getRequestVerificationToken(): Promise<string> {
+  if (IS_DEV) return "dev-token";
+  if (cachedToken) return cachedToken;
+
+  const input = document.querySelector<HTMLInputElement>(
+    'input[name="__RequestVerificationToken"]',
+  );
+  if (input?.value) {
+    cachedToken = input.value;
+    return cachedToken;
   }
 
+  try {
+    const res = await fetch("/_layout/tokenhtml", { credentials: "same-origin" });
+    const html = await res.text();
+    const match = html.match(/value="([^"]+)"/);
+    if (match?.[1]) {
+      cachedToken = match[1];
+      return cachedToken;
+    }
+  } catch { /* fall through */ }
+  return "";
+}
+
+function baseHeaders(): Record<string, string> {
+  return {
+    Accept: "application/json",
+    "OData-MaxVersion": "4.0",
+    "OData-Version": "4.0",
+    Prefer: 'odata.include-annotations="*"',
+  };
+}
+
+async function handleResponse<T>(res: Response, path: string): Promise<T> {
+  if (res.redirected && res.url.includes("/Account/Login")) {
+    throw new ApiAuthError(302);
+  }
   if (res.status === 401 || res.status === 403) {
-    const body = await res.text();
-    console.error(`[API] ${res.status}:`, body);
-    if (shouldRedirectToLogin()) {
-      window.location.href = "/Account/Login";
-      return new Promise(() => {});
-    }
-    throw new Error(`アクセスが拒否されました (${res.status})`);
+    throw new ApiAuthError(res.status);
   }
-
   if (!res.ok) {
     const body = await res.text();
-    console.error(`[API] ${res.status}:`, body);
+    console.error(`[API] ${res.status} (${path}):`, body);
     throw new Error(`API ${res.status}: ${body}`);
   }
-
-  console.log(`[API] ✓ ${res.status} ${url}`);
-  return res.status === 204 ? (undefined as T) : res.json();
+  if (res.status === 204) return undefined as T;
+  return res.json();
 }
 
-// ── インシデント型定義 ──
+export async function apiGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${BASE}/${path}`, {
+    method: "GET",
+    credentials: "same-origin",
+    headers: baseHeaders(),
+  });
+  return handleResponse<T>(res, path);
+}
+
+export async function apiPost<T>(path: string, body: unknown): Promise<T> {
+  const token = await getRequestVerificationToken();
+  const res = await fetch(`${BASE}/${path}`, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {
+      ...baseHeaders(),
+      "Content-Type": "application/json",
+      __RequestVerificationToken: token,
+    },
+    body: JSON.stringify(body),
+  });
+  return handleResponse<T>(res, path);
+}
+
+export async function apiPatch(path: string, body: unknown): Promise<void> {
+  const token = await getRequestVerificationToken();
+  const res = await fetch(`${BASE}/${path}`, {
+    method: "PATCH",
+    credentials: "same-origin",
+    headers: {
+      ...baseHeaders(),
+      "Content-Type": "application/json",
+      __RequestVerificationToken: token,
+    },
+    body: JSON.stringify(body),
+  });
+  await handleResponse<void>(res, path);
+}
+
+// ── インシデント型定義（実テーブルカラム名に準拠）──
 export interface Incident {
   geek_incidentid: string;
-  geek_title: string;
+  geek_name: string;
   geek_description?: string;
   geek_status?: number;
   geek_priority?: number;
-  geek_assettype?: number;
-  geek_reportedby?: string;
-  geek_assignedto?: string;
-  geek_resolvedon?: string;
+  geek_category?: number;
   geek_resolution?: string;
+  geek_resolvedon?: string;
+  geek_ticketnumber?: string;
   createdon?: string;
   modifiedon?: string;
-  _createdby_value?: string;
+  // lookup formatted values (Prefer: odata.include-annotations)
+  "_geek_inquirerid_value@OData.Community.Display.V1.FormattedValue"?: string;
+  "_geek_assignedtoid_value@OData.Community.Display.V1.FormattedValue"?: string;
+  _geek_inquirerid_value?: string;
+  _geek_assignedtoid_value?: string;
+  [key: string]: unknown;
 }
 
 export interface IncidentCreate {
-  geek_title: string;
+  geek_name: string;
   geek_description?: string;
   geek_status?: number;
   geek_priority?: number;
-  geek_assettype?: number;
-  geek_reportedby?: string;
-}
-
-interface ODataResponse<T> {
-  value: T[];
+  geek_category?: number;
+  "geek_inquirerid@odata.bind"?: string;
 }
 
 // ── CRUD ──
+const INCIDENT_SELECT =
+  "geek_incidentid,geek_name,geek_description,geek_status,geek_priority,geek_category,geek_ticketnumber,geek_resolution,geek_resolvedon,_geek_inquirerid_value,_geek_assignedtoid_value,createdon";
+
 export async function getIncidents(): Promise<Incident[]> {
-  const data = await apiFetch<ODataResponse<Incident>>(
-    "geek_incidents?$select=geek_incidentid,geek_title,geek_description,geek_status,geek_priority,geek_assettype,geek_reportedby,geek_assignedto,geek_resolvedon,geek_resolution,createdon&$orderby=createdon desc",
+  const data = await apiGet<ODataCollection<Incident>>(
+    `geek_incidents?$select=${INCIDENT_SELECT}&$orderby=createdon desc`,
   );
   return data.value;
 }
 
 export async function getIncident(id: string): Promise<Incident> {
-  return apiFetch<Incident>(
-    `geek_incidents(${id})?$select=geek_incidentid,geek_title,geek_description,geek_status,geek_priority,geek_assettype,geek_reportedby,geek_assignedto,geek_resolvedon,geek_resolution,createdon,modifiedon`,
+  return apiGet<Incident>(
+    `geek_incidents(${id})?$select=${INCIDENT_SELECT},modifiedon`,
   );
 }
 
 export async function createIncident(data: IncidentCreate): Promise<void> {
-  await apiFetch<void>("geek_incidents", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
+  await apiPost<void>("geek_incidents", data);
 }
 
 // ── ラベル定義 ──
@@ -138,7 +194,7 @@ export const priorityStyles: Record<number, string> = {
   100000003: "bg-red-500/10 text-red-600 dark:text-red-400",
 };
 
-export const assetTypeLabels: Record<number, string> = {
+export const categoryLabels: Record<number, string> = {
   100000000: "PC",
   100000001: "サーバー",
   100000002: "プリンター",

--- a/portal/src/pages/profile.tsx
+++ b/portal/src/pages/profile.tsx
@@ -1,0 +1,194 @@
+import { useState, useEffect } from "react";
+import { useAuth } from "@/hooks/use-auth";
+import { Button } from "@/components/ui/button";
+import { Save, Loader2, User } from "lucide-react";
+import { apiGet, apiPatch, ApiAuthError } from "@/lib/api";
+
+interface ContactProfile {
+  firstname: string;
+  lastname: string;
+  emailaddress1: string;
+  telephone1: string;
+}
+
+export default function ProfilePage() {
+  const { user } = useAuth();
+  const [profile, setProfile] = useState<ContactProfile>({
+    firstname: "",
+    lastname: "",
+    emailaddress1: "",
+    telephone1: "",
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!user?.contactId) return;
+    fetchProfile();
+  }, [user?.contactId]);
+
+  async function fetchProfile() {
+    const path = `contacts(${user!.contactId})?$select=firstname,lastname,emailaddress1,telephone1`;
+    try {
+      const data = await apiGet<ContactProfile>(path);
+      setProfile({
+        firstname: data.firstname || "",
+        lastname: data.lastname || "",
+        emailaddress1: data.emailaddress1 || "",
+        telephone1: data.telephone1 || "",
+      });
+    } catch (e) {
+      console.error("[Profile] fetch failed:", e);
+      if (e instanceof ApiAuthError) {
+        setMessage({
+          type: "error",
+          text: `プロフィール取得に失敗しました（認証エラー ${e.status}）。再ログインしてください。\nGET /_api/${path}`,
+        });
+      } else {
+        setMessage({
+          type: "error",
+          text: `プロフィール取得に失敗しました。\nGET /_api/${path}\n${e instanceof Error ? e.message : String(e)}`,
+        });
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setMessage(null);
+
+    const path = `contacts(${user!.contactId})`;
+    try {
+      await apiPatch(path, {
+        firstname: profile.firstname,
+        lastname: profile.lastname,
+        telephone1: profile.telephone1,
+      });
+      setMessage({ type: "success", text: "プロフィールを更新しました" });
+    } catch (e) {
+      console.error("[Profile] save failed:", e);
+      if (e instanceof ApiAuthError) {
+        setMessage({
+          type: "error",
+          text: `更新に失敗しました（認証エラー ${e.status}）。再ログインしてください。\nPATCH /_api/${path}`,
+        });
+      } else {
+        setMessage({
+          type: "error",
+          text: `更新に失敗しました。\nPATCH /_api/${path}\n${e instanceof Error ? e.message : String(e)}`,
+        });
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[300px]">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-lg mx-auto py-8 px-4">
+      <div className="flex items-center gap-3 mb-6">
+        <div className="h-12 w-12 rounded-full bg-primary/10 flex items-center justify-center">
+          <User className="h-6 w-6 text-primary" />
+        </div>
+        <div>
+          <h1 className="text-xl font-bold text-foreground">
+            プロフィール編集
+          </h1>
+          <p className="text-sm text-muted-foreground">{user?.email}</p>
+        </div>
+      </div>
+
+      {message && (
+        <div
+          className={`mb-4 p-3 rounded-lg text-sm whitespace-pre-line break-words ${
+            message.type === "success"
+              ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300"
+              : "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300"
+          }`}
+        >
+          {message.text}
+        </div>
+      )}
+
+      <form onSubmit={handleSave} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-1">
+            姓
+          </label>
+          <input
+            type="text"
+            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+            value={profile.lastname}
+            onChange={(e) =>
+              setProfile({ ...profile, lastname: e.target.value })
+            }
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-1">
+            名
+          </label>
+          <input
+            type="text"
+            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+            value={profile.firstname}
+            onChange={(e) =>
+              setProfile({ ...profile, firstname: e.target.value })
+            }
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-1">
+            メールアドレス
+          </label>
+          <input
+            type="email"
+            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 cursor-not-allowed opacity-60"
+            value={profile.emailaddress1}
+            disabled
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            メールアドレスは変更できません
+          </p>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-1">
+            電話番号
+          </label>
+          <input
+            type="tel"
+            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+            value={profile.telephone1}
+            onChange={(e) =>
+              setProfile({ ...profile, telephone1: e.target.value })
+            }
+            placeholder="090-1234-5678"
+          />
+        </div>
+
+        <Button type="submit" disabled={saving} className="w-full gap-2">
+          {saving ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Save className="h-4 w-4" />
+          )}
+          保存
+        </Button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Contact テーブル Web API 有効化で発生した 404 (9004010C) のデバッグ過程で得た教訓をすべてスキルに反映。

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `.github/skills/power-pages/SKILL.md` | **完全刷新** — 以下の全教訓を反映 |
| `portal/scripts/setup_contact_webapi.py` | EDM 2.0 正対応版に書き換え |
| `portal/src/lib/api.ts` | 共有 Web API クライアント (credentials: same-origin) |
| `portal/src/pages/profile.tsx` | api.ts 使用版 (詳細エラー表示) |
| `portal/.powerpages-site/site-settings/*.yml` | Webapi 設定 YAML 永続化 (5ファイル新規) |

## 反映した教訓

### Critical (404 の根本原因)
1. **powerpagecomponent type=18 には powerpagesitelanguageid が必須** — 未設定だとランタイムが権限を無視して 404 を返す
2. **Content JSON の正しい形式**: `{entitylogicalname, scope (int), read (bool)}` — `mspp_` プレフィックスの文字列値は古い形式

### 重要な修正
3. **`credentials: "same-origin"`** — `include` ではない (Power Pages は same-site Cookie 認証)
4. **共有 api.ts クライアント** — anti-forgery token キャッシュ、handleResponse で redirect 検出 + 詳細エラーログ
5. **`Webapi/error/innererror = true`** — デバッグ時に内部エラー情報を取得するための Site Setting
6. **エラーコード 9004010C** = Resource not found for the segment = テーブル権限未設定
7. **.powerpages-site/site-settings/ YAML** — upload-code-site で自動同期される永続化パターン
8. **System table (contact) は fields=`*`** — 明示リストだと抜け漏れが発生しやすい
9. **Profile ページ**: apiGet/apiPatch + 詳細エラーメッセージ (path + status + body 表示)
10. **Lookup カラム**: `_<field>_value` で読み取り、`field@odata.bind` で書き込み

## 旧 SKILL.md からの修正箇所
- `credentials: include` → `same-origin` に修正
- profile.tsx: 生 fetch → api.ts 共有クライアント使用
- テーブル権限: mspp_entitypermission + mspp_webrole → powerpagecomponent type=18 + type=11 (EDM 2.0)
- `.powerpages-site/ は手動編集しない` → site-settings YAML は手動追加して永続化可能
- エラーコード早見表・チェックリスト追加
