### PR TITLE
feat(copilot-studio): 外部公開WebサイトUIデザインテンプレートを標準化

### DIFF
--- a/.github/skills/copilot-studio/SKILL.md
+++ b/.github/skills/copilot-studio/SKILL.md
@@ -37,6 +37,13 @@ triggers:
   - "認証なし"
   - "静的Webサイト"
   - "Azure Storage"
+  - "WebChat SDK"
+  - "DirectLine"
+  - "トークンエンドポイント"
+  - "ネイティブアプリ"
+  - "styleOptions"
+  - "カルーセル"
+  - "プロンプトチップス"
 ---
 
 # Copilot Studio エージェント構築スキル
@@ -49,7 +56,8 @@ Copilot Studio エージェントを **生成オーケストレーション（Ge
 | リファレンス | 内容 |
 |---|---|
 | [構築リファレンス](references/build-reference.md) | 構築手順の詳細・Instructions テンプレート・スクリプトコード |
-| [外部公開 Web 埋め込み](references/external-web-embed.md) | 認証なしエージェントを外部 Web サイトに iframe で公開するパターン |
+| [外部公開 Web 埋め込み](references/external-web-embed.md) | 認証なしエージェントを外部 Web サイトに iframe で公開するパターン（簡易版） |
+| [外部公開 WebChat SDK](references/webchat-sdk-embed.md) | WebChat SDK で外部公開する推奨パターン（UIカスタマイズ・メッセージ送信対応） |
 | [外部トリガー](references/trigger.md) | メール受信・Teams メッセージ・スケジュール等のトリガー追加 |
 | [トリガーパターン](references/trigger-patterns.md) | トリガーの設定パターン集 |
 | [トリガートラブルシューティング](references/trigger-troubleshooting.md) | トリガー関連のトラブルシューティング |

--- a/.github/skills/copilot-studio/SKILL.md
+++ b/.github/skills/copilot-studio/SKILL.md
@@ -44,6 +44,13 @@ triggers:
   - "styleOptions"
   - "カルーセル"
   - "プロンプトチップス"
+  - "デザインテンプレート"
+  - "左パネル"
+  - "カテゴリ別カード"
+  - "AI タイピング"
+  - "グラデーション枠"
+  - "外部Webデザイン"
+  - "ランディングページ"
 ---
 
 # Copilot Studio エージェント構築スキル
@@ -58,12 +65,24 @@ Copilot Studio エージェントを **生成オーケストレーション（Ge
 | [構築リファレンス](references/build-reference.md) | 構築手順の詳細・Instructions テンプレート・スクリプトコード |
 | [外部公開 Web 埋め込み](references/external-web-embed.md) | 認証なしエージェントを外部 Web サイトに iframe で公開するパターン（簡易版） |
 | [外部公開 WebChat SDK](references/webchat-sdk-embed.md) | WebChat SDK で外部公開する推奨パターン（UIカスタマイズ・メッセージ送信対応） |
+| [**外部公開デザインテンプレート**](references/webchat-sdk-design-template.md) | **標準 UI デザイン**：左パネル（カテゴリ別カード＋プロンプトチップス）＋ 右 WebChat パネル（グラデーション枠・AI タイピング Tips） |
 | [外部トリガー](references/trigger.md) | メール受信・Teams メッセージ・スケジュール等のトリガー追加 |
 | [トリガーパターン](references/trigger-patterns.md) | トリガーの設定パターン集 |
 | [トリガートラブルシューティング](references/trigger-troubleshooting.md) | トリガー関連のトラブルシューティング |
 | [ニュース配信エージェント](references/market-research-report.md) | RSS + Web検索 + Work IQ MCP によるニュース収集・配信エージェント構築 |
 | [ニュース配信デプロイガイド](references/market-research-deployment-guide.md) | ニュース配信エージェントのデプロイ手順 |
 | [ニュース配信メールテンプレート](references/market-research-email-template.md) | ニュース配信メールの HTML テンプレート |
+
+## 外部公開 Web サイト開発フロー（必須）
+
+**エージェントを外部顧客向け Web サイトに公開する場合、[デザインテンプレート](references/webchat-sdk-design-template.md) を標準として提案する。**
+
+フロー:
+1. デザインテンプレートのレイアウト構成 + カテゴリ/プロンプト案をユーザーに提示
+2. ユーザー承認
+3. `website/index.html` をテンプレートベースで実装
+4. カテゴリ・プロンプト・Tips・カラーを案件に合わせて調整
+5. `py scripts/deploy_website.py` で Azure Storage にデプロイ
 
 ## 前提: 設計フェーズ完了後に構築に入る（必須）
 

