### PR TITLE
feat(power-pages): 設計前レビュー・デプロイ前レビュースキルを追加

### DIFF
--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -707,7 +707,35 @@ SPA は独自の React 19 バンドルで動作するため、ホスト側の Re
 
 ---
 
-## チェックリスト
+## レビュースキル（品質ゲート）
+
+Power Pages の品質を標準的に維持するための **設計前レビュー** と **デプロイ前レビュー** を提供する。
+
+| レビュー | タイミング | ドキュメント | スクリプト |
+|---|---|---|---|
+| **設計前レビュー** | テーブル設計完了後、SPA 実装開始前 | [reviews/pre-design-review.md](reviews/pre-design-review.md) | `scripts/review_pre_design.py` |
+| **デプロイ前レビュー** | `npm run build` 後、`pac pages upload-code-site` 前 | [reviews/pre-deploy-review.md](reviews/pre-deploy-review.md) | `scripts/review_pre_deploy.py` |
+
+### 呼び出し方
+
+```bash
+# 設計前レビュー（ローカル静的チェックのみ、Dataverse 接続不要）
+cd portal
+python ../.github/skills/power-pages/scripts/review_pre_design.py
+
+# デプロイ前レビュー（ビルド出力 + Dataverse API チェック）
+cd portal
+python ../.github/skills/power-pages/scripts/review_pre_deploy.py
+
+# CI/CD でリモートチェックをスキップする場合
+SKIP_REMOTE=1 python ../.github/skills/power-pages/scripts/review_pre_deploy.py
+```
+
+> **標準フロー**: 設計前レビュー → 実装 → ビルド → デプロイ前レビュー → デプロイ
+
+---
+
+## チェックリスト（レガシー参照用）
 
 ### 認証・認可
 - [ ] POST/PATCH/DELETE に `__RequestVerificationToken` ヘッダーを付与している（教訓 1）

