### PR TITLE
fix(portal): 報告者を geek_inquirerid (contact Lookup) に変更

### DIFF
--- a/portal/src/lib/api.ts
+++ b/portal/src/lib/api.ts
@@ -129,9 +129,7 @@ export interface Incident {
   modifiedon?: string;
   // lookup formatted values (Prefer: odata.include-annotations)
   "_geek_inquirerid_value@OData.Community.Display.V1.FormattedValue"?: string;
-  "_geek_assignedtoid_value@OData.Community.Display.V1.FormattedValue"?: string;
   _geek_inquirerid_value?: string;
-  _geek_assignedtoid_value?: string;
   [key: string]: unknown;
 }
 
@@ -146,7 +144,7 @@ export interface IncidentCreate {
 
 // ── CRUD ──
 const INCIDENT_SELECT =
-  "geek_incidentid,geek_name,geek_description,geek_status,geek_priority,geek_category,geek_ticketnumber,geek_resolution,geek_resolvedon,_geek_inquirerid_value,_geek_assignedtoid_value,createdon";
+  "geek_incidentid,geek_name,geek_description,geek_status,geek_priority,geek_category,geek_ticketnumber,geek_resolution,geek_resolvedon,_geek_inquirerid_value,createdon";
 
 export async function getIncidents(): Promise<Incident[]> {
   const data = await apiGet<ODataCollection<Incident>>(

--- a/portal/src/pages/incident-detail.tsx
+++ b/portal/src/pages/incident-detail.tsx
@@ -165,12 +165,7 @@ export default function IncidentDetailPage() {
           <InfoItem
             icon={User}
             label="報告者"
-            value={incident.geek_reportedby}
-          />
-          <InfoItem
-            icon={User}
-            label="担当者"
-            value={incident.geek_assignedto}
+            value={incident["_geek_inquirerid_value@OData.Community.Display.V1.FormattedValue"]}
           />
           <InfoItem
             icon={Monitor}

--- a/portal/src/pages/incident-new.tsx
+++ b/portal/src/pages/incident-new.tsx
@@ -35,7 +35,9 @@ export default function IncidentNewPage() {
       geek_status: 100000000, // 新規
       geek_priority: parseInt(priority),
       geek_assettype: assetType ? parseInt(assetType) : undefined,
-      geek_reportedby: user?.fullName || undefined,
+      ...(user?.contactId
+        ? { "geek_inquirerid@odata.bind": `/contacts(${user.contactId})` }
+        : {}),
     };
 
     try {
@@ -140,17 +142,6 @@ export default function IncidentNewPage() {
               ))}
             </select>
           </div>
-        </div>
-
-        {/* 報告者（自動入力） */}
-        <div className="space-y-1.5">
-          <label className="text-sm font-medium text-foreground">報告者</label>
-          <input
-            type="text"
-            value={user?.fullName ?? ""}
-            disabled
-            className="w-full h-10 px-3 rounded-lg border border-border/60 bg-muted text-sm text-muted-foreground"
-          />
         </div>
 
         {/* 送信ボタン */}

--- a/portal/src/pages/incidents.tsx
+++ b/portal/src/pages/incidents.tsx
@@ -57,7 +57,7 @@ export default function IncidentsPage() {
       list = list.filter(
         (i) =>
           i.geek_title.toLowerCase().includes(q) ||
-          i.geek_reportedby?.toLowerCase().includes(q),
+          (i["_geek_inquirerid_value@OData.Community.Display.V1.FormattedValue"] as string | undefined)?.toLowerCase().includes(q),
       );
     }
     return list;
@@ -232,7 +232,7 @@ export default function IncidentsPage() {
               </div>
 
               <div className="flex items-center justify-between text-xs text-muted-foreground">
-                <span>{item.geek_reportedby ?? "—"}</span>
+                <span>{(item["_geek_inquirerid_value@OData.Community.Display.V1.FormattedValue"] as string) ?? "—"}</span>
                 <span>
                   {item.createdon
                     ? new Date(item.createdon).toLocaleDateString("ja-JP")


### PR DESCRIPTION
## 変更内容
Power Pages ポータルのインシデント報告者をテキスト列から contact Lookup に変更。

### 背景
- geek_reportedby (Text) / geek_assignedto (Text) は手動入力で不正確
- createdby (systemuser) は Power Pages ではサービスアカウントがセットされるため不適切
- geek_inquirerid (contact Lookup) でログインユーザーの contact を正しく記録

### 変更ファイル
- portal/src/lib/api.ts: Incident 型を geek_inquirerid Lookup に統一
- portal/src/pages/incident-new.tsx: contactId で odata.bind を自動バインド
- portal/src/pages/incidents.tsx: 検索とカード表示を FormattedValue に変更
- portal/src/pages/incident-detail.tsx: 報告者を FormattedValue 表示に変更