### PR TITLE
fix: Power Pages deploy/activation - PP API version 2022-03-01-preview

### DIFF
--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -282,7 +282,7 @@ create_table_permission(
 ## 核心原則
 
 1. **`pac pages upload-code-site` がサイト作成とデプロイの両方を行う** — API でサイトを事前作成する必要はない
-2. **初回は Inactive Sites に作成される** → Power Pages ポータル or PP API でアクティブ化
+2. **初回は Inactive Sites に作成される** → PP API (`2022-03-01-preview`) で `activate_site.py` を使ってアクティブ化
 3. **2回目以降は upload-code-site → restart の2ステップだけ**
 4. **Post-Upload Fix は不要** — `upload-code-site` が header/footer/page を正しく構成する
 5. **`.powerpages-site/` は upload-code-site が自動管理する** — ただし `site-settings/` YAML は手動追加して永続化できる（下記参照）
@@ -295,11 +295,51 @@ create_table_permission(
 
 ```
 初回:
-  npm run build → pac pages upload-code-site → Activate → setup_contact_webapi.py → Restart
+  npm run build
+  → pac pages upload-code-site          ← Inactive Sites に作成
+  → py portal/scripts/activate_site.py  ← PP API でアクティブ化 (api-version=2022-03-01-preview)
+  → py portal/scripts/setup_contact_webapi.py
+  → Restart (deploy.py --skip-build or PP API restart)
 
 2回目以降:
   npm run build → pac pages upload-code-site → Restart
+  (deploy.py がビルド・アップロード・リスタートを一括実行)
 ```
+
+### アクティベーション詳細
+
+> **参照**: [microsoft/power-platform-skills activate-site](https://github.com/microsoft/power-platform-skills/tree/main/plugins/power-pages/skills/activate-site)
+
+初回の `pac pages upload-code-site` はサイトを **Inactive Sites** に作成する。
+アクティブ化は **Power Platform API** (`api-version=2022-03-01-preview`) で行う。
+
+```
+POST https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites?api-version=2022-03-01-preview
+
+Body:
+{
+  "name": "<PAGES_SITE_NAME>",
+  "subdomain": "<PAGES_SUBDOMAIN>",
+  "templateName": "DefaultPortalTemplate",
+  "dataverseOrganizationId": "<org_id>",
+  "selectedBaseLanguage": 1033,
+  "websiteRecordId": "<powerpagesiteid>"     ← pac pages upload-code-site が作った ID
+}
+
+Response: 202 Accepted + Operation-Location ヘッダー
+→ Operation-Location を 10 秒間隔でポーリング
+→ OperationComplete = 成功、OperationFailed = 失敗
+```
+
+| パラメータ | 取得方法 |
+|---|---|
+| `ENV_ID` | .env |
+| `PAGES_SITE_NAME` | .env / powerpages.config.json の siteName |
+| `PAGES_SUBDOMAIN` | .env / ユーザー指定 |
+| `dataverseOrganizationId` | `GET /api/data/v9.2/organizations?$select=organizationid` |
+| `websiteRecordId` | `GET /api/data/v9.2/powerpagesites` から name で検索 |
+
+**⚠️ API バージョン注意**: `2022-03-01-preview` を使用すること。`2024-10-01` ではアクティベーションが正しく動作しない。
 
 ## 前提条件
 
@@ -314,6 +354,8 @@ create_table_permission(
 ```env
 DATAVERSE_URL=https://{org}.crm.dynamics.com/
 ENV_ID=                               # Power Platform 環境 ID
+PAGES_SITE_NAME=                      # サイト名 (powerpages.config.json の siteName と一致)
+PAGES_SUBDOMAIN=                      # サブドメイン (例: myportal → myportal.powerappsportals.com)
 ```
 
 ## プロジェクト構造（公式準拠）
@@ -663,9 +705,19 @@ npm run build
 pac pages upload-code-site --rootPath .
 ```
 
-### 2-C: サイトのアクティブ化
+### 2-C: サイトのアクティブ化（PP API 経由）
 
-Power Pages ポータルの Inactive sites から **再アクティブ化** をクリック。
+```bash
+py portal/scripts/activate_site.py
+```
+
+スクリプトが以下を自動実行:
+1. PP API でサイトが既にアクティブか確認
+2. Dataverse から Organization ID と Website Record ID を取得
+3. パラメータ確認後、PP API に POST
+4. Operation-Location をポーリングして完了待ち（最大 5 分）
+
+> カスタムサブドメインを指定する場合: `py portal/scripts/activate_site.py --subdomain my-portal`
 
 ### 2-D: Contact Web API 有効化（★初回必須）
 

--- a/portal/scripts/activate_site.py
+++ b/portal/scripts/activate_site.py
@@ -1,0 +1,264 @@
+"""Power Pages Code Site: Activate (Provision) via PP API
+
+Activates an inactive Power Pages site by calling the Power Platform
+websites API. Equivalent to microsoft/power-platform-skills activate-site.js.
+
+Usage:
+    py portal/scripts/activate_site.py [--subdomain <name>]
+
+Reads from .env:
+    ENV_ID              - Power Platform environment ID
+    PAGES_SITE_NAME     - Site name (from powerpages.config.json)
+    PAGES_SUBDOMAIN     - Subdomain for the site URL (or pass --subdomain)
+
+References:
+    - API version: 2022-03-01-preview (NOT 2024-10-01)
+    - Template: DefaultPortalTemplate
+    - microsoft/power-platform-skills/plugins/power-pages/skills/activate-site/
+"""
+import json, logging, os, sys, time
+
+logging.disable(logging.INFO)
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PORTAL_DIR = os.path.dirname(SCRIPT_DIR)
+ROOT_DIR = os.path.dirname(PORTAL_DIR)
+
+sys.path.insert(0, os.path.join(ROOT_DIR, ".github", "skills", "standard", "scripts"))
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(ROOT_DIR, ".env"))
+import auth_helper, requests
+
+# ---------- Constants ----------
+API_VERSION = "2022-03-01-preview"
+POLL_INTERVAL_SEC = 10
+MAX_POLL_ATTEMPTS = 30  # 30 x 10s = 5 minutes
+
+# ---------- Env / args ----------
+ENV_ID = os.environ["ENV_ID"]
+SITE_NAME = os.environ.get("PAGES_SITE_NAME", "IncidentPortal")
+
+# --subdomain from CLI overrides .env
+SUBDOMAIN = ""
+for i, arg in enumerate(sys.argv):
+    if arg == "--subdomain" and i + 1 < len(sys.argv):
+        SUBDOMAIN = sys.argv[i + 1]
+if not SUBDOMAIN:
+    SUBDOMAIN = os.environ.get("PAGES_SUBDOMAIN", "")
+
+
+def get_organization_id() -> str:
+    """Retrieve Dataverse organization ID."""
+    t = auth_helper.get_token()
+    dv = os.environ["DATAVERSE_URL"].rstrip("/")
+    r = requests.get(
+        f"{dv}/api/data/v9.2/organizations?$select=organizationid",
+        headers={"Authorization": f"Bearer {t}", "Accept": "application/json"},
+    )
+    r.raise_for_status()
+    orgs = r.json().get("value", [])
+    if not orgs:
+        print("ERROR: Could not retrieve organization ID")
+        sys.exit(1)
+    return orgs[0]["organizationid"]
+
+
+def get_website_record_id() -> str | None:
+    """Find the Dataverse website record ID from powerpagesites table."""
+    t = auth_helper.get_token()
+    dv = os.environ["DATAVERSE_URL"].rstrip("/")
+    r = requests.get(
+        f"{dv}/api/data/v9.2/powerpagesites?$select=powerpagesiteid,name",
+        headers={"Authorization": f"Bearer {t}", "Accept": "application/json"},
+    )
+    r.raise_for_status()
+    for site in r.json().get("value", []):
+        if site.get("name", "").lower() == SITE_NAME.lower():
+            return site["powerpagesiteid"]
+    return None
+
+
+def check_already_activated() -> dict | None:
+    """Check if site is already activated in PP API."""
+    t = auth_helper.get_token(scope="https://api.powerplatform.com/.default")
+    h = {"Authorization": f"Bearer {t}", "Accept": "application/json"}
+    url = f"https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites?api-version={API_VERSION}"
+    r = requests.get(url, headers=h)
+    if r.status_code != 200:
+        return None
+    for site in r.json().get("value", []):
+        name_match = site.get("name", "").lower() == SITE_NAME.lower()
+        sub_match = SUBDOMAIN and site.get("subdomain", "").lower() == SUBDOMAIN.lower()
+        if name_match or sub_match:
+            return site
+    return None
+
+
+def activate(org_id: str, website_record_id: str | None) -> dict:
+    """POST to PP API to provision the site. Returns the poll result."""
+    t = auth_helper.get_token(scope="https://api.powerplatform.com/.default")
+    h = {
+        "Authorization": f"Bearer {t}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    url = f"https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites?api-version={API_VERSION}"
+
+    body = {
+        "name": SITE_NAME,
+        "subdomain": SUBDOMAIN,
+        "templateName": "DefaultPortalTemplate",
+        "dataverseOrganizationId": org_id,
+        "selectedBaseLanguage": 1033,
+    }
+    if website_record_id:
+        body["websiteRecordId"] = website_record_id
+
+    print(f"  POST {url}")
+    print(f"  Body: {json.dumps(body, indent=2)}")
+
+    r = requests.post(url, headers=h, json=body)
+    print(f"  Status: {r.status_code}")
+
+    if r.status_code != 202:
+        try:
+            err = r.json()
+            msg = err.get("error", {}).get("message", r.text[:500])
+        except Exception:
+            msg = r.text[:500]
+        return {"status": "Failed", "statusCode": r.status_code, "error": msg}
+
+    # Extract Operation-Location header
+    op_loc = r.headers.get("Operation-Location", "")
+    if not op_loc:
+        return {"status": "Failed", "error": "202 but no Operation-Location header"}
+
+    # Ensure api-version is in the poll URL
+    if "api-version" not in op_loc:
+        sep = "&" if "?" in op_loc else "?"
+        op_loc += f"{sep}api-version={API_VERSION}"
+
+    print(f"  Polling: {op_loc}")
+    site_url = f"https://{SUBDOMAIN}.powerappsportals.com"
+
+    for attempt in range(1, MAX_POLL_ATTEMPTS + 1):
+        time.sleep(POLL_INTERVAL_SEC)
+
+        # Refresh token periodically
+        if attempt % 6 == 0:
+            t = auth_helper.get_token(scope="https://api.powerplatform.com/.default")
+
+        try:
+            pr = requests.get(
+                op_loc,
+                headers={"Authorization": f"Bearer {t}", "Accept": "application/json"},
+            )
+            ps = pr.json()
+        except Exception:
+            print(f"  [{attempt}] poll error")
+            continue
+
+        status = ps.get("operationStatus", ps.get("status", "?"))
+        print(f"  [{attempt}] {status}")
+
+        if status == "OperationComplete":
+            return {
+                "status": "Succeeded",
+                "siteUrl": ps.get("websiteUrl", site_url),
+                "siteName": SITE_NAME,
+                "subdomain": SUBDOMAIN,
+            }
+        if status == "OperationFailed":
+            err_msg = (
+                ps.get("error", {}).get("message", "")
+                or json.dumps(ps)[:500]
+            )
+            return {"status": "Failed", "error": f"Provisioning failed: {err_msg}"}
+
+    return {
+        "status": "Running",
+        "message": "Provisioning still in progress after 5 minutes. Check admin center.",
+        "siteUrl": site_url,
+    }
+
+
+def main():
+    if not SUBDOMAIN:
+        print("ERROR: PAGES_SUBDOMAIN not set. Set in .env or pass --subdomain <name>")
+        sys.exit(1)
+
+    print("=" * 60)
+    print(f"Power Pages Code Site Activation")
+    print(f"  Site Name:  {SITE_NAME}")
+    print(f"  Subdomain:  {SUBDOMAIN}")
+    print(f"  API:        {API_VERSION}")
+    print("=" * 60)
+
+    # Phase 1: Check if already activated
+    print("\n[1/4] Checking activation status...")
+    existing = check_already_activated()
+    if existing and existing.get("status") not in ("StateDeletingApplication",):
+        site_url = existing.get("websiteUrl", f"https://{SUBDOMAIN}.powerappsportals.com")
+        print(f"  Site already activated: {site_url}")
+        print(f"  Status: {existing.get('status')}")
+        print("\n  Use deploy.py to redeploy and restart.")
+        return
+
+    # Phase 2: Gather parameters
+    print("\n[2/4] Gathering parameters...")
+    org_id = get_organization_id()
+    print(f"  Organization ID: {org_id}")
+
+    website_record_id = get_website_record_id()
+    if website_record_id:
+        print(f"  Website Record ID: {website_record_id}")
+    else:
+        print("  Website Record ID: (none — will create new)")
+
+    # Phase 3: Confirm
+    print(f"\n[3/4] Activation parameters:")
+    print(f"  Site Name:          {SITE_NAME}")
+    print(f"  Subdomain:          {SUBDOMAIN}.powerappsportals.com")
+    print(f"  Organization ID:    {org_id}")
+    print(f"  Environment ID:     {ENV_ID}")
+    print(f"  Website Record ID:  {website_record_id or '(new)'}")
+    print(f"  Template:           DefaultPortalTemplate")
+    print(f"  Language:           1033 (English)")
+
+    confirm = input("\n  Proceed with activation? (y/N): ").strip().lower()
+    if confirm not in ("y", "yes"):
+        print("  Cancelled.")
+        return
+
+    # Phase 4: Activate & Poll
+    print("\n[4/4] Activating...")
+    result = activate(org_id, website_record_id)
+
+    # Phase 5: Summary
+    print("\n" + "=" * 60)
+    if result["status"] == "Succeeded":
+        print("Activation SUCCEEDED!")
+        print(f"  Site URL:  {result['siteUrl']}")
+        print(f"  Site Name: {result['siteName']}")
+        print()
+        print("Next steps:")
+        print("  1. Wait 60-90 seconds for DNS propagation")
+        print("  2. Run: py portal/scripts/setup_contact_webapi.py")
+        print("  3. Run: py portal/scripts/deploy.py --skip-build")
+    elif result["status"] == "Running":
+        print("Activation IN PROGRESS (timed out waiting)")
+        print(f"  {result['message']}")
+        print(f"  Expected URL: {result.get('siteUrl', '?')}")
+    else:
+        print("Activation FAILED")
+        print(f"  Status Code: {result.get('statusCode', '?')}")
+        print(f"  Error: {result.get('error', '?')}")
+        if result.get("statusCode") == 400 and "subdomain" in str(result.get("error", "")).lower():
+            print("\n  The subdomain may already be taken. Try a different one:")
+            print(f"    py portal/scripts/activate_site.py --subdomain <new-name>")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/portal/scripts/deploy.py
+++ b/portal/scripts/deploy.py
@@ -32,7 +32,7 @@ def ask_subdomain():
     t = auth_helper.get_token(scope="https://api.powerplatform.com/.default")
     h = {"Authorization": f"Bearer {t}", "Content-Type": "application/json"}
     base = f"https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites"
-    r = requests.get(f"{base}?api-version=2024-10-01", headers=h)
+    r = requests.get(f"{base}?api-version=2022-03-01-preview", headers=h)
     sites = r.json().get("value", [])
     if not sites:
         print("  環境にサイトが見つかりません。PAGES_SUBDOMAIN を .env に手動設定してください。")
@@ -106,14 +106,14 @@ def main():
         t = auth_helper.get_token(scope="https://api.powerplatform.com/.default")
         h = {"Authorization": f"Bearer {t}", "Content-Type": "application/json"}
         base = f"https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites"
-        r = requests.get(f"{base}?api-version=2024-10-01", headers=h)
+        r = requests.get(f"{base}?api-version=2022-03-01-preview", headers=h)
         site_found = False
         for s in r.json().get("value", []):
             match = (SUBDOMAIN and s.get("subdomain") == SUBDOMAIN) or \
                     (not SUBDOMAIN and s.get("name", "").startswith(SITE_NAME))
             if match:
                 sid = s["id"]
-                rr = requests.post(f"{base}/{sid}/restart?api-version=2024-10-01", headers=h)
+                rr = requests.post(f"{base}/{sid}/restart?api-version=2022-03-01-preview", headers=h)
                 print(f"  Restart: {rr.status_code}")
                 print(f"  URL: {s.get('websiteUrl')}")
                 site_found = True


### PR DESCRIPTION
## 概要

microsoft/power-platform-skills の activate-site.js 実装に基づき、Power Pages Code Site のデプロイ・アクティベーション手順を修正。

## 問題

- `deploy.py` の PP API 呼び出しが `api-version=2024-10-01` を使用 → アクティベーションが正しく動作しない
- アクティベーション手順が「ポータルからクリック」のみ → API 経由の自動化不可
- SKILL.md にアクティベーション API の詳細仕様が未記載

## 修正内容

### 1. `portal/scripts/deploy.py`
- PP API バージョンを `2024-10-01` → `2022-03-01-preview` に修正（3箇所）

### 2. `portal/scripts/activate_site.py` (新規)
- PP API 経由のサイトアクティベーションスクリプト
- microsoft/power-platform-skills の `activate-site.js` と同等の機能
- フロー: 状態確認 → パラメータ収集 → 確認 → POST → ポーリング → 結果表示
- `DefaultPortalTemplate` + `websiteRecordId` + `Operation-Location` ポーリング

### 3. `.github/skills/power-pages/SKILL.md`
- ワークフロー図を更新（activate_site.py を使用）
- アクティベーション API の詳細仕様を追記
- Step 2-C を PP API 経由に変更
- .env パラメータに `PAGES_SITE_NAME` と `PAGES_SUBDOMAIN` を追加

## 参照
- [microsoft/power-platform-skills activate-site SKILL.md](https://github.com/microsoft/power-platform-skills/tree/main/plugins/power-pages/skills/activate-site)
- [activate-site.js](https://github.com/microsoft/power-platform-skills/tree/main/plugins/power-pages/skills/activate-site/scripts/activate-site.js)
- API: `POST /powerpages/environments/{envId}/websites?api-version=2022-03-01-preview`