--- a/.github/skills/power-pages/reviews/pre-deploy-review.md
+++ b/.github/skills/power-pages/reviews/pre-deploy-review.md
@@ -1,0 +1,140 @@
+# Power Pages デプロイ前レビュー
+
+> **タイミング**: `npm run build` 完了後、`pac pages upload-code-site` 実行前に実行する。
+> **目的**: デプロイ先の環境設定が正しいことを Dataverse API で検証し、デプロイ後の 403/404 を予防する。
+
+---
+
+## チェック項目一覧
+
+### 1. ローカルビルド検証
+
+| # | チェック項目 | 自動 | 根拠 |
+|---|---|---|---|
+| 1.1 | `dist-site/index.html` が存在する | ✅ | ビルド出力確認 |
+| 1.2 | `dist-site/assets/` に `.js` ファイルが 1 つだけ存在する | ✅ | inlineDynamicImports |
+| 1.3 | `dist-site/index.html` が相対パス (`./assets/`) で JS/CSS を参照 | ✅ | `base: "./"` |
+| 1.4 | TypeScript ビルドエラーがないこと (`tsc --noEmit`) | ✅ | 型安全 |
+| 1.5 | `api.ts` に `credentials: "same-origin"` がある | ✅ | 核心原則8 |
+| 1.6 | `api.ts` に `redirect: "manual"` がある | ✅ | 教訓7 |
+| 1.7 | `api.ts` に `__RequestVerificationToken` 取得ロジックがある | ✅ | 教訓1 |
+| 1.8 | POST ペイロードにカスタム reporter @odata.bind が含まれていない | ✅ | CreatedBy 標準 |
+
+### 2. 環境接続検証
+
+| # | チェック項目 | 自動 | 根拠 |
+|---|---|---|---|
+| 2.1 | `pac org who` で接続先環境が `.env` の `DATAVERSE_URL` と一致 | ✅ | 教訓10: 環境取り違え |
+| 2.2 | `pac auth list` でアクティブプロファイルが存在する | ✅ | 教訓10 |
+| 2.3 | `powerpagesites` に対象サイトが Active 状態で存在する | ✅ | Step 2-C |
+| 2.4 | `powerpagesitelanguages` にサイトの言語レコードが存在する | ✅ | languageid null 防止 |
+
+### 3. テーブル権限検証（Dataverse API）
+
+| # | チェック項目 | 自動 | 根拠 |
+|---|---|---|---|
+| 3.1 | 対象テーブルに `powerpagecomponent` type=18 が存在する | ✅ | 教訓2: 未設定 → 403 |
+| 3.2 | content JSON に `adx_entitypermission_webrole` が含まれている | ✅ | 教訓2 |
+| 3.3 | `_powerpagesitelanguageid_value` が null でない | ✅ | 核心: null → 404 9004010C |
+| 3.4 | scope が意図通り（Global=756150000 / Self=756150004）| ✅ | 教訓3 |
+| 3.5 | Contact 用権限は scope=756150004 (Self) | ✅ | 教訓3 |
+| 3.6 | `append=true, appendto=true` が設定されている（Lookup 使用テーブル） | ✅ | 教訓4: 403 90040106 |
+| 3.7 | N:N `powerpagecomponent_powerpagecomponent` リンクが存在する | ✅ | 教訓2 |
+
+### 4. サイト設定検証
+
+| # | チェック項目 | 自動 | 根拠 |
+|---|---|---|---|
+| 4.1 | `Authentication/Registration/ProfileRedirectEnabled` = `false` | ✅ | 教訓5 |
+| 4.2 | `Authentication/Registration/LoginButtonAuthEnabled` = `false` | ✅ | 教訓5 |
+| 4.3 | `Webapi/error/innererror` = `true`（開発環境のみ） | ✅ | デバッグ用 |
+| 4.4 | 不要な `Webapi/{table}/enabled` 設定が存在しない（EDM 2.0 では不要） | ✅ | 教訓8 |
+
+### 5. セキュリティ検証（本番デプロイ時）
+
+| # | チェック項目 | 自動 | 根拠 |
+|---|---|---|---|
+| 5.1 | `Webapi/error/innererror` = `false`（本番環境） | ✅ | 情報漏洩防止 |
+| 5.2 | テーブル権限が Global scope ではなく Self/Contact scope（必要最小限） | ⚠️手動 | 最小権限原則 |
+| 5.3 | CORS / CSP 設定が過度に緩和されていない | ⚠️手動 | OWASP |
+
+---
+
+## 実行方法
+
+```bash
+cd portal
+python ../.github/skills/power-pages/scripts/review_pre_deploy.py
+```
+
+### 出力例
+
+```
+╔══════════════════════════════════════════════════╗
+║  Power Pages デプロイ前レビュー                   ║
+╚══════════════════════════════════════════════════╝
+
+[1/5] ローカルビルド検証
+  ✅ dist-site/index.html が存在
+  ✅ assets/ に JS ファイルが 1 つ (index-Abc123.js)
+  ✅ index.html が相対パス参照
+  ✅ api.ts: credentials: "same-origin"
+  ✅ api.ts: redirect: "manual"
+  ✅ api.ts: __RequestVerificationToken 取得ロジック
+  ✅ POST に reporter @odata.bind なし
+
+[2/5] 環境接続検証
+  ✅ pac auth アクティブプロファイル: org123.crm7.dynamics.com
+  ✅ .env DATAVERSE_URL と一致
+  ✅ サイト "IncidentPortal" (Active)
+  ✅ 言語レコード: 1e12c1b1-... (Japanese)
+
+[3/5] テーブル権限検証
+  ✅ geek_incident: type=18 あり, languageid 設定済み, scope=Global
+  ✅ geek_incident: adx_entitypermission_webrole あり
+  ✅ geek_incident: N:N リンク あり
+  ✅ geek_incident: append=true, appendto=true
+  ✅ contact: type=18 あり, scope=Self(756150004)
+
+[4/5] サイト設定検証
+  ✅ ProfileRedirectEnabled = false
+  ✅ LoginButtonAuthEnabled = false
+  ✅ Webapi/error/innererror = true (開発環境)
+  ✅ 不要な Webapi/* 設定なし
+
+[5/5] セキュリティ検証
+  ⚠️  Webapi/error/innererror = true — 本番デプロイ時は false にしてください
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+結果: 19/20 PASS, 0 FAIL, 1 WARN
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+---
+
+## 不合格時のアクション
+
+| 不合格項目 | 自動修復コマンド |
+|---|---|
+| 3.1 テーブル権限なし | `python scripts/setup_permissions.py` |
+| 3.3 languageid null | `python scripts/setup_permissions.py` (languageid パッチ含む) |
+| 3.7 N:N リンクなし | `python scripts/setup_permissions.py` (N:N 設定含む) |
+| 4.1 ProfileRedirect | `python scripts/setup_auth.py` |
+| 5.1 innererror=true (本番) | サイト設定を `false` に PATCH |
+
+---
+
+## CI/CD 統合
+
+GitHub Actions で `npm run build` 後に `review_pre_deploy.py` を実行する:
+
+```yaml
+- name: Pre-deploy review
+  run: python .github/skills/power-pages/scripts/review_pre_deploy.py
+  env:
+    DATAVERSE_URL: ${{ secrets.DATAVERSE_URL }}
+    TENANT_ID: ${{ secrets.TENANT_ID }}
+    # CI 用: サービスプリンシパル認証
+    CLIENT_ID: ${{ secrets.CLIENT_ID }}
+    CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+```

--- a/.github/skills/power-pages/reviews/pre-design-review.md
+++ b/.github/skills/power-pages/reviews/pre-design-review.md
@@ -1,0 +1,93 @@
+# Power Pages 設計前レビュー
+
+> **タイミング**: テーブル設計完了後、SPA コード実装の開始前に実行する。
+> **目的**: 実装で手戻りを起こさない設計判断がされていることを確認する。
+
+---
+
+## チェック項目一覧
+
+### 1. テーブル設計
+
+| # | チェック項目 | 根拠 |
+|---|---|---|
+| 1.1 | 報告者・作成者にカスタム Lookup 列を作っていない（`createdby` で代用） | 教訓4: @odata.bind ターゲット不一致 404 / AppendTo 403 の連鎖を防止 |
+| 1.2 | ユーザー参照は `systemuser` テーブルへの Lookup（カスタムユーザーテーブルを作っていない） | Dataverse 標準 |
+| 1.3 | テーブル / 列のスキーマ名が英語（日本語スキーマ名は pac code add-data-source で失敗） | Dataverse 標準 |
+| 1.4 | Choice 値は `100000000` 始まり | カスタム Choice の制約 |
+| 1.5 | 全 Lookup リレーションが設計書に明記されている | @odata.bind のターゲットテーブル誤り防止 |
+
+### 2. 認証設計
+
+| # | チェック項目 | 根拠 |
+|---|---|---|
+| 2.1 | 認証方式が「サーバー側セッション Cookie + Portal.User」になっている | 教訓6: contacts クエリ禁止 |
+| 2.2 | 認証判定で `/_api/contacts` をクエリする設計になっていない | 教訓6: 403 EntityPermissionReadIsMissing |
+| 2.3 | ログイン後のリダイレクト先を制御する設計（ProfileRedirectEnabled=false）になっている | 教訓5: /profile 強制リダイレクト |
+| 2.4 | SSO auto-redirect パターン（`/SignIn` → ExternalLogin form POST）が計画されている | 教訓5: プロバイダー選択スキップ |
+
+### 3. API 設計
+
+| # | チェック項目 | 根拠 |
+|---|---|---|
+| 3.1 | 共有クライアント `api.ts` パターンを使う設計（fetch を直接散在させない） | コード品質・教訓横断適用 |
+| 3.2 | POST/PATCH/DELETE に __RequestVerificationToken を付与する設計 | 教訓1: 401 anti-forgery |
+| 3.3 | `credentials: "same-origin"` を使用（`"include"` ではない） | 核心原則8 |
+| 3.4 | `redirect: "manual"` で認証切れを検知する設計 | 教訓7: 302 → ログインページ追従防止 |
+| 3.5 | 報告者はPOST時に送らず、GET時に `_createdby_value` で取得する設計 | CreatedBy 標準 |
+| 3.6 | @odata.bind 使用列の参照先テーブルが ManyToOneRelationships で確認済み | 教訓4: 404 9004010D |
+
+### 4. テーブル権限設計
+
+| # | チェック項目 | 根拠 |
+|---|---|---|
+| 4.1 | EDM 2.0 前提（`Webapi/*` Site Settings は使わない） | 教訓8 |
+| 4.2 | テーブル権限 content JSON に `adx_entitypermission_webrole` を含める設計 | 教訓2: 403 |
+| 4.3 | N:N リンク（`powerpagecomponent_powerpagecomponent`）も同時に設定する | 教訓2 |
+| 4.4 | Contact 権限は scope=756150004 (Self) を使用 | 教訓3: contactrelationship 不要 |
+| 4.5 | Lookup 参照先テーブルに `appendto=true` を設定する計画がある | 教訓4: 403 90040106 |
+| 4.6 | `powerpagesitelanguageid` を設定する計画がある | 核心: null → 404 9004010C |
+
+### 5. デプロイ構成
+
+| # | チェック項目 | 根拠 |
+|---|---|---|
+| 5.1 | HashRouter を使用（History API は直接 URL で 404） | SPA 制約 |
+| 5.2 | Vite `base: "./"` + `inlineDynamicImports: true` | Power Pages パス構造制約 |
+| 5.3 | `powerpages.config.json` が存在し `compiledPath` が一致 | pac pages 必須 |
+| 5.4 | 環境の `.js` ファイルアップロードブロックを解除する計画がある | Step 2-A |
+
+---
+
+## 実行方法
+
+### 手動レビュー
+
+上記チェック項目をプルリクエストレビュー時 or 設計レビュー会で確認する。
+
+### 自動チェック（ローカルファイルのみ）
+
+```bash
+cd portal
+python ../.github/skills/power-pages/scripts/review_pre_design.py
+```
+
+スクリプトは以下のローカルファイルを静的にチェックする:
+- `vite.config.ts` の `base` と `inlineDynamicImports`
+- `powerpages.config.json` の存在と `compiledPath`
+- `src/lib/api.ts` の `credentials`/`redirect`/`__RequestVerificationToken` パターン
+- `src/**/*.ts{x}` で `@odata.bind` 使用時の参照先確認
+- `src/**/*.ts{x}` で `createdby` 標準の遵守（カスタム reporter 列不使用）
+- ルーターが `HashRouter` であること
+
+---
+
+## 不合格時のアクション
+
+| 不合格項目 | 次のアクション |
+|---|---|
+| 1.1 報告者にカスタム Lookup | テーブルから列を削除し createdby 利用に設計変更 |
+| 2.2 contacts クエリ | Portal.User + セッション Cookie に変更 |
+| 3.6 @odata.bind 未確認 | `EntityDefinitions/ManyToOneRelationships` で参照先を確認 |
+| 4.6 languageid 計画なし | setup_permissions.py に languageid 設定を追加 |
+| 5.1 BrowserRouter | HashRouter に変更 |

--- a/.github/skills/power-pages/scripts/review_pre_deploy.py
+++ b/.github/skills/power-pages/scripts/review_pre_deploy.py
@@ -1,0 +1,454 @@
+"""Power Pages デプロイ前レビュー — ビルド出力 + Dataverse 環境チェック.
+
+ローカルビルド出力の検証に加え、Dataverse API でテーブル権限・サイト設定の
+整合性を確認する。デプロイ後の 403/404 を事前に検出して防止する。
+
+前提:
+    - .env に DATAVERSE_URL, TENANT_ID が設定されている
+    - auth_helper.py がプロジェクトルートまたは標準パスにある
+    - portal/dist-site/ にビルド済み出力がある
+
+Usage:
+    cd portal
+    python ../.github/skills/power-pages/scripts/review_pre_deploy.py
+
+環境変数:
+    PORTAL_ROOT     : ポータルルート (default: ".")
+    SKIP_REMOTE     : "1" でリモートチェックをスキップ（CI ローカルテスト用）
+    TARGET_TABLES   : チェック対象テーブル（カンマ区切り、default: .env の PORTAL_TABLES or 自動検出）
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Windows cp932 対策: stdout を UTF-8 に強制
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+# ---------------------------------------------------------------------------
+# パス設定
+# ---------------------------------------------------------------------------
+
+PORTAL_ROOT = Path(os.environ.get("PORTAL_ROOT", ".")).resolve()
+PROJECT_ROOT = PORTAL_ROOT.parent
+SKILL_SCRIPTS = PROJECT_ROOT / ".github" / "skills" / "standard" / "scripts"
+
+sys.path.insert(0, str(SKILL_SCRIPTS))
+sys.path.insert(0, str(PROJECT_ROOT))
+
+# dotenv
+try:
+    from dotenv import load_dotenv
+    load_dotenv(PROJECT_ROOT / ".env")
+except ImportError:
+    pass
+
+SKIP_REMOTE = os.environ.get("SKIP_REMOTE", "0") == "1"
+SRC_DIR = PORTAL_ROOT / "src"
+DIST_DIR = PORTAL_ROOT / "dist-site"
+
+# ---------------------------------------------------------------------------
+# ユーティリティ
+# ---------------------------------------------------------------------------
+
+PASS = "\033[92m✅\033[0m"
+FAIL = "\033[91m❌\033[0m"
+WARN = "\033[93m⚠️\033[0m"
+INFO = "\033[94mℹ️\033[0m"
+
+results: list[tuple[str, str, str]] = []
+
+
+def check(category: str, description: str, passed: bool, warn_only: bool = False):
+    """チェック結果を記録・表示."""
+    if passed:
+        icon = PASS
+        status = "PASS"
+    elif warn_only:
+        icon = WARN
+        status = "WARN"
+    else:
+        icon = FAIL
+        status = "FAIL"
+    results.append((status, category, description))
+    print(f"  {icon} {description}")
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (FileNotFoundError, UnicodeDecodeError):
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# [1] ローカルビルド検証
+# ---------------------------------------------------------------------------
+
+def check_local_build():
+    print("\n[1/5] ローカルビルド検証")
+
+    # 1.1 dist-site/index.html
+    index_html = DIST_DIR / "index.html"
+    check("1.1", "dist-site/index.html が存在する", index_html.exists())
+
+    # 1.2 assets/ に JS が 1 つ
+    assets_dir = DIST_DIR / "assets"
+    js_files = list(assets_dir.glob("*.js")) if assets_dir.exists() else []
+    check("1.2", f"assets/ に JS ファイルが {len(js_files)} 個 (1個が理想)", len(js_files) >= 1)
+    if js_files:
+        for jf in js_files:
+            print(f"    {INFO} {jf.name} ({jf.stat().st_size // 1024}KB)")
+
+    # 1.3 相対パス参照
+    if index_html.exists():
+        html_content = read_text(index_html)
+        uses_relative = "./assets/" in html_content or '"./assets' in html_content
+        check("1.3", 'index.html が相対パス (./assets/) で JS/CSS を参照', uses_relative)
+    else:
+        check("1.3", "index.html が相対パス参照", False)
+
+    # 1.5-1.7 api.ts パターン
+    api_ts = SRC_DIR / "lib" / "api.ts"
+    api_content = read_text(api_ts)
+    if api_content:
+        check("1.5", 'api.ts: credentials: "same-origin"', '"same-origin"' in api_content)
+        check("1.6", 'api.ts: redirect: "manual"', '"manual"' in api_content)
+        check("1.7", "api.ts: __RequestVerificationToken 取得ロジック",
+              "RequestVerificationToken" in api_content)
+
+        # 1.8 reporter @odata.bind チェック
+        has_reporter_bind = bool(re.search(
+            r'(reporter|inquirer).*@odata\.bind', api_content, re.IGNORECASE
+        ))
+        check("1.8", "POST に reporter @odata.bind が含まれていない", not has_reporter_bind)
+    else:
+        check("1.5-1.8", "api.ts が見つからない", False)
+
+
+# ---------------------------------------------------------------------------
+# [2] 環境接続検証
+# ---------------------------------------------------------------------------
+
+def check_environment():
+    print("\n[2/5] 環境接続検証")
+
+    if SKIP_REMOTE:
+        print(f"  {INFO} SKIP_REMOTE=1 のためスキップ")
+        return
+
+    dv_url = os.environ.get("DATAVERSE_URL", "")
+    if not dv_url:
+        check("2.1", ".env に DATAVERSE_URL が設定されている", False)
+        return
+    check("2.1", f"DATAVERSE_URL = {dv_url[:40]}...", True)
+
+    # pac org who
+    try:
+        result = subprocess.run(
+            ["pac", "org", "who"], capture_output=True, text=True, timeout=30
+        )
+        if result.returncode == 0:
+            org_url = ""
+            for line in result.stdout.splitlines():
+                if "Environment URL" in line or "組織 URL" in line:
+                    org_url = line.split(":")[-1].strip() if "http" not in line else re.search(r'https?://[^\s]+', line).group()
+            if org_url:
+                matches = dv_url.rstrip("/").lower() in org_url.lower() or org_url.lower() in dv_url.rstrip("/").lower()
+                check("2.1", f"pac org who の環境が .env と一致 ({org_url})", matches)
+            else:
+                check("2.1", "pac org who の環境URL取得", False)
+        else:
+            check("2.2", "pac auth アクティブプロファイルが存在する", False)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        check("2.2", "pac CLI が利用可能", False)
+
+    # Dataverse API でサイト確認
+    try:
+        import auth_helper
+        import requests
+
+        token = auth_helper.get_token(scope=f"{dv_url.rstrip('/')}/.default")
+        headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+        # powerpagesites
+        r = requests.get(
+            f"{dv_url.rstrip('/')}/api/data/v9.2/powerpagesites?$select=name,statecode",
+            headers=headers, timeout=30
+        )
+        if r.status_code == 200:
+            sites = r.json().get("value", [])
+            active_sites = [s for s in sites if s.get("statecode") == 0]
+            check("2.3", f"Active サイト: {len(active_sites)} 件", len(active_sites) >= 1)
+            for s in active_sites:
+                print(f"    {INFO} {s['name']}")
+        else:
+            check("2.3", "powerpagesites クエリ", False)
+
+        # powerpagesitelanguages
+        r2 = requests.get(
+            f"{dv_url.rstrip('/')}/api/data/v9.2/powerpagesitelanguages?$select=powerpagesitelanguageid,_powerpagesiteid_value&$top=5",
+            headers=headers, timeout=30
+        )
+        if r2.status_code == 200:
+            langs = r2.json().get("value", [])
+            check("2.4", f"サイト言語レコード: {len(langs)} 件", len(langs) >= 1)
+        else:
+            check("2.4", "powerpagesitelanguages クエリ", False)
+
+    except ImportError:
+        print(f"  {WARN} auth_helper / requests が見つかりません — リモートチェックスキップ")
+    except Exception as e:
+        print(f"  {WARN} 環境接続エラー: {e}")
+
+
+# ---------------------------------------------------------------------------
+# [3] テーブル権限検証
+# ---------------------------------------------------------------------------
+
+def check_table_permissions():
+    print("\n[3/5] テーブル権限検証")
+
+    if SKIP_REMOTE:
+        print(f"  {INFO} SKIP_REMOTE=1 のためスキップ")
+        return
+
+    dv_url = os.environ.get("DATAVERSE_URL", "").rstrip("/")
+    if not dv_url:
+        return
+
+    try:
+        import auth_helper
+        import requests
+
+        token = auth_helper.get_token(scope=f"{dv_url}/.default")
+        headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+        # テーブル権限一覧 (type=18)
+        r = requests.get(
+            f"{dv_url}/api/data/v9.2/powerpagecomponents"
+            "?$filter=powerpagecomponenttype eq 18"
+            "&$select=name,content,_powerpagesitelanguageid_value",
+            headers=headers, timeout=30
+        )
+        if r.status_code != 200:
+            check("3.1", "テーブル権限クエリ", False)
+            return
+
+        permissions = r.json().get("value", [])
+        if not permissions:
+            check("3.1", "テーブル権限が1件以上存在する", False)
+            return
+
+        check("3.1", f"テーブル権限: {len(permissions)} 件", True)
+
+        for perm in permissions:
+            name = perm.get("name", "unknown")
+            lang_id = perm.get("_powerpagesitelanguageid_value")
+            content_str = perm.get("content", "{}")
+
+            try:
+                content = json.loads(content_str) if content_str else {}
+            except json.JSONDecodeError:
+                content = {}
+
+            entity = content.get("entitylogicalname", "?")
+            scope = content.get("scope", "?")
+            has_webrole = "adx_entitypermission_webrole" in content and content["adx_entitypermission_webrole"]
+            has_append = content.get("append", False)
+            has_appendto = content.get("appendto", False)
+
+            # 3.3 languageid
+            if lang_id is None:
+                check("3.3", f"{name}: powerpagesitelanguageid が null (❌ 404 の原因)", False)
+            else:
+                check("3.3", f"{name}: languageid 設定済み", True)
+
+            # 3.2 webrole
+            check("3.2", f"{name}: adx_entitypermission_webrole あり", has_webrole)
+
+            # 3.5 Contact scope
+            if entity == "contact":
+                check("3.5", f"{name}: Contact scope={scope} (期待: 756150004=Self)",
+                      scope == 756150004)
+
+            # 3.6 append/appendto
+            if entity != "contact":
+                check("3.6", f"{name}: append={has_append}, appendto={has_appendto}",
+                      has_append and has_appendto)
+
+        # 3.7 N:N リンク確認 (サンプリング: 最初の権限)
+        if permissions:
+            first_id = permissions[0].get("powerpagecomponentid", "")
+            if first_id:
+                r_nn = requests.get(
+                    f"{dv_url}/api/data/v9.2/powerpagecomponents({first_id})"
+                    "/powerpagecomponent_powerpagecomponent?$select=name",
+                    headers=headers, timeout=30
+                )
+                if r_nn.status_code == 200:
+                    links = r_nn.json().get("value", [])
+                    check("3.7", f"{permissions[0]['name']}: N:N リンク {len(links)} 件", len(links) >= 1)
+                else:
+                    check("3.7", "N:N リンク確認", False)
+
+    except ImportError:
+        print(f"  {WARN} auth_helper / requests なし — スキップ")
+    except Exception as e:
+        print(f"  {WARN} テーブル権限チェックエラー: {e}")
+
+
+# ---------------------------------------------------------------------------
+# [4] サイト設定検証
+# ---------------------------------------------------------------------------
+
+def check_site_settings():
+    print("\n[4/5] サイト設定検証")
+
+    if SKIP_REMOTE:
+        print(f"  {INFO} SKIP_REMOTE=1 のためスキップ")
+        return
+
+    dv_url = os.environ.get("DATAVERSE_URL", "").rstrip("/")
+    if not dv_url:
+        return
+
+    try:
+        import auth_helper
+        import requests
+
+        token = auth_helper.get_token(scope=f"{dv_url}/.default")
+        headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+        # EDM type=9 site settings
+        r = requests.get(
+            f"{dv_url}/api/data/v9.2/powerpagecomponents"
+            "?$filter=powerpagecomponenttype eq 9"
+            "&$select=name,content",
+            headers=headers, timeout=30
+        )
+        if r.status_code != 200:
+            check("4", "サイト設定クエリ", False)
+            return
+
+        settings = {s["name"]: s.get("content", "") for s in r.json().get("value", [])}
+
+        # 4.1 ProfileRedirectEnabled
+        profile_redirect = settings.get("Authentication/Registration/ProfileRedirectEnabled", "")
+        check("4.1", "ProfileRedirectEnabled = false",
+              profile_redirect.lower() == "false" if profile_redirect else False)
+
+        # 4.2 LoginButtonAuthEnabled
+        login_button = settings.get("Authentication/Registration/LoginButtonAuthEnabled", "")
+        check("4.2", "LoginButtonAuthEnabled = false",
+              login_button.lower() == "false" if login_button else False)
+
+        # 4.3 innererror
+        innererror = settings.get("Webapi/error/innererror", "")
+        check("4.3", f"Webapi/error/innererror = {innererror or '(未設定)'}",
+              innererror.lower() == "true", warn_only=True)
+
+        # 4.4 不要な Webapi/* 設定
+        webapi_settings = [k for k in settings if k.startswith("Webapi/") and "/error/" not in k]
+        if webapi_settings:
+            check("4.4", f"不要な Webapi/* 設定が {len(webapi_settings)} 件ある (EDM 2.0 では不要)",
+                  False, warn_only=True)
+            for ws in webapi_settings[:5]:
+                print(f"    {INFO} {ws}")
+        else:
+            check("4.4", "不要な Webapi/* 設定なし (EDM 2.0 正常)", True)
+
+    except ImportError:
+        print(f"  {WARN} auth_helper / requests なし — スキップ")
+    except Exception as e:
+        print(f"  {WARN} サイト設定チェックエラー: {e}")
+
+
+# ---------------------------------------------------------------------------
+# [5] セキュリティ検証
+# ---------------------------------------------------------------------------
+
+def check_security():
+    print("\n[5/5] セキュリティ検証")
+
+    is_production = os.environ.get("DEPLOY_ENV", "").lower() == "production"
+
+    if SKIP_REMOTE:
+        print(f"  {INFO} SKIP_REMOTE=1 のためスキップ")
+        return
+
+    dv_url = os.environ.get("DATAVERSE_URL", "").rstrip("/")
+    if not dv_url:
+        return
+
+    try:
+        import auth_helper
+        import requests
+
+        token = auth_helper.get_token(scope=f"{dv_url}/.default")
+        headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+        r = requests.get(
+            f"{dv_url}/api/data/v9.2/powerpagecomponents"
+            "?$filter=powerpagecomponenttype eq 9 and name eq 'Webapi/error/innererror'"
+            "&$select=content",
+            headers=headers, timeout=30
+        )
+        if r.status_code == 200:
+            vals = r.json().get("value", [])
+            if vals:
+                innererror_val = vals[0].get("content", "")
+                if is_production:
+                    check("5.1", "本番: Webapi/error/innererror = false",
+                          innererror_val.lower() == "false")
+                else:
+                    if innererror_val.lower() == "true":
+                        check("5.1", "innererror=true (開発環境 OK、本番デプロイ時は false に)",
+                              True, warn_only=True)
+
+    except (ImportError, Exception):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# メイン
+# ---------------------------------------------------------------------------
+
+def main():
+    print("╔══════════════════════════════════════════════════╗")
+    print("║  Power Pages デプロイ前レビュー                    ║")
+    print("╚══════════════════════════════════════════════════╝")
+
+    check_local_build()
+    check_environment()
+    check_table_permissions()
+    check_site_settings()
+    check_security()
+
+    # サマリー
+    pass_count = sum(1 for r in results if r[0] == "PASS")
+    fail_count = sum(1 for r in results if r[0] == "FAIL")
+    warn_count = sum(1 for r in results if r[0] == "WARN")
+
+    print("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    print(f"結果: {pass_count} PASS, {fail_count} FAIL, {warn_count} WARN")
+    print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+    if fail_count > 0:
+        print(f"\n{FAIL} {fail_count} 件の不合格があります。デプロイを中止してください。")
+        print(f"   修復: python scripts/setup_permissions.py")
+        sys.exit(1)
+    elif warn_count > 0:
+        print(f"\n{WARN} 警告がありますがデプロイ可能です。")
+        sys.exit(0)
+    else:
+        print(f"\n{PASS} 全項目合格。デプロイに進めます。")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/power-pages/scripts/review_pre_design.py
+++ b/.github/skills/power-pages/scripts/review_pre_design.py
@@ -1,0 +1,236 @@
+"""Power Pages 設計前レビュー — ローカルファイル静的チェック.
+
+ポータルプロジェクトのソースコードを静的に解析し、設計前レビュー項目の
+合格/不合格を判定する。Dataverse 接続は不要。
+
+Usage:
+    cd portal
+    python ../.github/skills/power-pages/scripts/review_pre_design.py
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Windows cp932 対策: stdout を UTF-8 に強制
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+# ---------------------------------------------------------------------------
+# 設定
+# ---------------------------------------------------------------------------
+
+PORTAL_ROOT = Path(os.environ.get("PORTAL_ROOT", ".")).resolve()
+SRC_DIR = PORTAL_ROOT / "src"
+DIST_DIR = PORTAL_ROOT / "dist-site"
+
+# ---------------------------------------------------------------------------
+# ユーティリティ
+# ---------------------------------------------------------------------------
+
+PASS = "\033[92m✅\033[0m"
+FAIL = "\033[91m❌\033[0m"
+WARN = "\033[93m⚠️\033[0m"
+
+results: list[tuple[str, str, str]] = []
+
+
+def check(category: str, description: str, passed: bool, warn_only: bool = False):
+    """チェック結果を記録・表示."""
+    if passed:
+        icon = PASS
+        status = "PASS"
+    elif warn_only:
+        icon = WARN
+        status = "WARN"
+    else:
+        icon = FAIL
+        status = "FAIL"
+    results.append((status, category, description))
+    print(f"  {icon} {description}")
+
+
+def find_files(directory: Path, pattern: str) -> list[Path]:
+    """glob でファイル一覧を返す."""
+    return list(directory.rglob(pattern))
+
+
+def read_text(path: Path) -> str:
+    """UTF-8 でファイルを読む."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except (FileNotFoundError, UnicodeDecodeError):
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# チェック項目
+# ---------------------------------------------------------------------------
+
+def check_vite_config():
+    """[5] Vite 設定の確認."""
+    print("\n[1] Vite / ビルド構成")
+
+    vite_path = PORTAL_ROOT / "vite.config.ts"
+    content = read_text(vite_path)
+
+    if not content:
+        check("5", "vite.config.ts が存在する", False)
+        return
+
+    check("5.2", 'base: "./" が設定されている', 'base: "./"' in content or "base: './' " in content)
+    check("5.2", "inlineDynamicImports: true が設定されている", "inlineDynamicImports: true" in content or "inlineDynamicImports:true" in content)
+
+
+def check_powerpages_config():
+    """[5.3] powerpages.config.json."""
+    config_path = PORTAL_ROOT / "powerpages.config.json"
+    content = read_text(config_path)
+
+    if not content:
+        check("5.3", "powerpages.config.json が存在する", False)
+        return
+
+    check("5.3", "powerpages.config.json が存在する", True)
+    try:
+        cfg = json.loads(content)
+        compiled_path = cfg.get("compiledPath", "")
+        check("5.3", f"compiledPath='{compiled_path}' と dist-site/ が一致", compiled_path == "dist-site")
+    except json.JSONDecodeError:
+        check("5.3", "powerpages.config.json が有効な JSON", False)
+
+
+def check_router():
+    """[5.1] HashRouter の使用確認."""
+    print("\n[2] ルーター")
+
+    tsx_files = find_files(SRC_DIR, "*.tsx") + find_files(SRC_DIR, "*.ts")
+    has_hash_router = False
+    has_browser_router = False
+
+    for f in tsx_files:
+        content = read_text(f)
+        if "HashRouter" in content:
+            has_hash_router = True
+        if "BrowserRouter" in content:
+            has_browser_router = True
+
+    check("5.1", "HashRouter を使用している", has_hash_router)
+    if has_browser_router:
+        check("5.1", "BrowserRouter を使用していない（History API は 404）", False)
+
+
+def check_api_patterns():
+    """[3] API 設計パターンの確認."""
+    print("\n[3] API 設計パターン (api.ts)")
+
+    api_path = SRC_DIR / "lib" / "api.ts"
+    content = read_text(api_path)
+
+    if not content:
+        check("3.1", "src/lib/api.ts が存在する", False)
+        return
+
+    check("3.1", "共有クライアント api.ts が存在する", True)
+    check("3.3", 'credentials: "same-origin" を使用', '"same-origin"' in content)
+    check("3.3", 'credentials: "include" を使用していない（NG）',
+          '"include"' not in content or "// include" in content, warn_only=True)
+    check("3.4", 'redirect: "manual" を使用', '"manual"' in content)
+    check("3.2", "__RequestVerificationToken 取得ロジックがある",
+          "__RequestVerificationToken" in content or "RequestVerificationToken" in content)
+
+
+def check_createdby_standard():
+    """[1.1, 3.5] CreatedBy 標準の遵守確認."""
+    print("\n[4] CreatedBy 標準")
+
+    tsx_files = find_files(SRC_DIR, "*.tsx") + find_files(SRC_DIR, "*.ts")
+
+    # カスタム reporter @odata.bind パターンを探す
+    reporter_bind_pattern = re.compile(r'(reporter|inquirer|reportedby).*@odata\.bind', re.IGNORECASE)
+    # カスタム reporter Lookup 使用パターン
+    reporter_lookup_pattern = re.compile(r'_geek_(reporter|inquirer)id_value', re.IGNORECASE)
+    # createdby の正しい使用
+    createdby_pattern = re.compile(r'_createdby_value')
+
+    violations = []
+    uses_createdby = False
+
+    for f in tsx_files:
+        content = read_text(f)
+        if reporter_bind_pattern.search(content):
+            violations.append(f"  → {f.relative_to(PORTAL_ROOT)}: @odata.bind にカスタム reporter")
+        if reporter_lookup_pattern.search(content):
+            violations.append(f"  → {f.relative_to(PORTAL_ROOT)}: カスタム reporter Lookup 参照")
+        if createdby_pattern.search(content):
+            uses_createdby = True
+
+    check("1.1", "カスタム reporter @odata.bind を使用していない", len(violations) == 0)
+    if violations:
+        for v in violations:
+            print(f"    {v}")
+
+    check("3.5", "報告者表示に _createdby_value を使用している", uses_createdby)
+
+
+def check_auth_design():
+    """[2] 認証設計の確認."""
+    print("\n[5] 認証設計")
+
+    tsx_files = find_files(SRC_DIR, "*.tsx") + find_files(SRC_DIR, "*.ts")
+
+    queries_contacts_api = False
+    uses_portal_user = False
+
+    for f in tsx_files:
+        content = read_text(f)
+        # /_api/contacts を認証判定に使っているか
+        if re.search(r'/_api/contacts\??.*\$select.*contactid', content):
+            queries_contacts_api = True
+        if "Portal.User" in content or "Dynamic365.Portal.User" in content:
+            uses_portal_user = True
+
+    check("2.2", "認証判定で /_api/contacts をクエリしていない", not queries_contacts_api)
+    check("2.1", "Portal.User を認証判定に使用している", uses_portal_user)
+
+
+# ---------------------------------------------------------------------------
+# メイン
+# ---------------------------------------------------------------------------
+
+def main():
+    print("╔══════════════════════════════════════════════════╗")
+    print("║  Power Pages 設計前レビュー (ローカル静的チェック) ║")
+    print("╚══════════════════════════════════════════════════╝")
+
+    check_vite_config()
+    check_powerpages_config()
+    check_router()
+    check_api_patterns()
+    check_createdby_standard()
+    check_auth_design()
+
+    # サマリー
+    pass_count = sum(1 for r in results if r[0] == "PASS")
+    fail_count = sum(1 for r in results if r[0] == "FAIL")
+    warn_count = sum(1 for r in results if r[0] == "WARN")
+
+    print("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    print(f"結果: {pass_count} PASS, {fail_count} FAIL, {warn_count} WARN")
+    print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+    if fail_count > 0:
+        print(f"\n{FAIL} {fail_count} 件の不合格項目があります。設計を見直してください。")
+        sys.exit(1)
+    elif warn_count > 0:
+        print(f"\n{WARN} 警告がありますが続行可能です。")
+        sys.exit(0)
+    else:
+        print(f"\n{PASS} 全項目合格。実装に進めます。")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

Power Pages の品質を標準的に維持するための 2 つのレビュースキル（品質ゲート）を追加。

## 追加ファイル

| ファイル | 役割 |
|----------|------|
| `reviews/pre-design-review.md` | 設計前レビュー チェック項目一覧（14項目） |
| `reviews/pre-deploy-review.md` | デプロイ前レビュー チェック項目一覧（20項目） |
| `scripts/review_pre_design.py` | 設計前レビュー自動チェックスクリプト |
| `scripts/review_pre_deploy.py` | デプロイ前レビュー自動チェックスクリプト |

## 設計前レビュー

タイミング: テーブル設計完了後、SPA 実装開始前。Dataverse 接続不要。

チェック: CreatedBy標準 / HashRouter / api.tsパターン / Portal.User認証 / Vite設定

## デプロイ前レビュー

タイミング: npm run build 後、pac pages upload-code-site 前。

チェック: dist出力整合性 / pac auth環境一致 / テーブル権限(languageid, webrole, N:N) / サイト設定

## 標準フロー

設計前レビュー -> 実装 -> ビルド -> デプロイ前レビュー -> デプロイ