--- a/.github/skills/copilot-studio/references/webchat-sdk-design-template.md
+++ b/.github/skills/copilot-studio/references/webchat-sdk-design-template.md
@@ -1,0 +1,517 @@
+# WebChat SDK 外部公開デザインテンプレート（標準）
+
+外部顧客向け AI エージェント Web サイトの **標準デザインテンプレート**。
+左パネルにカテゴリ別プロンプトカード、右パネルに美しい WebChat UI を配置するレイアウトパターン。
+
+> このテンプレートはユーザーに**設計として提案**し、承認後に実装を進める。
+
+## 設計提案テンプレート（ユーザーに提示）
+
+```
+## 外部公開 Web サイト 設計案
+
+### レイアウト構成
+
+| セクション | 内容 |
+|---|---|
+| ヘッダー | ブランドロゴ + AI バッジ + 統計値 |
+| ヒーロー + 特徴カード | キャッチコピー + 3 カラム特徴紹介 |
+| ワークスペース（左） | カテゴリ別カードグリッド + プロンプトチップス（sticky） |
+| ワークスペース（右） | WebChat パネル（グラデーション枠 + AI タイピングインジケーター） |
+| フッター | 著作権表示 |
+| モーダル | 画像拡大 + お気に入り登録 |
+
+### デザイン方針
+
+- ダーク UI（背景 #050a18）+ AI グラデーション（emerald → cyan → indigo → purple）
+- Inter + Noto Sans JP フォント
+- グラスモーフィズム（backdrop-filter: blur）
+- 角丸 20px / カード 14px
+- ホバーアニメーション（translateY + glow）
+
+### 左パネル（500px 固定幅・sticky）
+
+- カテゴリラベル（絵文字 + テキスト、ピル型バッジ）
+- 3 カラムカードグリッド（画像 + ラベル + メタ情報）
+- カードクリック → WebChat にプロンプト送信
+- カテゴリごとプロンプトチップス（ピル型ボタン）
+- チップスクリック → WebChat にプロンプト送信
+
+### 右パネル（WebChat）
+
+- AI グラデーション枠線（::before pseudo-element）
+- ダークヘッダー（アバター + エージェント名 + オンラインステータス）
+- AI タイピングインジケーター（3 ドットアニメーション + ローテーションTips）
+- 白背景チャットエリア
+- 丸角送信ボックス（24px radius）
+- 画像クリック → モーダル拡大表示
+
+### カテゴリ・プロンプト案
+
+| カテゴリ | プロンプト例 |
+|---|---|
+| {カテゴリ1} | {プロンプト1-1}, {プロンプト1-2}, {プロンプト1-3} |
+| {カテゴリ2} | {プロンプト2-1}, {プロンプト2-2}, {プロンプト2-3} |
+| {カテゴリ3} | {プロンプト3-1}, {プロンプト3-2}, {プロンプト3-3} |
+```
+
+## UI アーキテクチャ
+
+```
+┌──────────────────────────────────────────────────┐
+│ [Header] Brand + AI Badge + Stats                │
+├──────────────────────────────────────────────────┤
+│ [Hero] Gradient Title + Description              │
+│ [Features] 3-col feature cards                   │
+├─────────────────────┬────────────────────────────┤
+│ [Left Panel]        │ [Right Panel]              │
+│ (500px, sticky)     │ (1fr, flex)                │
+│                     │                            │
+│ ┌─Category Label─┐  │ ┌──Chat Container───────┐  │
+│ │ Card Card Card │  │ │ ╔═ Gradient Border ═╗ │  │
+│ │ Card Card Card │  │ │ ║ Dark Header      ║ │  │
+│ └────────────────┘  │ │ ║ Avatar + Status  ║ │  │
+│ [Prompt] [Prompt]   │ │ ╠═══════════════════╣ │  │
+│                     │ │ ║ AI Typing Tips   ║ │  │
+│ ┌─Category Label─┐  │ │ ╠═══════════════════╣ │  │
+│ │ Card Card Card │  │ │ ║                  ║ │  │
+│ └────────────────┘  │ │ ║   Chat Body      ║ │  │
+│ [Prompt] [Prompt]   │ │ ║   (WebChat SDK)  ║ │  │
+│                     │ │ ║                  ║ │  │
+│                     │ │ ╠═══════════════════╣ │  │
+│                     │ │ ║ Rounded SendBox  ║ │  │
+│                     │ │ ╚═════════════════════╝ │  │
+│                     │ └────────────────────────┘  │
+├─────────────────────┴────────────────────────────┤
+│ [Footer]                                         │
+└──────────────────────────────────────────────────┘
+```
+
+## CSS デザインシステム
+
+### カラーパレット（CSS Variables）
+
+```css
+:root {
+    /* プライマリ: サービスのブランドカラーに変更 */
+    --color-primary: #10b981;
+    /* 背景: ダークネイビー */
+    --color-bg: #050a18;
+    --color-surface: rgba(15, 23, 42, 0.6);
+    --color-surface-solid: #0f172a;
+    --color-surface-hover: #1e293b;
+    /* テキスト */
+    --color-text: #f1f5f9;
+    --color-text-muted: #94a3b8;
+    /* ボーダー */
+    --color-border: rgba(99, 102, 241, 0.15);
+    --color-accent: #818cf8;
+    /* AI グラデーション（メイン） */
+    --gradient-ai: linear-gradient(135deg, #10b981, #06b6d4, #6366f1, #a78bfa);
+    --gradient-ai-subtle: linear-gradient(135deg, rgba(16,185,129,0.08), rgba(99,102,241,0.08));
+    /* 角丸 */
+    --radius: 20px;
+    --radius-lg: 28px;
+    /* グロー */
+    --shadow-glow: 0 0 80px -20px rgba(99,102,241,0.3), 0 0 60px -30px rgba(16,185,129,0.2);
+}
+```
+
+### レイアウト（Grid Split）
+
+```css
+.workspace {
+    display: grid;
+    grid-template-columns: 500px 1fr;
+    gap: 1.5rem;
+    align-items: start;
+}
+
+.left-panel {
+    position: sticky;
+    top: 76px;
+    max-height: calc(100vh - 92px);
+    overflow-y: auto;
+    padding-right: 0.75rem;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(99,102,241,0.2) transparent;
+}
+```
+
+### カードグリッド
+
+```css
+.plan-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.6rem;
+}
+
+.plan-card {
+    background: var(--color-surface);
+    backdrop-filter: blur(12px);
+    border: 1px solid var(--color-border);
+    border-radius: 14px;
+    overflow: hidden;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.2,0.8,0.2,1);
+}
+
+.plan-card:hover {
+    transform: translateY(-3px) scale(1.02);
+    border-color: rgba(99,102,241,0.4);
+    box-shadow: 0 8px 24px rgba(99,102,241,0.12);
+}
+```
+
+### チャットコンテナ（グラデーション枠）
+
+```css
+.chat-container {
+    background: #ffffff;
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-glow);
+    position: relative;
+}
+
+/* AI グラデーション枠線 */
+.chat-container::before {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    border-radius: var(--radius-lg);
+    padding: 1.5px;
+    background: var(--gradient-ai);
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    pointer-events: none;
+    opacity: 0.4;
+    z-index: 2;
+}
+
+.chat-container:hover {
+    box-shadow: 0 0 100px -20px rgba(99,102,241,0.35),
+                0 0 80px -30px rgba(16,185,129,0.25),
+                0 40px 80px -20px rgba(0,0,0,0.35);
+}
+```
+
+### 送信ボックス（丸角オーバーライド）
+
+```css
+/* WebChat 送信ボックスを丸角に */
+.chat-body [class*="webchat__send-box"] {
+    padding: 0.6rem 0.75rem !important;
+    background: #f9fafb !important;
+}
+
+.chat-body [class*="webchat__send-box__main"] {
+    border-radius: 24px !important;
+    border: 1px solid #e2e8f0 !important;
+    background: #ffffff !important;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.04) !important;
+    overflow: hidden !important;
+}
+
+.chat-body [class*="webchat__send-box"] input,
+.chat-body [class*="webchat__send-box"] textarea {
+    border: none !important;
+    outline: none !important;
+    background: transparent !important;
+}
+```
+
+### バブル角丸オーバーライド
+
+```css
+.chat-body [class*="webchat__bubble"] [class*="content"] {
+    border-radius: 18px !important;
+}
+```
+
+### プロンプトチップス
+
+```css
+.left-prompts-list button {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 99px;
+    padding: 0.45rem 0.9rem;
+    font-size: 0.73rem;
+    color: var(--color-text);
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.2,0.8,0.2,1);
+    font-family: inherit;
+    font-weight: 500;
+}
+
+.left-prompts-list button:hover {
+    background: rgba(99,102,241,0.15);
+    border-color: var(--color-accent);
+    color: #fff;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 16px rgba(99,102,241,0.2);
+}
+```
+
+## WebChat styleOptions（標準設定）
+
+```javascript
+const styleOptions = {
+    accent: '#6366f1',
+    backgroundColor: '#fafbfc',
+    botAvatarBackgroundColor: '#6366f1',
+    botAvatarInitials: '{EMOJI}',
+    userAvatarBackgroundColor: '#6366f1',
+    userAvatarInitials: 'U',
+    avatarBorderRadius: '12px',
+    avatarSize: 34,
+    bubbleBackground: '#ffffff',
+    bubbleBorderColor: '#e5e7eb',
+    bubbleBorderRadius: 18,
+    bubbleBorderWidth: 1,
+    bubbleFromUserBackground: '#eef2ff',
+    bubbleFromUserBorderColor: '#c7d2fe',
+    bubbleFromUserBorderRadius: 18,
+    bubbleFromUserBorderWidth: 1,
+    bubbleFromUserTextColor: '#1e1b4b',
+    bubbleTextColor: '#1f2937',
+    bubbleMinHeight: 40,
+    bubbleNubSize: 0,
+    bubbleFromUserNubSize: 0,
+    sendBoxBackground: '#f9fafb',
+    sendBoxBorderTop: 'none',
+    sendBoxButtonColor: '#6366f1',
+    sendBoxButtonColorOnHover: '#4f46e5',
+    sendBoxHeight: 56,
+    sendBoxPlaceholderColor: '#9ca3af',
+    sendBoxTextColor: '#1f2937',
+    suggestedActionBackgroundColor: '#6366f1',
+    suggestedActionBorderRadius: 20,
+    suggestedActionTextColor: '#ffffff',
+    suggestedActionLayout: 'flow',
+    primaryFont: "'Inter', 'Noto Sans JP', sans-serif",
+    hideUploadButton: true,
+    autoScrollSnapOnPage: true,
+    rootHeight: '100%',
+    rootWidth: '100%',
+};
+```
+
+## AI タイピングインジケーター（Tips ローテーション）
+
+ボットが応答生成中にユーザーの待ち時間を有効活用するパターン。
+
+### HTML 構造
+
+```html
+<div class="ai-typing" id="ai-typing">
+    <div class="ai-typing-dots"><span></span><span></span><span></span></div>
+    <div class="ai-typing-content">
+        <span class="ai-typing-label">AIが探索中…</span>
+        <span class="ai-typing-tip" id="ai-tip"></span>
+    </div>
+</div>
+```
+
+### CSS
+
+```css
+.ai-typing {
+    display: none;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.65rem 1.25rem;
+    background: linear-gradient(90deg, rgba(99,102,241,0.03), rgba(16,185,129,0.03));
+    border-bottom: 1px solid rgba(99,102,241,0.05);
+}
+.ai-typing.active { display: flex; }
+
+.ai-typing-dots { display: flex; gap: 3px; }
+.ai-typing-dots span {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--gradient-ai);
+    animation: bounce 1.4s ease-in-out infinite;
+}
+.ai-typing-dots span:nth-child(2) { animation-delay: .15s; }
+.ai-typing-dots span:nth-child(3) { animation-delay: .3s; }
+
+@keyframes bounce {
+    0%,60%,100% { transform: translateY(0); opacity: .4; }
+    30% { transform: translateY(-5px); opacity: 1; }
+}
+
+.ai-typing-tip {
+    font-size: 0.7rem; color: #64748b;
+    animation: tipFade 0.4s ease;
+}
+@keyframes tipFade {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+```
+
+### JavaScript
+
+```javascript
+const tips = [
+    '💡 {ドメイン固有のTip1}',
+    '🏗️ {ドメイン固有のTip2}',
+    // ... 10-12 個用意
+];
+let tipIndex = 0;
+let tipInterval = null;
+
+function showTyping() {
+    typingEl.classList.add('active');
+    tipIndex = Math.floor(Math.random() * tips.length);
+    tipEl.textContent = tips[tipIndex];
+    tipInterval = setInterval(() => {
+        tipIndex = (tipIndex + 1) % tips.length;
+        tipEl.textContent = tips[tipIndex];
+        tipEl.style.animation = 'none';
+        tipEl.offsetHeight;
+        tipEl.style.animation = '';
+    }, 4000);
+}
+
+function hideTyping() {
+    typingEl.classList.remove('active');
+    if (tipInterval) { clearInterval(tipInterval); tipInterval = null; }
+}
+```
+
+### WebChat Store 統合
+
+```javascript
+function createCustomStore() {
+    return window.WebChat.createStore({}, ({ dispatch }) => next => action => {
+        if (action.type === 'DIRECT_LINE/CONNECT_FULFILLED') {
+            dispatch({
+                type: 'DIRECT_LINE/POST_ACTIVITY',
+                meta: { method: 'keyboard' },
+                payload: {
+                    activity: {
+                        channelData: { postBack: true },
+                        name: 'startConversation',
+                        type: 'event',
+                    },
+                },
+            });
+        }
+        // タイピング検出
+        if (action.type === 'DIRECT_LINE/INCOMING_ACTIVITY') {
+            const a = action.payload?.activity;
+            if (a?.type === 'typing') showTyping();
+            else if (a?.type === 'message' && a?.from?.role === 'bot') hideTyping();
+        }
+        if (action.type === 'WEB_CHAT/SEND_MESSAGE') showTyping();
+        return next(action);
+    });
+}
+```
+
+## カテゴリ別カード + プロンプト（JavaScript データ構造）
+
+```javascript
+const categories = [
+    {
+        name: '{EMOJI} {カテゴリ名}',
+        plans: [
+            { id: 1, label: '{ラベル}', meta: '{メタ情報}' },
+            // 3-6 カード / カテゴリ
+        ],
+        prompts: [
+            { text: '{短縮ラベル}', prompt: '{送信するフルプロンプト}' },
+            // 3 プロンプト / カテゴリ
+        ],
+    },
+    // 2-4 カテゴリ
+];
+```
+
+### カード → メッセージ送信
+
+```javascript
+card.addEventListener('click', () => {
+    if (selectedCard) selectedCard.classList.remove('selected');
+    card.classList.add('selected');
+    selectedCard = card;
+    sendMessage(`${cat.name.replace(/^\S+\s/, '')}に最適な「${plan.label}」によく似た{ITEM}の例をいくつか提案して`);
+});
+```
+
+### プロンプトチップス → メッセージ送信
+
+```javascript
+btn.addEventListener('click', () => sendMessage(p.prompt));
+```
+
+## 画像モーダル（WebChat 内画像クリック対応）
+
+```javascript
+document.getElementById('webchat').addEventListener('click', (e) => {
+    const img = e.target.closest('img');
+    if (img && img.src && !img.closest('[class*="send-box"]')) {
+        modalImg.src = img.src;
+        imgModal.classList.add('active');
+    }
+});
+```
+
+## レスポンシブ対応
+
+```css
+@media (max-width: 900px) {
+    .workspace { grid-template-columns: 1fr; }
+    .left-panel { position: static; max-height: none; }
+}
+
+@media (max-width: 600px) {
+    .features-row { grid-template-columns: 1fr; }
+    .plan-grid { grid-template-columns: 1fr 1fr; }
+    .chat-container { border-radius: var(--radius); }
+}
+```
+
+## ファイル構成
+
+```
+website/
+  index.html           ← 本テンプレートで生成
+scripts/
+  deploy_website.py    ← Azure Storage デプロイ
+```
+
+## カスタマイズポイント一覧
+
+| 項目 | 変更箇所 | 説明 |
+|---|---|---|
+| ブランドカラー | `--color-primary` | emerald → 任意のブランドカラーに |
+| グラデーション | `--gradient-ai` | 4色グラデーション配色 |
+| アバター | `.avatar-invader` | CSS ピクセルアート or 絵文字 |
+| カテゴリ数 | `categories[]` | 2〜4 カテゴリ推奨 |
+| カード数/カテゴリ | `plans[]` | 3〜6 カード推奨 |
+| プロンプト数/カテゴリ | `prompts[]` | 3 プロンプト推奨 |
+| Tips | `tips[]` | ドメイン固有 10〜12 個推奨 |
+| 画像ベース URL | `BLOB_BASE` | Azure Blob Storage URL |
+| トークン | `tokenEndpoint` | Copilot Studio DirectLine URL |
+| モーダル | 画像モーダル / 登録モーダル | 要件に応じて有効/無効 |
+
+## 実装フロー
+
+1. **設計提案**: 本テンプレートのレイアウト + カテゴリ/プロンプト案をユーザーに提示
+2. **承認**: ユーザーが承認
+3. **実装**: `website/index.html` をテンプレートベースで生成
+4. **カスタマイズ**: カテゴリ・プロンプト・Tips・カラーを案件に合わせて調整
+5. **デプロイ**: `py scripts/deploy_website.py` で Azure Storage にデプロイ
+
+## 適用条件
+
+- 外部顧客向け AI エージェント Web サイト
+- 認証なし（匿名アクセス）
+- Azure Storage 静的 Web サイト
+- WebChat SDK（BotFramework）
+- カテゴリ分類可能な提案コンテンツが存在する

