### PR TITLE
feat(power-pages): corporate-lp に認証UX 3点（ログイン遷移/ログアウト確認/連絡先編集）を既定実装

### DIFF
--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -113,14 +113,17 @@ triggers:
 
 ---
 
-### 教訓 2: EDM 2.0 テーブル権限は content JSON 内の `adx_entitypermission_webrole` が必須
+### 教訓 2: EDM 2.0 テーブル権限は content JSON 内の `adx_entitypermission_webrole` が唯一の正本
 
 ```
 ❌ NG: powerpagecomponent type=18 の content に entitylogicalname/scope/CRUD だけ設定
-       → ランタイムが権限を認識せず 403
+       → content の adx_entitypermission_webrole が空 → ランタイムが権限を認識せず 403
 
-✅ OK: content JSON に adx_entitypermission_webrole（ロール ID 配列）を含める
-       + powerpagecomponent_powerpagecomponent N:N リンクも設定
+❌ NG: powerpagecomponent_powerpagecomponent（自己参照 N:N）に $ref POST して紐付けたつもりになる
+       → 204 が返るが幽霊リンク。content の配列が空のままなので 403 のまま
+
+✅ OK: content JSON に adx_entitypermission_webrole（ロール ID 配列）を含めて PATCH する
+       これがランタイム／Design Studio「ロール」列の唯一の正本
 ```
 
 **Design Studio が書く完全な content JSON:**
@@ -148,9 +151,9 @@ triggers:
 ```
 
 **API で完結する手順:**
-1. `powerpagecomponent` type=18 を POST — content に `adx_entitypermission_webrole` 含む
-2. `powerpagecomponent_powerpagecomponent` N:N で Web Role コンポーネントとリンク
-3. 両方セットで初めてランタイムが認識
+1. `powerpagecomponent` type=18 を POST — content に `adx_entitypermission_webrole`（＋`websiteid`）を含む
+2. 既存権限に後からロールを追加する場合は `content` を GET → 配列にロール ID を冪等追加 → PATCH
+3. ランタイムは content のこの配列のみを読む（N:N `powerpagecomponent_powerpagecomponent` への `$ref` POST は不要・幽霊）
 
 ---
 
@@ -754,7 +757,7 @@ name: Authenticated Users
 | 1 | `adx_sitesettings` | `Webapi/contact/enabled=true` | `adx_websites` |
 | 2 | `adx_sitesettings` | `Webapi/contact/fields=*` | `adx_websites` |
 | 3 | `powerpagecomponent` type=18 | テーブル権限 (Self) | `powerpagesites` + **`powerpagesitelanguages`** |
-| 4 | `powerpagecomponent_powerpagecomponent` N:N | 権限→Web ロール紐付け | type=11 (Authenticated Users) |
+| 4 | type=18 の content JSON | `adx_entitypermission_webrole` に Web ロール ID | type=11 (Authenticated Users) |
 
 ### ⚠️ 致命的な落とし穴: `powerpagesitelanguageid`
 
@@ -810,13 +813,15 @@ PATCH /api/data/v9.2/powerpagecomponents({perm_id})
 create_site_setting("Webapi/contact/enabled", "true", website_id)
 create_site_setting("Webapi/contact/fields", "*", website_id)  # system table は * 推奨
 
-# 2. powerpagecomponent type=18 (★ powerpagesitelanguageid 必須)
+# 2. powerpagecomponent type=18 (★ powerpagesitelanguageid 必須、content に webrole を含める)
 content = json.dumps({
     "entitylogicalname": "contact",
     "entityname": "contact - Self Read Write",
     "scope": 756150004,  # Self (NOT 756150001 which is Contact scope)
     "read": True, "write": True, "create": False,
     "delete": False, "append": False, "appendto": False,
+    "websiteid": adx_website_id,                       # ← 必須
+    "adx_entitypermission_webrole": [auth_role_id],    # ← 必須（ランタイム正本）
 })
 body = {
     "powerpagecomponenttype": 18,
@@ -826,9 +831,10 @@ body = {
     "powerpagesitelanguageid@odata.bind": f"/powerpagesitelanguages({lang_id})",  # ★ 必須！
 }
 
-# 3. Authenticated Users (type=11) への N:N リンク
-POST /powerpagecomponents({perm_id})/powerpagecomponent_powerpagecomponent/$ref
-{"@odata.id": "/api/data/v9.2/powerpagecomponents({role_id})"}
+# 3. 既存権限に後からロールを追加する場合は content を PATCH（N:N $ref は使わない）
+#   GET .../powerpagecomponents({perm_id})?$select=content → JSON パース
+#   content["adx_entitypermission_webrole"] に role_id を冪等追加 →
+#   PATCH .../powerpagecomponents({perm_id})  {"content": json.dumps(content)}
 ```
 
 > ⚠️ **よくあるミス（修正済み）:**

