### PR TITLE
fix(power-pages): Webapi/* はEDM 2.0でも必須に教訓修正＋テンプレート不具合修正

### DIFF
--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -196,9 +196,13 @@ triggers:
 ```
 
 **SPA 側のリダイレクト復元パターン:**
-1. ログイン前: `sessionStorage.setItem("pp_return_hash", location.hash)` で保存
+1. ログイン前: `sessionStorage.setItem("pp_return_hash", location.hash)` で保存（`use-auth.ts` の `login()`）
 2. `returnUrl: "/"` でルートに戻す
-3. SPA 初期化時: `RestoreRoute` コンポーネントで `sessionStorage` から復元 → `navigate()`
+3. SPA 初期化時: `RestoreRoute` コンポーネントで `sessionStorage` から復元 → `navigate(target, { replace: true })`
+
+> ⚠️ **保存と復元はセット**: 手順 1 の保存だけでは往復が完成せず、ログイン後にディープリンク
+> （例: `#/incidents/123`）がホームに化ける。`App.tsx` の `<HashRouter>` 直下に `RestoreRoute`
+> を必ず配置すること（corporate-lp テンプレートに実装済み）。
 
 ---
 
@@ -226,14 +230,48 @@ triggers:
 
 ---
 
-### 教訓 8: EDM 2.0 Code Site では Webapi/* Site Settings は不要
+### 教訓 8: EDM 2.0 Code Site でも Webapi/* Site Settings は必須（カスタムテーブル含む）
 
 ```
-❌ NG: Webapi/contact/enabled, Webapi/contact/fields 等を作成
-       → EDM 2.0 では不要。Standard Data Model (SDM) の legacy 設定。
+❌ NG: type=18 テーブル権限（adx_entitypermission_webrole + N:N リンク）だけ設定
+       → 認可は通るが /_api/{table} エンドポイント自体が公開されず 404 (9004010C)
 
-✅ OK: powerpagecomponent type=18（テーブル権限）の content JSON だけで制御される
+✅ OK: アクセスする全テーブルに以下の 2 設定を追加する（カスタムテーブルも必須）
+       - Webapi/{table}/enabled = true
+       - Webapi/{table}/fields  = *          ← または公開する列をカンマ区切りで列挙
 ```
+
+**type=18 テーブル権限と Webapi/* 設定は役割が異なり、両方必要:**
+
+| レイヤー | 役割 | 無いと |
+|---|---|---|
+| `powerpagecomponent` type=18（テーブル権限） | **認可**（誰がどの操作をできるか） | 403 EntityPermission* |
+| `Webapi/{table}/enabled` + `/fields` | **エンドポイント公開**（`/_api/{table}` を有効化） | **404 (9004010C)** |
+
+> **実証（本リポジトリの IncidentPortal セッション）**: 新規 EDM 2.0 Code Site で
+> `geek_m365service` / `geek_m365incident` / `geek_inquiry` の type=18 権限を正しく
+> デプロイ・検証済みでも `/_api/geek_m365services` は **404**。`Webapi/{table}/enabled=true`
+> と `Webapi/{table}/fields=*` を追加して restart した直後に **404 → 302**（未認証リダイレクト＝
+> エンドポイント解決成功）に変化した。`scripts/setup_permissions.py` も全テーブルに対して
+> この 2 設定を作成しており、`operations-and-pitfalls.md` の「Web API が 404 → Webapi/{table}/enabled
+> 未設定」とも一致する。**Webapi/* は Contact 専用のレガシー設定ではなく、カスタムテーブルにも必須。**
+
+**`.powerpages-site/site-settings/` に YAML で永続化（upload-code-site で再デプロイされる）:**
+
+```yaml
+# .powerpages-site/site-settings/Webapi-geek_m365service-enabled.sitesetting.yml
+id: <UUID v4>
+name: Webapi/geek_m365service/enabled
+value: "true"
+---
+# .powerpages-site/site-settings/Webapi-geek_m365service-fields.sitesetting.yml
+id: <UUID v4>
+name: Webapi/geek_m365service/fields
+value: "*"
+```
+
+> デバッグ時は `Webapi/error/innererror = true` も追加すると `/_api/` のエラーレスポンスに
+> `innererror` が含まれ原因特定が容易になる。
 
 ---
 
@@ -690,12 +728,13 @@ name: Authenticated Users
 
 ---
 
-## ★ Contact テーブル Web API 有効化 (EDM 2.0)
+## ★ テーブル Web API 有効化 (EDM 2.0 — Contact / カスタムテーブル共通)
 
-> ⚠️ **EDM 2.0 では `Webapi/*` Site Settings は不要**（教訓 2 参照）。
-> geeksupport（動作済み参考サイト）は Webapi/* 設定なしで全テーブルにアクセス可能。
-> 以下の手順は **Standard Data Model (SDM) のレガシーパターン** であり、
-> 新規 Code Site では `mspp_entitypermissions` + `mspp_webroles` N:N だけで十分。
+> ✅ **EDM 2.0 Code Site でも `Webapi/{table}/enabled` + `Webapi/{table}/fields` は必須**（教訓 8 参照）。
+> Contact だけでなく **カスタムテーブルにも適用される**。type=18 テーブル権限は「認可」、
+> Webapi/* 設定は「`/_api/{table}` エンドポイントの公開」で役割が異なり、両方そろって初めて
+> `/_api/` が 200 を返す。どちらか欠けると 404 (9004010C)。
+> 以下は Contact を例にした手順だが、`contact` を任意のテーブル論理名に置き換えてそのまま使える。
 
 ### 重大な教訓: 404 "Resource not found for the segment contact"
 
@@ -1065,5 +1104,5 @@ SKIP_REMOTE=1 python ../.github/skills/power-pages/scripts/review_pre_deploy.py
 - [ ] HashRouter を使用している
 - [ ] `pac auth` で正しいユーザー・環境に接続されている（教訓 10）
 - [ ] テーブル権限が正しい `powerpagesiteid` に紐づいている（教訓 9）
-- [ ] EDM 2.0: `Webapi/*` Site Settings は不要（教訓 8）
+- [ ] アクセスする全テーブルに `Webapi/{table}/enabled=true` + `Webapi/{table}/fields=*` を設定済み（教訓 8）
 - [ ] `Webapi/error/innererror = true` が開発環境で有効

--- a/.github/skills/power-pages/references/design-system.md
+++ b/.github/skills/power-pages/references/design-system.md
@@ -91,8 +91,13 @@ box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 8px rgba(0,0,0,0.04),
 
 ### Button（グラデーションボタン）
 
-default バリアントは `bg-gradient-to-r from-primary to-accent` で視覚的にリッチ。
+default バリアントは `bg-linear-to-r from-primary to-accent` で視覚的にリッチ。
 ホバー時に `brightness-110` + `shadow-lg`。クリック時に `scale-[0.98]`。
+
+> ⚠️ **Tailwind CSS v4 のグラデーションユーティリティ名に注意**: テンプレートは Tailwind v4 を使用する。
+> v4 では `bg-gradient-to-*` が **`bg-linear-to-*`** にリネームされた（`bg-gradient-to-r` → `bg-linear-to-r`、
+> `bg-gradient-to-br` → `bg-linear-to-br`）。v4 で旧 `bg-gradient-to-*` を書くと**ユーティリティが認識されず
+> グラデーションが描画されない**（エラーも出ないため気づきにくい）。放射状/円錐は `bg-radial-*` / `bg-conic-*`。
 
 | バリアント | 用途 |
 |-----------|------|

--- a/.github/skills/power-pages/references/design-templates.md
+++ b/.github/skills/power-pages/references/design-templates.md
@@ -36,6 +36,25 @@
 
 ---
 
+## 実装共通コードの監査結果（2026-06-05）
+
+`templates/` 配下の実装を走査した結果、コード実体は `templates/corporate-lp` の 1 系統で、以下 5 テンプレート（配色差分）は同一実装を共有する。
+
+| # | テンプレート名 | 実装ディレクトリ |
+|---|---|---|
+| 1 | Indigo / Violet | `templates/corporate-lp` |
+| 2 | Blue / Navy | `templates/corporate-lp` |
+| 3 | Emerald / Teal | `templates/corporate-lp` |
+| 4 | Amber / Orange | `templates/corporate-lp` |
+| 5 | Rose / Pink | `templates/corporate-lp` |
+
+上記 5 テンプレート共通の不具合は、共有実装側で修正済み:
+- `src/components/ui/button.tsx` : `bg-linear-to-r` へ統一（Tailwind CSS v4）
+- `src/components/site-layout.tsx` : `bg-linear-to-br` へ統一（Tailwind CSS v4）
+- `src/App.tsx` : `RestoreRoute` 実装（`pp_return_hash` 復元）
+
+---
+
 ## テンプレート定義
 
 ### 1. Indigo / Violet（デフォルト）

--- a/.github/skills/power-pages/templates/corporate-lp/src/App.tsx
+++ b/.github/skills/power-pages/templates/corporate-lp/src/App.tsx
@@ -1,12 +1,39 @@
-import { HashRouter, Routes, Route } from "react-router-dom";
+import { useEffect } from "react";
+import { HashRouter, Routes, Route, useNavigate } from "react-router-dom";
 import { SiteLayout } from "@/components/site-layout";
 import { RequireAuth } from "@/components/require-auth";
 import HomePage from "@/pages/home";
 import ProfilePage from "@/pages/profile";
 
+/**
+ * ログイン後にサーバーから "/" へ戻された際、ログイン前に
+ * use-auth.ts が sessionStorage("pp_return_hash") へ保存したルートへ復元する。
+ * HashRouter のハッシュ部分はサーバーの returnUrl では保持できないため必須。
+ */
+function RestoreRoute() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    let saved: string | null = null;
+    try {
+      saved = sessionStorage.getItem("pp_return_hash");
+      if (saved) sessionStorage.removeItem("pp_return_hash");
+    } catch {
+      saved = null;
+    }
+    if (saved) {
+      const target = saved.replace(/^#/, ""); // "#/profile" → "/profile"
+      if (target && target !== "/") {
+        navigate(target, { replace: true });
+      }
+    }
+  }, [navigate]);
+  return null;
+}
+
 export default function App() {
   return (
     <HashRouter>
+      <RestoreRoute />
       <Routes>
         <Route element={<SiteLayout />}>
           <Route index element={<HomePage />} />

--- a/.github/skills/power-pages/templates/corporate-lp/src/components/site-layout.tsx
+++ b/.github/skills/power-pages/templates/corporate-lp/src/components/site-layout.tsx
@@ -280,7 +280,7 @@ export function SiteLayout() {
           <div className="flex items-center justify-between h-14">
             {/* ロゴ */}
             <NavLink to="/" className="flex items-center gap-2.5 shrink-0">
-              <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-primary to-accent flex items-center justify-center shadow-md">
+              <div className="h-8 w-8 rounded-lg bg-linear-to-br from-primary to-accent flex items-center justify-center shadow-md">
                 <span className="text-white font-bold text-sm">{SITE_LOGO_MARK}</span>
               </div>
               <span className="text-base font-semibold text-foreground hidden sm:block">

--- a/.github/skills/power-pages/templates/corporate-lp/src/components/ui/button.tsx
+++ b/.github/skills/power-pages/templates/corporate-lp/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-gradient-to-r from-primary to-accent text-primary-foreground shadow-md hover:shadow-lg hover:brightness-110 active:scale-[0.98]",
+          "bg-linear-to-r from-primary to-accent text-primary-foreground shadow-md hover:shadow-lg hover:brightness-110 active:scale-[0.98]",
         destructive: "bg-destructive text-white hover:bg-destructive/90",
         outline:
           "border border-border/60 bg-card shadow-sm hover:bg-accent/10 hover:border-primary/40 hover:text-foreground",


### PR DESCRIPTION
## 概要

実案件（IncidentPortal）でクリーンな **EDM 2.0 Power Pages Code Site** を新規デプロイした際に得た教訓を `power-pages` スキルへ反映し、あわせてテンプレート（`corporate-lp`）の不具合を修正します。

## 背景（実証ログ）

新規 EDM 2.0 Code Site（`m365status`）に対し、`geek_m365service` / `geek_m365incident` / `geek_inquiry` の **type=18 テーブル権限**（`adx_entitypermission_webrole` + Web ロール N:N リンク）を正しくデプロイ・検証済みでも、`/_api/geek_m365services` が **404 (9004010C)** を返しました。

`Webapi/{table}/enabled=true` + `Webapi/{table}/fields=*` を追加して restart した直後に **404 → 302**（未認証リダイレクト＝エンドポイント解決成功）に変化。これは:

- `scripts/setup_permissions.py` が**全テーブル**に対して `Webapi/{table}/enabled` + `/fields` を作成している事実
- `references/operations-and-pitfalls.md` の「Web API が 404 → `Webapi/{table}/enabled` 未設定」

とも一致します。**つまり `SKILL.md` の教訓8（「EDM 2.0 では Webapi/* は不要」）だけが矛盾しており、誤りでした。**

## 変更内容

### 1. `SKILL.md` — 教訓8の訂正（最重要）
- 「EDM 2.0 では Webapi/* は不要」→「**カスタムテーブル含め必須**」に修正。
- type=18 テーブル権限（=**認可**）と `Webapi/*` 設定（=**エンドポイント公開**）は役割が異なり**両方必要**である点を表で明記。欠けると 403 / 404 のどちらになるかを区別。
- 実証ログを根拠として記載。
- `.powerpages-site/site-settings/` での `Webapi-{table}-enabled.sitesetting.yml` 永続化パターン（`upload-code-site` で再デプロイされる）を追記。デバッグ用 `Webapi/error/innererror=true` も言及。

### 2. `SKILL.md` — Contact Web API セクションのヘッダー注記訂正
- 「EDM 2.0 では不要 / Standard Data Model のレガシーパターン」という記述を削除し、**全テーブル共通で必須**に訂正。手順は `contact` を任意のテーブル論理名に置換して流用できる旨を明記。
- 最終チェックリストの「`Webapi/*` は不要（教訓8）」も「全テーブルに `enabled`+`fields` を設定済み」に修正。

### 3. 教訓5（ログイン後リダイレクト）— 往復の完成を明記
- `pp_return_hash` の**保存だけでは往復が完成せず**、`RestoreRoute` での復元が必須である点を警告として追記。

## 他のデザインテンプレートへの指摘・修正

`corporate-lp` は全デザインテンプレート（Indigo/Blue/Emerald/Amber/Rose）の**共通ベース**（テンプレ差分は CSS 変数のみ）であり、以下は全テンプレートに影響します。

### A. Tailwind CSS v4 のグラデーションユーティリティ名（不具合）
テンプレートは `tailwindcss@^4.1.16` を使用していますが、旧 v3 構文が残存していました。v4 では `bg-gradient-to-*` が **`bg-linear-to-*`** にリネームされており、旧構文は**ユーティリティが認識されずグラデーションが描画されません**（エラーも出ない）。

- `components/ui/button.tsx`: `bg-gradient-to-r` → `bg-linear-to-r`（default ボタンのグラデーションが消えていた）
- `components/site-layout.tsx`: ロゴの `bg-gradient-to-br` → `bg-linear-to-br`
- `references/design-system.md`: 記載例を修正 + v4 注記を追加

### B. `RestoreRoute` 未実装（不具合）
`hooks/use-auth.ts` の `login()` は `sessionStorage("pp_return_hash")` に**保存**しますが、`App.tsx` に**復元側が無く**、ログイン後にディープリンク（例 `#/profile`）がホームに化けていました。教訓5の文書化済みパターンに合わせ `App.tsx` の `<HashRouter>` 直下に `RestoreRoute` を実装し、往復を完成させました。

## テスト
- 変更したテンプレート 3 ファイル（`App.tsx` / `button.tsx` / `site-layout.tsx`）の型エラーが無いことを確認。
- Webapi/* 必須の挙動は実案件デプロイで実証（404 → 302）。

## 補足
- `adx_website` の削除禁止など `operations-and-pitfalls.md` の既存ガイドは正確だったため変更なし。