--- a/.github/skills/copilot-studio/references/webchat-sdk-embed.md
+++ b/.github/skills/copilot-studio/references/webchat-sdk-embed.md
@@ -1,0 +1,630 @@
+# 外部公開 WebChat SDK 埋め込みパターン（推奨）
+
+外部顧客向けにエージェントを Web サイトに公開する際の **標準パターン**。
+BotFramework WebChat SDK を使い、プログラム的なメッセージ送信・UI フルカスタマイズを実現する。
+
+> ⚠️ iframe 方式（`external-web-embed.md`）は簡易版。本パターンが推奨。
+
+## iframe 方式との違い
+
+| 項目 | iframe 方式 | WebChat SDK 方式（本パターン） |
+|------|------------|-------------------------------|
+| UI カスタマイズ | 不可 | `styleOptions` で完全制御 |
+| プログラム的メッセージ送信 | 不可 | `store.dispatch()` で可能 |
+| カルーセル連携 | 不可 | カード選択 → 自動送信 |
+| デザイン統合 | iframe の境界が見える | ページと完全に統合 |
+| 認証設定 | 認証なし | 認証なし（トークンは自動取得） |
+
+## 前提条件
+
+- Copilot Studio エージェントが「**認証なし**」で公開済み
+- Azure Storage Account（静的 Web サイト有効）
+- エージェントの DirectLine トークンエンドポイント URL
+
+## トークンエンドポイントの取得
+
+「認証なし」エージェントでも DirectLine トークンエンドポイントは取得可能:
+
+1. Copilot Studio → エージェント → **チャネル** タブ
+2. 「**ネイティブ アプリ**」を選択
+3. 表示される **接続文字列** から URL を取得
+
+接続文字列の形式（Conversations API）:
+```
+https://{ENV_ID}.environment.api.powerplatform.com/copilotstudio/dataverse-backed/authenticated/bots/{BOT_SCHEMA}/conversations?api-version=2022-03-01-preview
+```
+
+**DirectLine トークンエンドポイント** はこの URL を変換して取得:
+```
+https://{ENV_ID}.environment.api.powerplatform.com/powervirtualagents/botsbyschema/{BOT_SCHEMA}/directline/token?api-version=2022-03-01-preview
+```
+
+変換ルール:
+```
+/copilotstudio/dataverse-backed/authenticated/bots/{SCHEMA}/conversations
+  ↓
+/powervirtualagents/botsbyschema/{SCHEMA}/directline/token
+```
+
+## アーキテクチャ
+
+```
+[外部ユーザー] → [Azure Storage 静的 Web サイト]
+                        ↓
+                  [WebChat SDK (BotFramework)]
+                        ↓ DirectLine token
+                  [Copilot Studio エージェント]
+                        ↓
+                  [Dataverse MCP Server / ナレッジ]
+```
+
+## Web サイト実装テンプレート
+
+### デザイン方針
+
+- **チャットを画面中央に配置**（フローティングではない）
+- **ダーク UI + モダンデザイン**（Inter + Noto Sans JP）
+- **カルーセル** で代表パターンを表示 → クリックでメッセージ送信
+- **プロンプトチップス** でクイック入力 → クリックでメッセージ送信
+- **WebChat SDK** で `styleOptions` 完全カスタマイズ
+
+### ファイル構成
+
+```
+website/
+  index.html     ← WebChat SDK 統合ランディングページ
+scripts/
+  deploy_website.py  ← Azure Storage デプロイ
+```
+
+### index.html テンプレート
+
+```html
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{サイト名} — {サブタイトル}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Noto+Sans+JP:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --color-primary: {PRIMARY_COLOR};       /* e.g. #10b981 */
+            --color-primary-dark: {PRIMARY_DARK};   /* e.g. #059669 */
+            --color-bg: #0f172a;
+            --color-surface: #1e293b;
+            --color-surface-hover: #334155;
+            --color-text: #f1f5f9;
+            --color-text-muted: #94a3b8;
+            --color-border: #334155;
+            --color-accent: {ACCENT_COLOR};         /* e.g. #6366f1 */
+            --radius: 16px;
+            --shadow-lg: 0 20px 60px rgba(0,0,0,0.4);
+        }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        html { scroll-behavior: smooth; }
+        body {
+            font-family: 'Inter', 'Noto Sans JP', sans-serif;
+            background: var(--color-bg);
+            color: var(--color-text);
+            min-height: 100vh;
+            overflow-x: hidden;
+        }
+
+        /* ── Header ── */
+        .header {
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            backdrop-filter: blur(20px);
+            background: rgba(15, 23, 42, 0.8);
+            border-bottom: 1px solid var(--color-border);
+            padding: 0 2rem;
+            height: 64px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+        .header-brand {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+        .header-brand svg {
+            width: 28px; height: 28px;
+            color: var(--color-primary);
+        }
+        .header-brand h1 {
+            font-size: 1.125rem;
+            font-weight: 600;
+            letter-spacing: -0.02em;
+        }
+        .header-badge {
+            font-size: 0.7rem; font-weight: 500;
+            background: var(--color-primary); color: #000;
+            padding: 0.2rem 0.6rem; border-radius: 99px;
+        }
+
+        /* ── Main Layout ── */
+        .main {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem 1.5rem 3rem;
+            display: flex;
+            flex-direction: column;
+            gap: 2rem;
+        }
+
+        /* ── Hero Section ── */
+        .hero { text-align: center; padding: 2rem 0 1rem; }
+        .hero h2 {
+            font-size: clamp(1.5rem, 4vw, 2.5rem);
+            font-weight: 700;
+            letter-spacing: -0.03em;
+            background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            margin-bottom: 0.75rem;
+        }
+        .hero p {
+            font-size: 1rem;
+            color: var(--color-text-muted);
+            max-width: 540px;
+            margin: 0 auto;
+            line-height: 1.7;
+        }
+
+        /* ── Carousel ── */
+        .carousel-section { position: relative; }
+        .carousel-section h3 {
+            font-size: 0.85rem; font-weight: 500;
+            color: var(--color-text-muted);
+            text-transform: uppercase; letter-spacing: 0.08em;
+            margin-bottom: 1rem;
+        }
+        .carousel-track {
+            display: flex; gap: 1rem;
+            overflow-x: auto; scroll-snap-type: x mandatory;
+            scrollbar-width: none; padding: 0.5rem 0 1rem;
+        }
+        .carousel-track::-webkit-scrollbar { display: none; }
+        .plan-card {
+            flex: 0 0 220px; scroll-snap-align: start;
+            background: var(--color-surface);
+            border: 1px solid var(--color-border);
+            border-radius: 12px; overflow: hidden;
+            cursor: pointer; transition: transform 0.2s, border-color 0.2s, box-shadow 0.2s;
+        }
+        .plan-card:hover {
+            transform: translateY(-4px);
+            border-color: var(--color-primary);
+            box-shadow: 0 8px 24px rgba(16, 185, 129, 0.15);
+        }
+        .plan-card.selected {
+            border-color: var(--color-primary);
+            box-shadow: 0 0 0 2px var(--color-primary);
+        }
+        .plan-card img {
+            width: 100%; height: 150px;
+            object-fit: cover; background: #f8fafc;
+        }
+        .plan-card-info { padding: 0.75rem; }
+        .plan-card-info .label { font-size: 0.8rem; font-weight: 600; }
+        .plan-card-info .meta { font-size: 0.7rem; color: var(--color-text-muted); }
+
+        /* ── Chat Center ── */
+        .chat-section { flex: 1; display: flex; flex-direction: column; }
+        .chat-container {
+            background: #ffffff;
+            border-radius: 20px; overflow: hidden;
+            box-shadow:
+                0 0 0 1px rgba(255,255,255,0.05),
+                0 25px 60px -12px rgba(0, 0, 0, 0.5),
+                0 0 120px -30px rgba(16, 185, 129, 0.1);
+            display: flex; flex-direction: column;
+        }
+        .chat-header {
+            display: flex; align-items: center; justify-content: space-between;
+            padding: 1rem 1.5rem;
+            background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%);
+            position: relative; overflow: hidden;
+        }
+        .chat-header::before {
+            content: ''; position: absolute; inset: 0;
+            background: linear-gradient(135deg, rgba(16, 185, 129, 0.08), transparent 60%);
+            pointer-events: none;
+        }
+        .chat-header-left {
+            display: flex; align-items: center; gap: 0.875rem;
+            position: relative; z-index: 1;
+        }
+        .chat-header-left .avatar {
+            width: 44px; height: 44px; border-radius: 14px;
+            background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+            display: flex; align-items: center; justify-content: center;
+            font-size: 1.25rem;
+            box-shadow: 0 6px 16px rgba(16, 185, 129, 0.35);
+        }
+        .chat-header-left .info h4 {
+            font-size: 1.05rem; font-weight: 700;
+            letter-spacing: -0.02em; color: #f1f5f9;
+        }
+        .chat-header-left .info p {
+            font-size: 0.75rem; color: #94a3b8; margin-top: 0.2rem;
+        }
+        .chat-status {
+            font-size: 0.78rem; color: var(--color-primary); font-weight: 500;
+            background: rgba(16, 185, 129, 0.08);
+            padding: 0.45rem 0.9rem; border-radius: 99px;
+            border: 1px solid rgba(16, 185, 129, 0.15);
+            position: relative; z-index: 1;
+        }
+        .chat-status .dot {
+            width: 8px; height: 8px; border-radius: 50%;
+            background: var(--color-primary); display: inline-block;
+            animation: pulse 2s ease-in-out infinite;
+            margin-right: 0.4rem;
+        }
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.4; }
+        }
+        .chat-body {
+            height: clamp(500px, calc(100vh - 320px), 900px);
+            overflow: hidden; resize: vertical;
+            min-height: 400px; max-height: 1200px;
+            background: #f9fafb;
+        }
+        .chat-body #webchat { height: 100%; width: 100%; }
+        .chat-body #webchat > * { height: 100%; }
+
+        /* ── Prompt Chips ── */
+        .prompt-chips {
+            display: flex; flex-wrap: wrap; gap: 0.5rem;
+            padding: 1rem 1.5rem;
+            border-top: 1px solid rgba(0,0,0,0.06);
+            background: linear-gradient(180deg, #f8fafc, #f1f5f9);
+        }
+        .prompt-chips-label {
+            width: 100%; font-size: 0.7rem; text-transform: uppercase;
+            letter-spacing: 0.06em; color: #64748b;
+            margin-bottom: 0.25rem; font-weight: 600;
+        }
+        .prompt-chips button {
+            background: #ffffff; border: 1px solid #e2e8f0;
+            border-radius: 99px; padding: 0.5rem 1rem;
+            font-size: 0.8rem; color: #334155;
+            cursor: pointer; transition: all 0.2s;
+            font-family: inherit; font-weight: 500;
+        }
+        .prompt-chips button:hover {
+            background: var(--color-primary); border-color: var(--color-primary);
+            color: #fff; transform: translateY(-2px);
+            box-shadow: 0 6px 16px rgba(16, 185, 129, 0.3);
+        }
+
+        @media (max-width: 768px) {
+            .header { padding: 0 1rem; }
+            .main { padding: 1.5rem 1rem; }
+            .plan-card { flex: 0 0 180px; }
+            .chat-body { height: clamp(360px, calc(100vh - 200px), 700px); }
+        }
+    </style>
+</head>
+<body>
+    <header class="header">
+        <div class="header-brand">
+            <!-- SVG アイコンを変更 -->
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
+                <polyline points="9 22 9 12 15 12 15 22"/>
+            </svg>
+            <h1>{サイト名}</h1>
+            <span class="header-badge">AI</span>
+        </div>
+    </header>
+
+    <main class="main">
+        <section class="hero">
+            <h2>{ヒーローテキスト}</h2>
+            <p>{説明文}</p>
+        </section>
+
+        <!-- カルーセル: 代表パターン -->
+        <section class="carousel-section">
+            <h3>{カルーセルタイトル}</h3>
+            <div class="carousel-track" id="carousel-track"></div>
+        </section>
+
+        <!-- チャット: ページ中央 -->
+        <section class="chat-section">
+            <div class="chat-container">
+                <div class="chat-header">
+                    <div class="chat-header-left">
+                        <div class="avatar">{EMOJI}</div>
+                        <div class="info">
+                            <h4>{エージェント名}</h4>
+                            <p>{サブタイトル}</p>
+                        </div>
+                    </div>
+                    <div class="chat-status">
+                        <span class="dot"></span> オンライン
+                    </div>
+                </div>
+                <div class="chat-body">
+                    <div id="webchat" role="main"></div>
+                </div>
+                <div class="prompt-chips" id="prompt-chips">
+                    <span class="prompt-chips-label">こんな質問を試してみよう</span>
+                    <!-- ボタンを配置: data-prompt にフル質問文を設定 -->
+                    <button data-prompt="{質問全文}"> {短縮ラベル}</button>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
+    <script>
+        // ========================================
+        // WebChat SDK Configuration
+        // ========================================
+        const tokenEndpoint = '{TOKEN_ENDPOINT}';
+
+        const styleOptions = {
+            accent: '{PRIMARY_COLOR}',
+            backgroundColor: '#f9fafb',
+            botAvatarBackgroundColor: '{PRIMARY_COLOR}',
+            botAvatarInitials: '{BOT_INITIALS}',
+            userAvatarBackgroundColor: '{ACCENT_COLOR}',
+            userAvatarInitials: 'U',
+            avatarBorderRadius: '8px',
+            avatarSize: 32,
+            bubbleBackground: '#ffffff',
+            bubbleBorderColor: '#e2e8f0',
+            bubbleBorderRadius: 16,
+            bubbleBorderWidth: 1,
+            bubbleFromUserBackground: '#eef2ff',
+            bubbleFromUserBorderColor: '#c7d2fe',
+            bubbleFromUserBorderRadius: 16,
+            bubbleFromUserBorderWidth: 1,
+            bubbleFromUserTextColor: '#1e293b',
+            bubbleTextColor: '#1e293b',
+            bubbleMinHeight: 40,
+            sendBoxBackground: '#ffffff',
+            sendBoxBorderTop: 'solid 1px #e2e8f0',
+            sendBoxButtonColor: '{PRIMARY_COLOR}',
+            sendBoxButtonColorOnHover: '{PRIMARY_DARK}',
+            sendBoxHeight: 56,
+            sendBoxPlaceholderColor: '#94a3b8',
+            sendBoxTextColor: '#1e293b',
+            suggestedActionBackgroundColor: '{PRIMARY_COLOR}',
+            suggestedActionBorderRadius: 20,
+            suggestedActionTextColor: '#ffffff',
+            suggestedActionLayout: 'flow',
+            primaryFont: "'Inter', 'Noto Sans JP', sans-serif",
+            hideUploadButton: true,
+            autoScrollSnapOnPage: true,
+        };
+
+        let directLine = null;
+        let store = null;
+
+        // startConversation イベントを送信
+        function createCustomStore() {
+            return window.WebChat.createStore({}, ({ dispatch }) => next => action => {
+                if (action.type === 'DIRECT_LINE/CONNECT_FULFILLED') {
+                    dispatch({
+                        type: 'DIRECT_LINE/POST_ACTIVITY',
+                        meta: { method: 'keyboard' },
+                        payload: {
+                            activity: {
+                                channelData: { postBack: true },
+                                name: 'startConversation',
+                                type: 'event',
+                            },
+                        },
+                    });
+                }
+                return next(action);
+            });
+        }
+
+        // プログラム的にメッセージを送信
+        function sendMessage(text) {
+            if (!store) return;
+            store.dispatch({
+                type: 'WEB_CHAT/SEND_MESSAGE',
+                payload: { text },
+            });
+        }
+
+        // WebChat 初期化
+        async function initializeChat() {
+            try {
+                const environmentEndPoint = tokenEndpoint.slice(0, tokenEndpoint.indexOf('/powervirtualagents'));
+                const apiVersion = tokenEndpoint.slice(tokenEndpoint.indexOf('api-version')).split('=')[1];
+                const regionalChannelSettingsURL = `${environmentEndPoint}/powervirtualagents/regionalchannelsettings?api-version=${apiVersion}`;
+
+                const [settingsRes, tokenRes] = await Promise.all([
+                    fetch(regionalChannelSettingsURL),
+                    fetch(tokenEndpoint),
+                ]);
+
+                const settings = await settingsRes.json();
+                const conversationInfo = await tokenRes.json();
+                const directLineUrl = settings.channelUrlsById?.directline;
+
+                if (!directLineUrl || !conversationInfo.token) {
+                    throw new Error('Failed to get DirectLine URL or token');
+                }
+
+                directLine = window.WebChat.createDirectLine({
+                    domain: `${directLineUrl}v3/directline`,
+                    token: conversationInfo.token,
+                });
+
+                store = createCustomStore();
+
+                window.WebChat.renderWebChat(
+                    { directLine, styleOptions, store },
+                    document.getElementById('webchat')
+                );
+            } catch (err) {
+                console.error('Chat init failed:', err);
+                document.getElementById('webchat').innerHTML = `
+                    <div style="display:flex;align-items:center;justify-content:center;height:100%;flex-direction:column;gap:1rem;color:#64748b;">
+                        <p>チャットの接続に失敗しました</p>
+                        <button onclick="initializeChat()" style="padding:0.5rem 1rem;border-radius:8px;border:1px solid #e2e8f0;background:#fff;cursor:pointer;">再試行</button>
+                    </div>`;
+            }
+        }
+
+        // ========================================
+        // Carousel: カードクリック → メッセージ送信
+        // ========================================
+        const items = [
+            // { id: 1, label: 'ラベル', meta: '説明', imageUrl: 'https://...' }
+        ];
+
+        const track = document.getElementById('carousel-track');
+        let selectedCard = null;
+
+        items.forEach(item => {
+            const card = document.createElement('div');
+            card.className = 'plan-card';
+            card.innerHTML = `
+                <img src="${item.imageUrl}" alt="${item.label}" loading="lazy">
+                <div class="plan-card-info">
+                    <div class="label">${item.label}</div>
+                    <div class="meta">${item.meta}</div>
+                </div>
+            `;
+            card.addEventListener('click', () => {
+                if (selectedCard) selectedCard.classList.remove('selected');
+                card.classList.add('selected');
+                selectedCard = card;
+                sendMessage(`${item.label} について詳しく教えて`);
+                document.querySelector('.chat-section').scrollIntoView({ behavior: 'smooth', block: 'center' });
+            });
+            track.appendChild(card);
+        });
+
+        // ========================================
+        // Prompt Chips: クリック → メッセージ送信
+        // ========================================
+        document.querySelectorAll('.prompt-chips button').forEach(btn => {
+            btn.addEventListener('click', () => {
+                sendMessage(btn.getAttribute('data-prompt'));
+                document.querySelector('.chat-section').scrollIntoView({ behavior: 'smooth', block: 'start' });
+            });
+        });
+
+        // Initialize on page load
+        initializeChat();
+    </script>
+</body>
+</html>
+```
+
+## deploy_website.py テンプレート
+
+```python
+"""Azure Storage 静的 Web サイトを有効化し、index.html をデプロイする"""
+from azure.storage.blob import BlobServiceClient, ContentSettings
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+ACCOUNT_NAME = os.getenv("AZURE_STORAGE_ACCOUNT")
+ACCOUNT_KEY = os.getenv("AZURE_STORAGE_KEY")
+
+conn_str = f"DefaultEndpointsProtocol=https;AccountName={ACCOUNT_NAME};AccountKey={ACCOUNT_KEY};EndpointSuffix=core.windows.net"
+blob_service = BlobServiceClient.from_connection_string(conn_str)
+
+# 静的 Web サイト有効化
+blob_service.set_service_properties(
+    static_website={
+        "enabled": True,
+        "index_document": "index.html",
+        "error_document404_path": "index.html",
+    }
+)
+print("Static website enabled")
+
+# index.html を $web コンテナにアップロード
+web_client = blob_service.get_container_client("$web")
+with open("website/index.html", "rb") as f:
+    web_client.upload_blob(
+        name="index.html",
+        data=f,
+        overwrite=True,
+        content_settings=ContentSettings(content_type="text/html; charset=utf-8"),
+    )
+print(f"Deployed: https://{ACCOUNT_NAME}.z11.web.core.windows.net/")
+```
+
+## .env 追加項目
+
+```env
+# Azure Storage（静的 Web サイトホスティング）
+AZURE_STORAGE_ACCOUNT=mystorageaccount
+AZURE_STORAGE_KEY=xxxxx
+
+# WebChat SDK
+WEBCHAT_TOKEN_ENDPOINT=https://{ENV_ID}.environment.api.powerplatform.com/powervirtualagents/botsbyschema/{BOT_SCHEMA}/directline/token?api-version=2022-03-01-preview
+```
+
+## 実装手順サマリー
+
+### Phase 1: Copilot Studio 設定
+
+1. エージェントを「**認証なし**」で設定・公開
+2. **チャネル → ネイティブ アプリ** から接続文字列を取得
+3. 接続文字列から DirectLine トークンエンドポイント URL を導出
+
+### Phase 2: Web サイト構築
+
+1. `website/index.html` を上記テンプレートから作成
+2. プレースホルダーを置換:
+   - `{TOKEN_ENDPOINT}` → DirectLine トークンエンドポイント
+   - `{PRIMARY_COLOR}` → ブランドカラー
+   - `{サイト名}` / `{エージェント名}` → プロジェクト固有値
+3. カルーセルの `items` 配列にデータを設定
+4. プロンプトチップスの `data-prompt` を設定
+
+### Phase 3: デプロイ
+
+1. `scripts/deploy_website.py` を作成
+2. `py scripts/deploy_website.py` を実行
+3. URL で動作確認: `https://{ACCOUNT}.z11.web.core.windows.net/`
+
+## 注意事項
+
+```
+✅ WebChat SDK + DirectLine トークンエンドポイント
+   → 「認証なし」でもネイティブアプリチャネルからトークンが取得できる
+   → store.dispatch() でプログラム的にメッセージ送信可能
+   → styleOptions で UI を完全カスタマイズ可能
+
+❌ iframe 方式
+   → UI カスタマイズ不可、postMessage 不可
+
+❌ /copilotstudio/dataverse-backed/authenticated/ API
+   → 認証なしエージェントでは外部ユーザーからアクセス不可（404）
+```
+
+## 適用条件
+
+| 条件 | 値 |
+|------|-----|
+| 対象ユーザー | 外部顧客（匿名） |
+| 認証設定 | 認証なし |
+| チャネル | ネイティブ アプリ（トークン取得用） |
+| ホスティング | Azure Storage 静的 Web サイト |
+| チャット表示方式 | ページ中央埋め込み（WebChat SDK） |
+| UI カスタマイズ | styleOptions で完全制御 |
+| メッセージ連携 | カルーセル / チップス → 自動送信 |