--- a/.github/skills/power-pages/references/authentication.md
+++ b/.github/skills/power-pages/references/authentication.md
@@ -165,6 +165,22 @@ export function useAuth() {
         },
         loading: false,
       });
+
+      // ── ログイン完了後、元のページ（ハッシュ）へ戻す ──
+      // Power Pages の returnUrl はサーバーパス（Code Site では "/"）なので、
+      // SPA 内のルート（ハッシュ）はクライアント側で復元する。
+      // → 「profile を経由せず、もとのページに戻る」を実現。
+      // ※ サーバー側でも Authentication/Registration/ProfileRedirectEnabled=false が必須
+      //   （setup_auth.py で設定。これがないと既定で /profile へ誘導される）。
+      const savedHash = sessionStorage.getItem("pp_return_hash");
+      if (savedHash) {
+        sessionStorage.removeItem("pp_return_hash");
+        const current = window.location.hash;
+        const atRoot = !current || current === "#" || current === "#/";
+        if (atRoot && savedHash !== current) {
+          window.location.hash = savedHash;
+        }
+      }
     } else {
       setState({ isAuthenticated: false, user: null, loading: false });
     }
@@ -267,6 +283,13 @@ export function useAuth() {
 
 ヘッダーで認証状態に応じてボタンを出し分ける。`useAuth` の `login` / `logout` を呼ぶだけ。
 
+> **デザインテンプレート既定の認証 UX（3 点）**:
+> 1. **ログイン遷移**: クラシックページを経由せず `ExternalLogin` に直接 POST → SSO。
+>    完了後は `pp_return_hash` でログイン前のページに戻る（`/profile` を経由しない）。
+> 2. **ログアウト遷移**: 「ログアウトしますか？」の確認モーダル → 確認後すぐ LP（ルート `/`）へ。
+> 3. **連絡先情報の編集**: ヘッダーに `UserCog` アイコンを表示 → クリックで取引先担当者（contact）編集ページへ。
+>    contact テーブルの **Self スコープ** 権限が前提（→ [テーブル権限](enhanced-data-model-permissions.md)）。
+
 ```tsx
 // src/components/site-header.tsx
 import { useAuth } from "@/hooks/use-auth";
@@ -301,6 +324,61 @@ export function SiteHeader() {
     </header>
   );
 }
+```
+
+### 3.1 ログアウト確認モーダル（既定実装）
+
+ログアウトは誤操作防止のため確認モーダルを挟む。確認後に `logout()` を呼び、`logout()` は
+`/Account/Login/LogOff?returnUrl=%2F`（= LP ルート）へリダイレクトする。
+
+```tsx
+// src/components/logout-confirm-dialog.tsx（要点）
+export function LogoutConfirmDialog({
+  open, onConfirm, onCancel,
+}: { open: boolean; onConfirm: () => void; onCancel: () => void }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4" role="dialog" aria-modal="true">
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onCancel} />
+      <div className="relative w-full max-w-sm rounded-2xl border bg-card shadow-premium p-6">
+        <h2 className="text-lg font-bold">ログアウトしますか？</h2>
+        <p className="text-sm text-muted-foreground">ログアウトするとトップページに戻ります。</p>
+        <div className="mt-6 flex gap-2">
+          <Button variant="outline" className="flex-1" onClick={onCancel}>キャンセル</Button>
+          <Button variant="destructive" className="flex-1" onClick={onConfirm}>ログアウト</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+```tsx
+// site-layout.tsx 側: ヘッダー／モバイルのログアウト導線は logout() を直接呼ばず
+// モーダルを開く。確認後に logout() を実行する。
+const [logoutDialogOpen, setLogoutDialogOpen] = useState(false);
+// ...ログアウトボタン: onClick={() => setLogoutDialogOpen(true)}
+<LogoutConfirmDialog
+  open={logoutDialogOpen}
+  onConfirm={logout}
+  onCancel={() => setLogoutDialogOpen(false)}
+/>
+```
+
+### 3.2 連絡先情報の編集アイコン（既定実装）
+
+ヘッダーの認証済み状態では `UserCog` アイコン + ユーザー名を表示し、クリックで
+`/profile`（取引先担当者の編集ページ）へ遷移する。編集対象は contact テーブルで、
+**Self スコープ**のテーブル権限により本人レコードのみ読み書きできる。
+
+```tsx
+// site-layout.tsx 側（要点）
+<button onClick={() => navigate("/profile")} aria-label="連絡先情報の編集">
+  <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center">
+    <UserCog className="h-4 w-4 text-primary" />
+  </div>
+  <span>{user?.fullName}</span>
+</button>
 ```
 
 ---

--- a/.github/skills/power-pages/references/enhanced-data-model-permissions.md
+++ b/.github/skills/power-pages/references/enhanced-data-model-permissions.md
@@ -386,7 +386,7 @@ requests.post(
 ### 開発時の注意
 
 ~~管理者で動作確認して OK でも、一般ユーザーでテストしないと 403 が発見できない。~~ **管理者でも 403 になる**。
-**全てのテーブル権限を Authenticated Users に紐づけること。** `deploy_site.py` Phase 4.5 で自動化済み。
+**全てのテーブル権限の content JSON に Authenticated Users を紐づけること。** `setup_permissions.py` で自動化。
 
 ---
 
@@ -404,9 +404,9 @@ Step 4: Site Restart（API）
 Step 5: テスト（管理者でも一般でも同じ権限設定が必要）
 ```
 
-### 自動紐づけ（推奨 — deploy_site.py Phase 4.5）
+### 自動紐づけ（推奨 — setup_permissions.py）
 
-`deploy_site.py` が Phase 4.5 で全テーブル権限を Authenticated Users に自動紐づけするため、手動作業は不要。
+`setup_permissions.py` が全テーブル権限の content JSON 内 `adx_entitypermission_webrole` に Authenticated Users を冪等に書き込むため、手動作業は不要。
 
 ### Design Studio での紐付け手順（手動が必要な場合のみ）
 

--- a/.github/skills/power-pages/reviews/pre-deploy-review.md
+++ b/.github/skills/power-pages/reviews/pre-deploy-review.md
@@ -39,7 +39,7 @@
 | 3.4 | scope が意図通り（Global=756150000 / Self=756150004）| ✅ | 教訓3 |
 | 3.5 | Contact 用権限は scope=756150004 (Self) | ✅ | 教訓3 |
 | 3.6 | `append=true, appendto=true` が設定されている（Lookup 使用テーブル） | ✅ | 教訓4: 403 90040106 |
-| 3.7 | N:N `powerpagecomponent_powerpagecomponent` リンクが存在する | ✅ | 教訓2 |
+| 3.7 | 全権限の content JSON に `adx_entitypermission_webrole` がある（N:N は幽霊なので検証に使わない） | ✅ | 教訓2・14 |
 
 ### 4. サイト設定検証
 

--- a/.github/skills/power-pages/reviews/pre-design-review.md
+++ b/.github/skills/power-pages/reviews/pre-design-review.md
@@ -43,7 +43,7 @@
 |---|---|---|
 | 4.1 | EDM 2.0 前提（`Webapi/*` Site Settings は使わない） | 教訓8 |
 | 4.2 | テーブル権限 content JSON に `adx_entitypermission_webrole` を含める設計 | 教訓2: 403 |
-| 4.3 | N:N リンク（`powerpagecomponent_powerpagecomponent`）も同時に設定する | 教訓2 |
+| 4.3 | content に `websiteid` を含める設計（N:N $ref は幽霊なので使わない） | 教訓2・14 |
 | 4.4 | Contact 権限は scope=756150004 (Self) を使用 | 教訓3: contactrelationship 不要 |
 | 4.5 | Lookup 参照先テーブルに `appendto=true` を設定する計画がある | 教訓4: 403 90040106 |
 | 4.6 | `powerpagesitelanguageid` を設定する計画がある | 核心: null → 404 9004010C |

--- a/.github/skills/power-pages/scripts/review_pre_deploy.py
+++ b/.github/skills/power-pages/scripts/review_pre_deploy.py
@@ -210,6 +210,17 @@ def check_environment():
 # [3] テーブル権限検証
 # ---------------------------------------------------------------------------
 
+def _content_has_webrole(content_str) -> bool:
+    """type=18 の content JSON 内 adx_entitypermission_webrole が非空かを判定。
+    これがランタイム正本。N:N powerpagecomponent_powerpagecomponent は幽霊なので使わない。"""
+    try:
+        content = json.loads(content_str) if content_str else {}
+    except (json.JSONDecodeError, TypeError):
+        return False
+    roles = content.get("adx_entitypermission_webrole")
+    return bool(roles)
+
+
 def check_table_permissions():
     print("\n[3/5] テーブル権限検証")
 
@@ -281,20 +292,14 @@ def check_table_permissions():
                 check("3.6", f"{name}: append={has_append}, appendto={has_appendto}",
                       has_append and has_appendto)
 
-        # 3.7 N:N リンク確認 (サンプリング: 最初の権限)
+        # 3.7 全権限の content webrole 検証（ランタイム正本＝content JSON の adx_entitypermission_webrole）
+        #     N:N powerpagecomponent_powerpagecomponent は幽霊リンクなので検証に使わない
         if permissions:
-            first_id = permissions[0].get("powerpagecomponentid", "")
-            if first_id:
-                r_nn = requests.get(
-                    f"{dv_url}/api/data/v9.2/powerpagecomponents({first_id})"
-                    "/powerpagecomponent_powerpagecomponent?$select=name",
-                    headers=headers, timeout=30
-                )
-                if r_nn.status_code == 200:
-                    links = r_nn.json().get("value", [])
-                    check("3.7", f"{permissions[0]['name']}: N:N リンク {len(links)} 件", len(links) >= 1)
-                else:
-                    check("3.7", "N:N リンク確認", False)
+            missing = [p["name"] for p in permissions
+                       if not _content_has_webrole(p.get("content"))]
+            check("3.7", f"全 {len(permissions)} 権限の content に adx_entitypermission_webrole あり"
+                         + (f"（未設定: {', '.join(missing)}）" if missing else ""),
+                  len(missing) == 0)
 
     except ImportError:
         print(f"  {WARN} auth_helper / requests なし — スキップ")

--- a/.github/skills/power-pages/templates/corporate-lp/src/App.tsx
+++ b/.github/skills/power-pages/templates/corporate-lp/src/App.tsx
@@ -10,7 +10,7 @@ export default function App() {
       <Routes>
         <Route element={<SiteLayout />}>
           <Route index element={<HomePage />} />
-          {/* プロフィール編集（認証必須・デフォルト実装） */}
+          {/* 連絡先情報の編集（取引先担当者 Self・認証必須・デフォルト実装） */}
           <Route
             path="profile"
             element={

--- a/.github/skills/power-pages/templates/corporate-lp/src/components/logout-confirm-dialog.tsx
+++ b/.github/skills/power-pages/templates/corporate-lp/src/components/logout-confirm-dialog.tsx
@@ -1,0 +1,92 @@
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { LogOut, X } from "lucide-react";
+
+/**
+ * ログアウト確認モーダル（デフォルト実装）
+ *
+ * 「ログアウトしますか？」を確認してから logout() を実行する。
+ * 確認後は use-auth.ts の logout() が LP（ルート "/"）へリダイレクトする。
+ *
+ * site-layout.tsx でヘッダー／モバイルメニューのログアウト導線から開く。
+ */
+export function LogoutConfirmDialog({
+  open,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  // Esc キーで閉じる
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="logout-dialog-title"
+    >
+      {/* オーバーレイ */}
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm animate-fade-in"
+        onClick={onCancel}
+      />
+
+      {/* ダイアログ本体 */}
+      <div className="relative w-full max-w-sm rounded-2xl border border-border/60 bg-card shadow-premium p-6 animate-fade-in">
+        <button
+          className="absolute top-3 right-3 p-1.5 rounded-lg text-muted-foreground hover:bg-muted transition-colors"
+          onClick={onCancel}
+          aria-label="閉じる"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <div className="flex flex-col items-center text-center space-y-3">
+          <div className="h-12 w-12 rounded-2xl bg-destructive/10 flex items-center justify-center">
+            <LogOut className="h-6 w-6 text-destructive" />
+          </div>
+          <h2
+            id="logout-dialog-title"
+            className="text-lg font-bold text-foreground"
+          >
+            ログアウトしますか？
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            ログアウトするとトップページに戻ります。
+          </p>
+        </div>
+
+        <div className="mt-6 flex gap-2">
+          <Button
+            variant="outline"
+            className="flex-1"
+            onClick={onCancel}
+          >
+            キャンセル
+          </Button>
+          <Button
+            variant="destructive"
+            className="flex-1 gap-1.5"
+            onClick={onConfirm}
+          >
+            <LogOut className="h-4 w-4" />
+            ログアウト
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/.github/skills/power-pages/templates/corporate-lp/src/components/site-layout.tsx
+++ b/.github/skills/power-pages/templates/corporate-lp/src/components/site-layout.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from "react";
 import { Outlet, NavLink, useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { ModeToggle } from "@/components/mode-toggle";
+import { LogoutConfirmDialog } from "@/components/logout-confirm-dialog";
 import { useAuth } from "@/hooks/use-auth";
 import {
   LayoutDashboard,
@@ -14,7 +15,7 @@ import {
   X,
   MoreHorizontal,
   ChevronDown,
-  User,
+  UserCog,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SITE_NAME, SITE_LOGO_MARK } from "@/config";
@@ -53,10 +54,11 @@ const navGroups: NavGroup[] = [
 /**
  * 認証アクション（ヘッダー右上）
  * - 未認証: ログインボタン → /SignIn 直行（自動 SSO）
- * - 認証済み: プロフィールアバター + ドロップダウン（プロフィール編集 / ログアウト）
+ * - 認証済み: 連絡先編集アイコン + ドロップダウン（連絡先情報の編集 / ログアウト）
+ *   ※ ログアウトは確認モーダル経由（onRequestLogout）。
  */
-function AuthActions() {
-  const { isAuthenticated, user, login, logout } = useAuth();
+function AuthActions({ onRequestLogout }: { onRequestLogout: () => void }) {
+  const { isAuthenticated, user, login } = useAuth();
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -92,9 +94,11 @@ function AuthActions() {
       <button
         className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-muted transition-colors"
         onClick={() => navigate("/profile")}
+        title="連絡先情報の編集"
+        aria-label="連絡先情報の編集"
       >
         <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center">
-          <User className="h-4 w-4 text-primary" />
+          <UserCog className="h-4 w-4 text-primary" />
         </div>
         <span className="text-xs text-muted-foreground max-w-[100px] truncate">
           {user?.fullName || "ユーザー"}
@@ -116,12 +120,15 @@ function AuthActions() {
                 navigate("/profile");
               }}
             >
-              <User className="h-4 w-4" />
-              プロフィール編集
+              <UserCog className="h-4 w-4" />
+              連絡先情報の編集
             </button>
             <button
               className="flex w-full items-center gap-2.5 px-3 py-2 rounded-lg text-sm text-foreground hover:bg-muted transition-colors"
-              onClick={logout}
+              onClick={() => {
+                setOpen(false);
+                onRequestLogout();
+              }}
             >
               <LogOut className="h-4 w-4" />
               ログアウト
@@ -269,6 +276,7 @@ function OverflowMenu({ groups }: { groups: NavGroup[] }) {
 
 export function SiteLayout() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [logoutDialogOpen, setLogoutDialogOpen] = useState(false);
   const { isAuthenticated, login, logout } = useAuth();
 
   return (
@@ -298,7 +306,7 @@ export function SiteLayout() {
             {/* 右側アクション */}
             <div className="flex items-center gap-2">
               <ModeToggle />
-              <AuthActions />
+              <AuthActions onRequestLogout={() => setLogoutDialogOpen(true)} />
 
               {/* モバイルメニューボタン */}
               <button
@@ -356,12 +364,15 @@ export function SiteLayout() {
                     onClick={() => setMobileMenuOpen(false)}
                     className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-foreground hover:bg-muted transition-colors"
                   >
-                    <User className="h-4 w-4" />
-                    プロフィール編集
+                    <UserCog className="h-4 w-4" />
+                    連絡先情報の編集
                   </NavLink>
                   <button
                     className="flex w-full items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-foreground hover:bg-muted transition-colors"
-                    onClick={logout}
+                    onClick={() => {
+                      setMobileMenuOpen(false);
+                      setLogoutDialogOpen(true);
+                    }}
                   >
                     <LogOut className="h-4 w-4" />
                     ログアウト
@@ -396,6 +407,13 @@ export function SiteLayout() {
           </p>
         </div>
       </footer>
+
+      {/* ログアウト確認モーダル */}
+      <LogoutConfirmDialog
+        open={logoutDialogOpen}
+        onConfirm={logout}
+        onCancel={() => setLogoutDialogOpen(false)}
+      />
     </div>
   );
 }

--- a/.github/skills/power-pages/templates/corporate-lp/src/hooks/use-auth.ts
+++ b/.github/skills/power-pages/templates/corporate-lp/src/hooks/use-auth.ts
@@ -87,6 +87,24 @@ export function useAuth() {
   useEffect(() => {
     const user = resolvePortalUser();
     setState({ isAuthenticated: !!user, user, loading: false });
+
+    // ログイン完了後、元のページ（ハッシュ）へ戻す。
+    // Power Pages の returnUrl はサーバーパス（Code Site では "/"）なので、
+    // SPA 内のルート（ハッシュ）はクライアント側で復元する。
+    // これにより「profile を経由せず、もとのページに戻る」を実現する。
+    // ※ サーバー側でも Authentication/Registration/ProfileRedirectEnabled=false が必須
+    //   （scripts/setup_auth.py で設定）。
+    if (user && !IS_DEV) {
+      const savedHash = sessionStorage.getItem("pp_return_hash");
+      if (savedHash) {
+        sessionStorage.removeItem("pp_return_hash");
+        const current = window.location.hash;
+        const atRoot = !current || current === "#" || current === "#/";
+        if (atRoot && savedHash !== current) {
+          window.location.hash = savedHash;
+        }
+      }
+    }
   }, []);
 
   const keepAliveRef = useRef<ReturnType<typeof setInterval> | null>(null);

--- a/.github/skills/power-pages/templates/corporate-lp/src/pages/profile.tsx
+++ b/.github/skills/power-pages/templates/corporate-lp/src/pages/profile.tsx
@@ -2,10 +2,10 @@ import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "@/hooks/use-auth";
 import { powerPagesFetch, buildODataUrl } from "@/lib/dataverse";
 import { Button } from "@/components/ui/button";
-import { Save, Loader2, User, CheckCircle2, AlertCircle } from "lucide-react";
+import { Save, Loader2, UserCog, CheckCircle2, AlertCircle } from "lucide-react";
 
 /**
- * プロフィール編集ページ（デフォルト実装）
+ * 連絡先情報の編集ページ（デフォルト実装）
  *
  * ログイン中ユーザー（取引先担当者 = contact）のプロフィールを
  * `/_api/contacts({contactId})` 経由で取得・更新する。
@@ -119,12 +119,12 @@ export default function ProfilePage() {
     <div className="max-w-lg mx-auto py-8 px-4">
       <div className="flex items-center gap-3 mb-6">
         <div className="h-12 w-12 rounded-2xl bg-primary/10 flex items-center justify-center">
-          <User className="h-6 w-6 text-primary" />
+          <UserCog className="h-6 w-6 text-primary" />
         </div>
         <div>
-          <h1 className="text-2xl font-bold text-foreground">プロフィール編集</h1>
+          <h1 className="text-2xl font-bold text-foreground">連絡先情報の編集</h1>
           <p className="text-sm text-muted-foreground">
-            登録情報を更新できます
+            取引先担当者（連絡先）の登録情報を更新できます
           </p>
         </div>
       </div>


### PR DESCRIPTION
## 概要

corporate-lp デザインテンプレートに、認証まわりの UX を 3 点既定実装として追加します。あわせてデプロイ前チェックとリファレンスを整備します。

> 注: 権限（テーブル権限・Web ロール）はテンプレートには組み込みません。contact の Self スコープ権限は**前提**としてドキュメントに明記しています。

## デザインテンプレートの認証 UX（3 点）

### 1. ログイン遷移
- クラシックなサインインページを経由せず `/Account/Login/ExternalLogin` へ直接 POST → SSO。
- ログイン完了後、`pp_return_hash` を復元して**ログイン前のページに戻る**（`/profile` を経由しない）。
- 前提: サーバー設定 `Authentication/Registration/ProfileRedirectEnabled=false`（`setup_auth.py` で設定済み）。

### 2. ログアウト遷移
- 「ログアウトしますか？」の確認モーダルを追加（`logout-confirm-dialog.tsx`）。
- 確認後 `logout()` を実行し、LP ルート `/` に戻る。
- デスクトップ／モバイル両方のログアウト導線をモーダル経由に統一。

### 3. 連絡先情報の編集
- ヘッダーに `UserCog` アイコンを表示 → クリックで取引先担当者（contact）編集ページへ。
- 編集対象は contact テーブル。**Self スコープ**のテーブル権限により本人レコードのみ読み書き可能（前提）。
- 文言を「連絡先情報の編集」に統一（`profile.tsx` / `App.tsx`）。

## 変更ファイル

- `templates/corporate-lp/src/hooks/use-auth.ts` — ログイン後の元ページ復元処理を追加
- `templates/corporate-lp/src/components/logout-confirm-dialog.tsx` — 新規（ログアウト確認モーダル）
- `templates/corporate-lp/src/components/site-layout.tsx` — モーダル連携・連絡先編集アイコン
- `templates/corporate-lp/src/pages/profile.tsx` — 連絡先情報の編集に文言統一
- `templates/corporate-lp/src/App.tsx` — ルートコメント整合
- `references/authentication.md` — 3 点の既定 UX を追記

## 動作確認

- `get_errors` で対象 4 ファイルにエラーなしを確認済み。
- ローカル（localhost）では DEV モックユーザーで UI 確認可能。