--- a/.github/skills/copilot-studio/references/webchat-sdk-embed.md
+++ b/.github/skills/copilot-studio/references/webchat-sdk-embed.md
@@ -4,6 +4,11 @@
 BotFramework WebChat SDK を使い、プログラム的なメッセージ送信・UI フルカスタマイズを実現する。
 
 > ⚠️ iframe 方式（`external-web-embed.md`）は簡易版。本パターンが推奨。
+>
+> 📐 **UI デザイン標準**: [webchat-sdk-design-template.md](webchat-sdk-design-template.md) を参照。
+> 外部公開 Web サイトを新規構築する際は、デザインテンプレートのレイアウト
+> （左パネル: カテゴリ別カード＋プロンプトチップス / 右パネル: WebChat）を
+> 標準として提案し、承認後に実装を進めること。
 
 ## iframe 方式との違い
 


### PR DESCRIPTION
## 概要

外部顧客向け AI エージェント Web サイトの**標準 UI デザインテンプレート**をスキルに追加します。
今後、外部公開 Web サイトを構築する際はこのテンプレートが提案され、承認後に実装を進めるフローになります。

## 追加内容

### 新規リファレンス: \.github/skills/copilot-studio/references/webchat-sdk-design-template.md\

**レイアウトパターン**:
- 左パネル（500px 固定・sticky）: カテゴリ別カードグリッド + プロンプトチップス
- 右パネル（1fr）: WebChat SDK（AI グラデーション枠・AI タイピング Tips）

**デザインシステム**:
- ダーク UI（#050a18）+ AI グラデーション（emerald → cyan → indigo → purple）
- グラスモーフィズム（backdrop-filter: blur）
- CSS Variables ベースのカラーパレット
- 丸角送信ボックス（24px radius）オーバーライド
- WebChat バブル角丸オーバーライド

**コンポーネント**:
- カテゴリ別カードグリッド → カードクリックでプロンプト送信
- プロンプトチップス（ピル型ボタン）→ クリックでプロンプト送信
- AI タイピングインジケーター（3 ドットアニメーション + ドメイン固有 Tips ローテーション）
- 画像モーダル（WebChat 内画像クリック対応）
- レスポンシブ対応（900px / 600px ブレークポイント）

**運用フロー**:
1. デザインテンプレートのレイアウト + カテゴリ/プロンプト案をユーザーに設計提案
2. ユーザー承認
3. テンプレートベースで実装
4. カスタマイズ（カテゴリ・プロンプト・Tips・カラー）
5. デプロイ

### SKILL.md 更新

- サブリファレンステーブルにデザインテンプレートを追加
- 「外部公開 Web サイト開発フロー」セクション追加（設計提案 → 承認 → 実装の必須フロー）
- トリガーキーワード追加: デザインテンプレート、左パネル、カテゴリ別カード、AI タイピング、グラデーション枠、外部Webデザイン、ランディングページ

### webchat-sdk-embed.md 更新

- デザインテンプレートへの参照ノートを追加

## 背景

Room Planner（不動産物件提案エージェント）で実装・検証済みの UI パターンをスキル標準化。
外部公開時の AI エージェント Web サイト UI を統一し、再利用可能にする。