### PR TITLE
feat(power-pages): contact Self セットアップ＆デプロイ後Webロール再付与スクリプトを追加（教訓15/16）

### DIFF
--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -113,18 +113,33 @@ triggers:
 
 ---
 
-### 教訓 2: EDM 2.0 テーブル権限は content JSON 内の `adx_entitypermission_webrole` が唯一の正本
+### 教訓 2: EDM 2.0 テーブル権限の Web ロール紐付けは N:N association がランタイム正本（content JSON は YAML シリアライズ形）
+
+> **重要な訂正（実機 m365status で確定）:** 以前は「content JSON が唯一の正本、N:N $ref は幽霊」と
+> 記載していたが、実機検証で **逆**だと判明した。content JSON 配列が入っていても
+> 自己参照 N:N `powerpagecomponent_powerpagecomponent` の **association が空なら 403**
+> (90040120 EntityPermissionReadIsMissing) になる。`$ref` POST で association を作成した
+> 直後に 200 になった。**ランタイム正本は N:N association**。
 
 ```
 ❌ NG: powerpagecomponent type=18 の content に entitylogicalname/scope/CRUD だけ設定
-       → content の adx_entitypermission_webrole が空 → ランタイムが権限を認識せず 403
+       → content の adx_entitypermission_webrole も N:N association も空 → 403
 
-❌ NG: powerpagecomponent_powerpagecomponent（自己参照 N:N）に $ref POST して紐付けたつもりになる
-       → 204 が返るが幽霊リンク。content の配列が空のままなので 403 のまま
+❌ NG: content JSON の adx_entitypermission_webrole 配列だけ PATCH して終わり
+       → API 単体では N:N association が作られない → 403 (90040120) のまま
+       （content 配列は YAML/git シリアライズ形であり、ランタイムは association を読む）
 
-✅ OK: content JSON に adx_entitypermission_webrole（ロール ID 配列）を含めて PATCH する
-       これがランタイム／Design Studio「ロール」列の唯一の正本
+✅ OK: (1) content JSON に adx_entitypermission_webrole（YAML/git 形）を含めて PATCH
+       (2) かつ N:N に $ref POST して association を作成（＝ランタイム正本）
+       POST .../powerpagecomponents({permId})/powerpagecomponent_powerpagecomponent/$ref
+            body: {"@odata.id": ".../powerpagecomponents({roleId})"}
 ```
+
+> `pac pages upload-code-site` で table-permissions YAML をデプロイすると、この
+> **association も自動作成される**。一方、API だけで content を編集した場合は
+> association が作られないため、`$ref` POST が必須。両方そろえるのが安全。
+> association は方向性があり、権限(type=18)→ロール(type=11) 方向で `$expand` すると見える
+> （逆方向のロール→権限 expand は空に見えることがある）。
 
 **Design Studio が書く完全な content JSON:**
 
@@ -153,7 +168,9 @@ triggers:
 **API で完結する手順:**
 1. `powerpagecomponent` type=18 を POST — content に `adx_entitypermission_webrole`（＋`websiteid`）を含む
 2. 既存権限に後からロールを追加する場合は `content` を GET → 配列にロール ID を冪等追加 → PATCH
-3. ランタイムは content のこの配列のみを読む（N:N `powerpagecomponent_powerpagecomponent` への `$ref` POST は不要・幽霊）
+3. **N:N association を `$ref` POST で作成**（`powerpagecomponent_powerpagecomponent`）。
+   これがランタイム正本。API のみの content 編集では作られないため必須
+4. 検証は association を `$expand`（権限→ロール方向）で確認する
 
 ---
 
@@ -350,46 +367,50 @@ value: "*"
 
 ---
 
-### 教訓 14: テーブル権限の Web ロール紐付けは content JSON の `adx_entitypermission_webrole` が正本 → デプロイ後に必ず書き込む
+### 教訓 14: テーブル権限の Web ロール紐付けは N:N association がランタイム正本 → デプロイ後 / API 編集後に必ず作成する
 
 ```
 ❌ NG: .powerpages-site/table-permissions/*.yml を pac pages upload-code-site で
-       デプロイしただけで「権限設定済み」と判断する
-       → powerpagecomponent type=18 レコードは作成されるが、
-         content JSON の adx_entitypermission_webrole が空のまま残る
+       デプロイしただけで「権限設定済み」と判断する（YAML に webrole 紐付けが無い場合）
+       → powerpagecomponent type=18 は作成されるが、association が空のまま
        → 管理者を含む全ユーザーが 403（Design Studio の「ロール」列が空）
 
-❌ NG: powerpagecomponent_powerpagecomponent（自己参照 N:N）に $ref POST する
-       → 204 が返るが「幽霊リンク」。Design Studio「ロール」列は空のまま、
-         ランタイムも認識せず 403 のまま（API の N:N 展開だけ紐付き済みに見える罠）
+❌ NG: content JSON の adx_entitypermission_webrole 配列だけ PATCH して終わり
+       → API 単体では N:N association が作られない → 403 (90040120) のまま
+         （content 配列は YAML/git シリアライズ形。ランタイムは association を読む）
 
-✅ OK: upload-code-site の後、type=18 の content JSON に
-       adx_entitypermission_webrole（＋ websiteid）を PATCH で書き込む
-       python scripts/setup_permissions.py   # content JSON を冪等に更新
+✅ OK: type=18 の content JSON（YAML 形）を書きつつ、N:N association を $ref POST で作成
+       python scripts/setup_permissions.py        # content + association を冪等作成
+       python scripts/relink_table_permissions.py # 全 type=18 を一括で content+association 修復
 ```
 
 **症状（実案件 IncidentPortal で発生）:**
 Design Studio の「セキュリティ → テーブルのアクセス許可」で、各権限の **「ロール」列が空欄**（Authenticated Users が割り当たっていない）。正しい `scope`/CRUD/`Webapi/*` がすべて揃っていても 403 になる。手動で Authenticated Users を割り当てると解消するが、再デプロイで再発しうる。
 
-**根本原因（実機検証で確定）:**
-ランタイム／Design Studio が参照する**正本は `powerpagecomponent` type=18 の `content` JSON 内の `adx_entitypermission_webrole` 配列**。`pac pages upload-code-site` は type=18 を作るが、この配列を空のまま残すため 403 になる。
-自己参照 N:N `powerpagecomponent_powerpagecomponent` への `$ref` POST は **204 を返すが永続化されず、ポータルは認識しない（幽霊リンク）**。`GET .../powerpagecomponent_powerpagecomponent` で紐付いて見えても、`content` の配列が空なら 403。
+**根本原因（実機検証で確定 — 以前の記述を訂正）:**
+ランタイムが参照する**正本は自己参照 N:N `powerpagecomponent_powerpagecomponent` の association**。
+content JSON の `adx_entitypermission_webrole` 配列は YAML/git シリアライズ形であり、これが
+入っていても association が空なら 403 (90040120 EntityPermissionReadIsMissing) になる。
+`pac pages upload-code-site` は YAML に webrole 紐付けがあれば association を作成するが、
+API だけで content を編集した場合は association が作られない。`$ref` POST で association を
+作成して初めてランタイムが認識する。
 
 **恒久対策（デプロイ手順に組み込む）:**
 1. `pac pages upload-code-site` でデプロイ
-2. **`python scripts/setup_permissions.py` を実行**して各 type=18 の `content.adx_entitypermission_webrole` に Authenticated Users の Web ロール ID を冪等に追加（`websiteid` も併せて設定）
+2. **`python scripts/setup_permissions.py` を実行**して各 type=18 に content（webrole 配列）と
+   **N:N association（$ref POST）の両方**を冪等作成
 3. `python scripts/review_pre_deploy.py` の **チェック 3.7** が ✅ になることを確認
 4. restart → 60〜90 秒待って `/_api/{table}` を検証
 
-**検証クエリ（正本＝content を直接確認）:**
+**検証クエリ（正本＝association を直接確認）:**
 ```
-GET /api/data/v9.2/powerpagecomponents({perm_id})?$select=content
-  → content をパースし adx_entitypermission_webrole に Web ロール ID が入っていれば OK。
-    空配列なら未設定 = 403 の原因。
-    （N:N 展開 powerpagecomponent_powerpagecomponent は幽霊リンクで紐付いて見えるため信用しない）
+GET /api/data/v9.2/powerpagecomponents({perm_id})
+    ?$expand=powerpagecomponent_powerpagecomponent($select=name,powerpagecomponenttype)
+  → 展開結果に type=11 の Web ロールが含まれていれば OK（＝ランタイム正本が紐付け済み）。
+    空なら未紐付け = 403 の原因。content の配列だけでは不十分。
 ```
 
-> 関連: 教訓 2（content の `adx_entitypermission_webrole` 必須）/ `references/operations-and-pitfalls.md`。本教訓は「**YAML デプロイでは content の配列が空のままなのでデプロイ後に必ず書き込む。N:N の $ref は幽霊なので使わない**」というデプロイ手順上の落とし穴を明示する。
+> 関連: 教訓 2（N:N association がランタイム正本）/ `references/operations-and-pitfalls.md`。本教訓は「**content 配列だけ・YAML デプロイだけでは association が空になりうるので、デプロイ後 / API 編集後に必ず $ref POST で association を作成する**」というデプロイ手順上の落とし穴を明示する。
 
 ---
 
@@ -399,10 +420,10 @@ GET /api/data/v9.2/powerpagecomponents({perm_id})?$select=content
 ❌ NG: 一度 Web ロールを紐付けた後、SPA 更新のために再度 upload-code-site を実行し、
        そのまま動作確認する
        → .powerpages-site/table-permissions/*.yml が既存 type=18 を上書きし、
-         content.adx_entitypermission_webrole を空に戻す
+         content.adx_entitypermission_webrole と N:N association をリセットする
        → 既存の全グローバル権限まで一斉に 403 になる（Design Studio「ロール」列が空に）
 
-✅ OK: upload-code-site のたびに content の Web ロールを再付与する
+✅ OK: upload-code-site のたびに content と N:N association の両方を再付与する
        python scripts/relink_table_permissions.py   # 全 type=18 を冪等に再付与＋再起動
 ```
 
@@ -414,17 +435,19 @@ GET /api/data/v9.2/powerpagecomponents({perm_id})?$select=content
 
 **根本原因（実機検証で確定）:**
 `pac pages upload-code-site` は `.powerpages-site/table-permissions/*.yml` を正として
-type=18 を上書きするが、この YAML には `adx_entitypermission_webrole` が含まれないため、
-content JSON の Web ロール配列が **毎回リセットされる**（教訓 14 が「デプロイのたびに」再発する）。
+type=18 を上書きするが、この YAML に webrole 紐付けが含まれないと、
+content JSON の Web ロール配列と N:N association が **毎回リセットされる**
+（教訓 14 が「デプロイのたびに」再発する）。
 
 **恒久対策（再デプロイ手順に固定）:**
 1. `npm run build && pac pages upload-code-site`
-2. **`python scripts/relink_table_permissions.py`** を実行（全 type=18 の content に
-   Authenticated Users を冪等再付与 → 自動で再起動）
+2. **`python scripts/relink_table_permissions.py`** を実行（全 type=18 に
+   Authenticated Users を content + N:N association の両方で冪等再付与 → 自動で再起動）
 3. 60〜90 秒待って `/_api/{table}` を検証
 
 > `setup_permissions.py`（TABLES に列挙したテーブルのみ）と異なり、
 > `relink_table_permissions.py` は**サイト上の全 type=18 を対象に一括修復**する。
+> 両スクリプトとも content JSON 配列と N:N association（$ref POST）の両方を作成する。
 > 環境変数 `RELINK_WEBROLE_NAMES`（既定 `Authenticated`, カンマ区切り）で対象ロールを変更可。
 
 ---
@@ -501,10 +524,11 @@ create_table_permission(
 | HTTP | OData Code | メッセージ | 原因 | 教訓 |
 |------|-----------|---------|------|------|
 | 401 | 90040107 | Anti-forgery token required | CSRF トークン未送信 | 教訓 1 |
-| 403 | — | Forbidden (no permission) | type=18 content の `adx_entitypermission_webrole` が空（YAML デプロイ後に未設定）。N:N の `$ref` は 204 でも幽霊で無効 | 教訓 2・14 |
+| 403 | 90040120 | EntityPermissionReadIsMissing | type=18 の N:N association が空（content 配列だけでは不十分。$ref POST 未実行 / YAML デプロイで未紐付け） | 教訓 2・14 |
+| 403 | 90040101 | AttributePermissionIsMissing | `Webapi/{table}/fields` 許可リスト外の列を要求（$select なし＝`*` 要求も含む） | 教訓 16 |
 | 403 | 90040106 | AppendTo permission missing | 参照先テーブルに appendto=false | 教訓 4 |
 | 404 | 9004010D | CDS entity resolution failed | @odata.bind のターゲットテーブルが違う | 教訓 4 |
-| 404 | 9004010C | Resource not found for segment | テーブル権限未設定 or languageid null | 教訓 2 |
+| 404 | 9004010C | Resource not found for segment | `Webapi/{table}/enabled` 未設定 or languageid null | 教訓 8 |
 | 302 | — | Redirect to /profile | ProfileRedirectEnabled=true | 教訓 5 |
 
 ---
@@ -864,7 +888,7 @@ name: Authenticated Users
 | 1 | `adx_sitesettings` | `Webapi/contact/enabled=true` | `adx_websites` |
 | 2 | `adx_sitesettings` | `Webapi/contact/fields=*` | `adx_websites` |
 | 3 | `powerpagecomponent` type=18 | テーブル権限 (Self) | `powerpagesites` + **`powerpagesitelanguages`** |
-| 4 | type=18 の content JSON | `adx_entitypermission_webrole` に Web ロール ID | type=11 (Authenticated Users) |
+| 4 | N:N association（$ref POST） | `powerpagecomponent_powerpagecomponent` でロールを紐付け | type=11 (Authenticated Users) |
 
 ### ⚠️ 致命的な落とし穴: `powerpagesitelanguageid`
 
@@ -928,7 +952,7 @@ content = json.dumps({
     "read": True, "write": True, "create": False,
     "delete": False, "append": False, "appendto": False,
     "websiteid": adx_website_id,                       # ← 必須
-    "adx_entitypermission_webrole": [auth_role_id],    # ← 必須（ランタイム正本）
+    "adx_entitypermission_webrole": [auth_role_id],    # ← YAML/git シリアライズ形
 })
 body = {
     "powerpagecomponenttype": 18,
@@ -938,17 +962,18 @@ body = {
     "powerpagesitelanguageid@odata.bind": f"/powerpagesitelanguages({lang_id})",  # ★ 必須！
 }
 
-# 3. 既存権限に後からロールを追加する場合は content を PATCH（N:N $ref は使わない）
-#   GET .../powerpagecomponents({perm_id})?$select=content → JSON パース
-#   content["adx_entitypermission_webrole"] に role_id を冪等追加 →
-#   PATCH .../powerpagecomponents({perm_id})  {"content": json.dumps(content)}
+# 3. ★ N:N association を $ref POST で作成（＝ランタイム正本。content 配列だけでは 403）
+#   POST .../powerpagecomponents({perm_id})/powerpagecomponent_powerpagecomponent/$ref
+#        body: {"@odata.id": ".../powerpagecomponents({auth_role_id})"}
+#   既存権限へのロール追加も content PATCH + この $ref POST の両方を冪等に行う
 ```
 
 > ⚠️ **よくあるミス（修正済み）:**
 > - `powerpagesitelanguageid` が null → ランタイムが権限を無視して 404
+> - **N:N association を作成せず content 配列だけ書く → 403 (90040120)**（教訓 2・14）
 > - content に `mspp_` プレフィックスの文字列値 → 整数・bool 値が正しい
 > - `credentials: "include"` → 正しくは `"same-origin"`
-> - `Webapi/<table>/fields` に明示リストのみ → system table は `*` を使う
+> - `Webapi/<table>/fields` に明示リストのみ → 列指定なし取得（`*`）で 403 になるため `*` 推奨（教訓 16）
 
 ---
 
@@ -1015,11 +1040,11 @@ value: "true"
 | HTTP | OData Code | メッセージ | 原因 | 対策 |
 |------|-----------|---------|------|------|
 | 401 | 90040107 | Anti-forgery token required | CSRF トークン未送信 | `/_layout/tokenhtml` から取得してヘッダー付与 |
-| 403 | — | Forbidden (no permission) | content に `adx_entitypermission_webrole` なし | content JSON にロール ID 配列を含める |
-| 403 | — | Forbidden (field not allowed) | `Webapi/{table}/fields` 許可リスト外の列を `$select` した | fields にクライアントの SELECT 全列を列挙（迷えば `*`）（教訓 16） |
+| 403 | 90040120 | EntityPermissionReadIsMissing | type=18 の N:N association が空（content 配列だけでは不十分） | `$ref` POST で association を作成（教訓 2・14） |
+| 403 | 90040101 | AttributePermissionIsMissing | `Webapi/{table}/fields` 許可リスト外の列を要求（$select なし＝`*` 要求も含む） | fields にクライアントの SELECT 全列を列挙（迷えば `*`）（教訓 16） |
 | 403 | 90040106 | AppendTo permission missing | 参照先テーブルに appendto=false | EDM content で `"appendto": true` に更新 |
 | 404 | 9004010D | CDS entity resolution failed | `@odata.bind` のターゲットテーブルが違う | `ManyToOneRelationships` で正しい参照先を確認 |
-| 404 | 9004010C | Resource not found for segment | テーブル権限未設定 or `powerpagesitelanguageid` null | type=18 content + languageid 設定 |
+| 404 | 9004010C | Resource not found for segment | `Webapi/{table}/enabled` 未設定 or `powerpagesitelanguageid` null | enabled=true + languageid 設定（教訓 8） |
 | 400 | 9004010A | Invalid column name | `$select` に存在しないカラム名 | `EntityDefinitions` でカラム名確認 |
 | 302 | — | Redirect to /profile | `ProfileRedirectEnabled=true` | サイト設定で `false` に変更 |
 | 302 | — | Login redirect | 未認証 | SSO ログイン or `redirect: "manual"` で検知 |

--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -393,6 +393,74 @@ GET /api/data/v9.2/powerpagecomponents({perm_id})?$select=content
 
 ---
 
+### 教訓 15: `upload-code-site` は既存テーブル権限の Web ロール紐付けを消す → デプロイ後に必ず再付与
+
+```
+❌ NG: 一度 Web ロールを紐付けた後、SPA 更新のために再度 upload-code-site を実行し、
+       そのまま動作確認する
+       → .powerpages-site/table-permissions/*.yml が既存 type=18 を上書きし、
+         content.adx_entitypermission_webrole を空に戻す
+       → 既存の全グローバル権限まで一斉に 403 になる（Design Studio「ロール」列が空に）
+
+✅ OK: upload-code-site のたびに content の Web ロールを再付与する
+       python scripts/relink_table_permissions.py   # 全 type=18 を冪等に再付与＋再起動
+```
+
+**症状（実案件 IncidentPortal で発生）:**
+`/profile`（contact Self）追加のために再デプロイしたところ、それまで動いていた
+`geek_inquiry` / `geek_m365incident` / `geek_m365service` の **3 つのグローバル権限の
+「ロール」列がすべて空**になり 403。デプロイ後に API で作成した `Contact - Self` だけは
+（YAML に含まれないため）影響を受けなかった。
+
+**根本原因（実機検証で確定）:**
+`pac pages upload-code-site` は `.powerpages-site/table-permissions/*.yml` を正として
+type=18 を上書きするが、この YAML には `adx_entitypermission_webrole` が含まれないため、
+content JSON の Web ロール配列が **毎回リセットされる**（教訓 14 が「デプロイのたびに」再発する）。
+
+**恒久対策（再デプロイ手順に固定）:**
+1. `npm run build && pac pages upload-code-site`
+2. **`python scripts/relink_table_permissions.py`** を実行（全 type=18 の content に
+   Authenticated Users を冪等再付与 → 自動で再起動）
+3. 60〜90 秒待って `/_api/{table}` を検証
+
+> `setup_permissions.py`（TABLES に列挙したテーブルのみ）と異なり、
+> `relink_table_permissions.py` は**サイト上の全 type=18 を対象に一括修復**する。
+> 環境変数 `RELINK_WEBROLE_NAMES`（既定 `Authenticated`, カンマ区切り）で対象ロールを変更可。
+
+---
+
+### 教訓 16: Web API は `Webapi/{table}/fields` 許可リスト外の列を要求すると 403 → クライアントの SELECT 全列を網羅する
+
+```
+❌ NG: Webapi/contact/fields = "firstname,lastname,emailaddress1,telephone1"
+       なのにクライアントが ?$select=contactid,firstname,lastname,fullname,emailaddress1
+       を投げる（fullname が許可リスト外）
+       → テーブル権限・Web ロールが正しくても 403 Forbidden（権限不足と誤認しやすい）
+
+✅ OK: クライアントが SELECT する全列を fields に列挙する
+       Webapi/contact/fields = "firstname,lastname,emailaddress1,telephone1,fullname"
+       （主キー contactid は常に許可される。迷う場合は "*"）
+```
+
+**症状（実案件 IncidentPortal で発生）:**
+contact Self 権限・`Webapi/contact/enabled=true` を設定し Web ロールも紐付け済みなのに、
+`/_api/contacts?$select=contactid,firstname,lastname,fullname,emailaddress1` が **403**。
+フロント側は「authenticated but no contact permission」と誤って解釈していた。
+
+**根本原因:**
+`fullname` を `Webapi/contact/fields` の許可リストに入れ忘れていた。Web API は
+許可リスト外の列を含むリクエストを **403** で拒否する（200＋空ではない）。
+
+**恒久対策:**
+`setup_contact_self.py` は既定で `firstname,lastname,emailaddress1,telephone1,fullname`
+を設定する（`/profile` の `checkAuth` + 編集で使う全列）。クライアントの
+`$select` を変更したら fields も合わせて更新し、再起動する。
+
+> 関連スクリプト: `scripts/setup_contact_self.py`（contact Self 権限 + Webapi 設定を
+> content JSON 正本方式で冪等作成）/ `scripts/relink_table_permissions.py`（デプロイ後の一括修復）。
+
+---
+
 ### まとめ: API でテーブル権限を完結する再利用パターン
 
 ```python
@@ -948,6 +1016,7 @@ value: "true"
 |------|-----------|---------|------|------|
 | 401 | 90040107 | Anti-forgery token required | CSRF トークン未送信 | `/_layout/tokenhtml` から取得してヘッダー付与 |
 | 403 | — | Forbidden (no permission) | content に `adx_entitypermission_webrole` なし | content JSON にロール ID 配列を含める |
+| 403 | — | Forbidden (field not allowed) | `Webapi/{table}/fields` 許可リスト外の列を `$select` した | fields にクライアントの SELECT 全列を列挙（迷えば `*`）（教訓 16） |
 | 403 | 90040106 | AppendTo permission missing | 参照先テーブルに appendto=false | EDM content で `"appendto": true` に更新 |
 | 404 | 9004010D | CDS entity resolution failed | `@odata.bind` のターゲットテーブルが違う | `ManyToOneRelationships` で正しい参照先を確認 |
 | 404 | 9004010C | Resource not found for segment | テーブル権限未設定 or `powerpagesitelanguageid` null | type=18 content + languageid 設定 |
@@ -1076,9 +1145,19 @@ py .github/skills/standard/scripts/_restart.py
 cd portal
 npm run build
 pac pages upload-code-site --rootPath .
-# → サイト再起動
+# ★ upload-code-site は既存 type=18 の content.adx_entitypermission_webrole を消すため、
+#   デプロイのたびに全テーブル権限の Web ロールを再付与する（教訓 15）
+py ../.github/skills/power-pages/scripts/relink_table_permissions.py
+# → relink スクリプトが PP_SUBDOMAIN 設定時に自動で再起動する
+#   （未設定の場合は手動再起動）
 py ../.github/skills/standard/scripts/_restart.py
 ```
+
+> `/profile`（contact Self）を使う場合は、初回のみ `setup_contact_self.py` で
+> contact 権限と `Webapi/contact/enabled|fields` を作成しておく（教訓 16）:
+> ```bash
+> py ../.github/skills/power-pages/scripts/setup_contact_self.py
+> ```
 
 ---
 
@@ -1150,8 +1229,10 @@ SKIP_REMOTE=1 python ../.github/skills/power-pages/scripts/review_pre_deploy.py
 - [ ] EDM content JSON に `adx_entitypermission_webrole`（Web ロール ID 配列）が含まれている（教訓 2）
 - [ ] content に `websiteid` が含まれている
 - [ ] **`upload-code-site` 後に `setup_permissions.py` を実行し、各テーブル権限 content の `adx_entitypermission_webrole` に Authenticated Users が入っている（Design Studio の「ロール」列が空でない）（教訓 14）**
+- [ ] **再デプロイのたびに `relink_table_permissions.py` を実行し、`upload-code-site` で消えた全 type=18 の Web ロールを再付与した（教訓 15）**
 - [ ] テーブル権限に `append=true, appendto=true` が設定されている
 - [ ] Contact 権限は scope=756150004 (Self) を使用（教訓 3）
+- [ ] **`/profile`（contact Self）を使う場合、`setup_contact_self.py` で contact 権限 + `Webapi/contact/enabled|fields` を設定し、`fields` にクライアントの SELECT 全列（`fullname` 含む）を網羅した（教訓 16）**
 
 ### デプロイ
 - [ ] `powerpages.config.json` が存在する

--- a/.github/skills/power-pages/scripts/relink_table_permissions.py
+++ b/.github/skills/power-pages/scripts/relink_table_permissions.py
@@ -1,0 +1,159 @@
+"""
+Power Pages テーブル権限 Web ロール再付与スクリプト（デプロイ後の修復）
+
+`pac pages upload-code-site` は `.powerpages-site/table-permissions/*.yml` で
+既存のテーブル権限を上書きし、content JSON の `adx_entitypermission_webrole`
+（＝ランタイム正本の Web ロール紐付け）を **消去する**ことがある。
+その結果、Design Studio の「ロール」列が空になり、認証済みユーザーでも 403 になる。
+
+このスクリプトは「サイト上の全 type=18 テーブル権限」の content JSON に対し、
+指定 Web ロール（既定: Authenticated Users）を冪等に再付与する。
+**デプロイ（upload-code-site）のたびに実行すること。**
+
+前提: .env に DATAVERSE_URL, ENV_ID。再起動には PP_SUBDOMAIN。
+
+検証済みの教訓:
+- N:N `powerpagecomponent_powerpagecomponent` への $ref POST は 204 を返すが
+  ポータルは認識しない（幽霊リンク）。content JSON が唯一の正本。
+- Web ロール名の既定一致は "Authenticated"（部分一致）。
+"""
+import os
+import sys
+import json
+import requests
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from auth_helper import get_token
+
+DATAVERSE_URL = os.environ["DATAVERSE_URL"].rstrip("/")
+ENV_ID = os.environ.get("ENV_ID", "")
+SUBDOMAIN = os.environ.get("PP_SUBDOMAIN", "")
+
+# 再付与する Web ロール名（部分一致）。複数付与したい場合はカンマ区切りで。
+WEBROLE_NAMES = os.environ.get("RELINK_WEBROLE_NAMES", "Authenticated")
+
+API = f"{DATAVERSE_URL}/api/data/v9.2"
+
+
+def get_headers(scope: str = None):
+    token = get_token(scope=scope) if scope else get_token()
+    return {
+        "Authorization": f"Bearer {token}",
+        "OData-MaxVersion": "4.0",
+        "OData-Version": "4.0",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+def get_site_id(headers: dict) -> str:
+    r = requests.get(
+        f"{API}/powerpagesites?$top=1&$orderby=createdon desc&$select=powerpagesiteid,name",
+        headers=headers,
+    )
+    r.raise_for_status()
+    sites = r.json()["value"]
+    if not sites:
+        print("ERROR: powerpagesites にレコードが見つかりません")
+        sys.exit(1)
+    print(f"  site: {sites[0]['name']} ({sites[0]['powerpagesiteid']})")
+    return sites[0]["powerpagesiteid"]
+
+
+def get_webrole_ids(site_id: str, headers: dict) -> list:
+    """指定名（部分一致, カンマ区切り）に該当する Web ロール (type=11) の ID 一覧"""
+    names = [n.strip().lower() for n in WEBROLE_NAMES.split(",") if n.strip()]
+    r = requests.get(
+        f"{API}/powerpagecomponents?$filter=_powerpagesiteid_value eq {site_id} "
+        f"and powerpagecomponenttype eq 11&$select=powerpagecomponentid,name&$top=200",
+        headers=headers,
+    )
+    r.raise_for_status()
+    ids = []
+    for c in r.json().get("value", []):
+        cname = (c.get("name") or "").lower()
+        if any(n in cname for n in names):
+            ids.append(c["powerpagecomponentid"])
+            print(f"  webrole: {c.get('name')} ({c['powerpagecomponentid']})")
+    if not ids:
+        print(f"ERROR: Web ロール '{WEBROLE_NAMES}' が見つかりません")
+        sys.exit(1)
+    return ids
+
+
+def relink_all(site_id: str, role_ids: list, headers: dict) -> int:
+    """全 type=18 テーブル権限の content.adx_entitypermission_webrole に role を冪等付与"""
+    r = requests.get(
+        f"{API}/powerpagecomponents?$filter=_powerpagesiteid_value eq {site_id} "
+        f"and powerpagecomponenttype eq 18&$select=powerpagecomponentid,name,content&$top=500",
+        headers=headers,
+    )
+    r.raise_for_status()
+    fixed = 0
+    for c in r.json().get("value", []):
+        cid = c["powerpagecomponentid"]
+        name = c.get("name")
+        try:
+            content = json.loads(c.get("content") or "{}")
+        except json.JSONDecodeError:
+            content = {}
+        roles = content.get("adx_entitypermission_webrole") or []
+        missing = [rid for rid in role_ids if rid not in roles]
+        if not missing:
+            print(f"  OK   : {name}")
+            continue
+        roles.extend(missing)
+        content["adx_entitypermission_webrole"] = roles
+        if not content.get("websiteid"):
+            content["websiteid"] = site_id
+        requests.patch(
+            f"{API}/powerpagecomponents({cid})",
+            headers=headers, json={"content": json.dumps(content)},
+        ).raise_for_status()
+        print(f"  FIXED: {name} → Web ロールを再付与")
+        fixed += 1
+    return fixed
+
+
+def restart_site():
+    if not SUBDOMAIN or not ENV_ID:
+        print("  SKIP restart: PP_SUBDOMAIN / ENV_ID 未設定")
+        return
+    headers = get_headers(scope="https://api.powerplatform.com/.default")
+    base = f"https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites"
+    r = requests.get(f"{base}?api-version=2024-10-01", headers=headers)
+    r.raise_for_status()
+    for site in r.json()["value"]:
+        if site.get("subdomain", "") == SUBDOMAIN:
+            requests.post(
+                f"{base}/{site['id']}/restart?api-version=2024-10-01", headers=headers
+            ).raise_for_status()
+            print(f"  RESTARTED: {SUBDOMAIN}")
+            return
+    print(f"  WARNING: subdomain '{SUBDOMAIN}' が見つかりません")
+
+
+def main():
+    print("=== テーブル権限 Web ロール再付与（デプロイ後の修復） ===\n")
+    headers = get_headers()
+
+    print("[1/4] サイト ID を取得...")
+    site_id = get_site_id(headers)
+    print()
+
+    print(f"[2/4] Web ロール '{WEBROLE_NAMES}' を取得...")
+    role_ids = get_webrole_ids(site_id, headers)
+    print()
+
+    print("[3/4] 全テーブル権限 content の Web ロールを再付与...")
+    fixed = relink_all(site_id, role_ids, headers)
+    print(f"  → {fixed} 件を修復\n")
+
+    print("[4/4] ポータルを再起動...")
+    restart_site()
+    print("\n完了! 再起動後 60-90秒でアクセス可能。")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/power-pages/scripts/relink_table_permissions.py
+++ b/.github/skills/power-pages/scripts/relink_table_permissions.py
@@ -6,15 +6,22 @@ Power Pages テーブル権限 Web ロール再付与スクリプト（デプロ
 （＝ランタイム正本の Web ロール紐付け）を **消去する**ことがある。
 その結果、Design Studio の「ロール」列が空になり、認証済みユーザーでも 403 になる。
 
-このスクリプトは「サイト上の全 type=18 テーブル権限」の content JSON に対し、
+このスクリプトは「サイト上の全 type=18 テーブル権限」に対し、
 指定 Web ロール（既定: Authenticated Users）を冪等に再付与する。
 **デプロイ（upload-code-site）のたびに実行すること。**
 
 前提: .env に DATAVERSE_URL, ENV_ID。再起動には PP_SUBDOMAIN。
 
-検証済みの教訓:
-- N:N `powerpagecomponent_powerpagecomponent` への $ref POST は 204 を返すが
-  ポータルは認識しない（幽霊リンク）。content JSON が唯一の正本。
+検証済みの教訓（実機 m365status で確定）:
+- ランタイムの正本は自己参照 N:N `powerpagecomponent_powerpagecomponent`
+  **アソシエーション**。content JSON の `adx_entitypermission_webrole` 配列は
+  YAML/git シリアライズ形であり、これだけ書いても association が無ければ 403
+  (90040120 EntityPermissionReadIsMissing) になる。
+- そのため本スクリプトは **(1) content JSON 配列の冪等付与** と
+  **(2) N:N association の冪等作成（$ref POST）** の両方を行う。
+- association は方向性があり、権限(type=18)→ロール(type=11) 方向で
+  `$ref` POST する（`POST .../powerpagecomponents({permId})/`
+  `powerpagecomponent_powerpagecomponent/$ref`）。
 - Web ロール名の既定一致は "Authenticated"（部分一致）。
 """
 import os
@@ -82,8 +89,33 @@ def get_webrole_ids(site_id: str, headers: dict) -> list:
     return ids
 
 
+def get_associated_role_ids(perm_id: str, headers: dict) -> set:
+    """権限(type=18)に N:N association 済みの Web ロール ID 集合を取得"""
+    r = requests.get(
+        f"{API}/powerpagecomponents({perm_id})"
+        f"?$select=powerpagecomponentid"
+        f"&$expand=powerpagecomponent_powerpagecomponent($select=powerpagecomponentid)",
+        headers=headers,
+    )
+    r.raise_for_status()
+    assoc = r.json().get("powerpagecomponent_powerpagecomponent", [])
+    return {a["powerpagecomponentid"] for a in assoc}
+
+
+def ensure_association(perm_id: str, role_id: str, headers: dict):
+    """権限→ロールの N:N association を作成（$ref POST, 冪等）。
+    これがランタイム正本。content JSON だけでは 403 になる。"""
+    requests.post(
+        f"{API}/powerpagecomponents({perm_id})/powerpagecomponent_powerpagecomponent/$ref",
+        headers=headers,
+        json={"@odata.id": f"{API}/powerpagecomponents({role_id})"},
+    ).raise_for_status()
+
+
 def relink_all(site_id: str, role_ids: list, headers: dict) -> int:
-    """全 type=18 テーブル権限の content.adx_entitypermission_webrole に role を冪等付与"""
+    """全 type=18 テーブル権限に対し、Web ロールを冪等再付与する。
+    (1) content.adx_entitypermission_webrole 配列（YAML シリアライズ形）
+    (2) N:N association（ランタイム正本）の両方を更新する。"""
     r = requests.get(
         f"{API}/powerpagecomponents?$filter=_powerpagesiteid_value eq {site_id} "
         f"and powerpagecomponenttype eq 18&$select=powerpagecomponentid,name,content&$top=500",
@@ -98,21 +130,35 @@ def relink_all(site_id: str, role_ids: list, headers: dict) -> int:
             content = json.loads(c.get("content") or "{}")
         except json.JSONDecodeError:
             content = {}
+
+        changed = False
+
+        # (1) content JSON 配列（YAML/git シリアライズ形）を冪等付与
         roles = content.get("adx_entitypermission_webrole") or []
-        missing = [rid for rid in role_ids if rid not in roles]
-        if not missing:
+        missing_in_content = [rid for rid in role_ids if rid not in roles]
+        if missing_in_content:
+            roles.extend(missing_in_content)
+            content["adx_entitypermission_webrole"] = roles
+            if not content.get("websiteid"):
+                content["websiteid"] = site_id
+            requests.patch(
+                f"{API}/powerpagecomponents({cid})",
+                headers=headers, json={"content": json.dumps(content)},
+            ).raise_for_status()
+            changed = True
+
+        # (2) N:N association（ランタイム正本）を冪等作成
+        associated = get_associated_role_ids(cid, headers)
+        missing_assoc = [rid for rid in role_ids if rid not in associated]
+        for rid in missing_assoc:
+            ensure_association(cid, rid, headers)
+            changed = True
+
+        if changed:
+            print(f"  FIXED: {name} → content={len(missing_in_content)} assoc={len(missing_assoc)} 件付与")
+            fixed += 1
+        else:
             print(f"  OK   : {name}")
-            continue
-        roles.extend(missing)
-        content["adx_entitypermission_webrole"] = roles
-        if not content.get("websiteid"):
-            content["websiteid"] = site_id
-        requests.patch(
-            f"{API}/powerpagecomponents({cid})",
-            headers=headers, json={"content": json.dumps(content)},
-        ).raise_for_status()
-        print(f"  FIXED: {name} → Web ロールを再付与")
-        fixed += 1
     return fixed
 
 

--- a/.github/skills/power-pages/scripts/review_pre_deploy.py
+++ b/.github/skills/power-pages/scripts/review_pre_deploy.py
@@ -211,14 +211,21 @@ def check_environment():
 # ---------------------------------------------------------------------------
 
 def _content_has_webrole(content_str) -> bool:
-    """type=18 の content JSON 内 adx_entitypermission_webrole が非空かを判定。
-    これがランタイム正本。N:N powerpagecomponent_powerpagecomponent は幽霊なので使わない。"""
+    """type=18 の content JSON 内 adx_entitypermission_webrole（YAML/git シリアライズ形）が
+    非空かを判定。ランタイム正本は N:N association（_assoc_has_webrole 参照）。"""
     try:
         content = json.loads(content_str) if content_str else {}
     except (json.JSONDecodeError, TypeError):
         return False
     roles = content.get("adx_entitypermission_webrole")
     return bool(roles)
+
+
+def _assoc_has_webrole(perm) -> bool:
+    """type=18 に N:N association で Web ロール(type=11) が紐付いているかを判定。
+    これがランタイム正本。content 配列だけでは 403 (90040120) になる。"""
+    assoc = perm.get("powerpagecomponent_powerpagecomponent", []) or []
+    return any(a.get("powerpagecomponenttype") == 11 for a in assoc)
 
 
 def check_table_permissions():
@@ -239,11 +246,12 @@ def check_table_permissions():
         token = auth_helper.get_token(scope=f"{dv_url}/.default")
         headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
 
-        # テーブル権限一覧 (type=18)
+        # テーブル権限一覧 (type=18) — N:N association も $expand で取得
         r = requests.get(
             f"{dv_url}/api/data/v9.2/powerpagecomponents"
             "?$filter=powerpagecomponenttype eq 18"
-            "&$select=name,content,_powerpagesitelanguageid_value",
+            "&$select=name,content,_powerpagesitelanguageid_value"
+            "&$expand=powerpagecomponent_powerpagecomponent($select=name,powerpagecomponenttype)",
             headers=headers, timeout=30
         )
         if r.status_code != 200:
@@ -269,7 +277,7 @@ def check_table_permissions():
 
             entity = content.get("entitylogicalname", "?")
             scope = content.get("scope", "?")
-            has_webrole = "adx_entitypermission_webrole" in content and content["adx_entitypermission_webrole"]
+            has_webrole = _assoc_has_webrole(perm)
             has_append = content.get("append", False)
             has_appendto = content.get("appendto", False)
 
@@ -279,8 +287,8 @@ def check_table_permissions():
             else:
                 check("3.3", f"{name}: languageid 設定済み", True)
 
-            # 3.2 webrole
-            check("3.2", f"{name}: adx_entitypermission_webrole あり", has_webrole)
+            # 3.2 webrole（ランタイム正本＝N:N association）
+            check("3.2", f"{name}: N:N association で Web ロール紐付けあり", has_webrole)
 
             # 3.5 Contact scope
             if entity == "contact":
@@ -292,12 +300,12 @@ def check_table_permissions():
                 check("3.6", f"{name}: append={has_append}, appendto={has_appendto}",
                       has_append and has_appendto)
 
-        # 3.7 全権限の content webrole 検証（ランタイム正本＝content JSON の adx_entitypermission_webrole）
-        #     N:N powerpagecomponent_powerpagecomponent は幽霊リンクなので検証に使わない
+        # 3.7 全権限の N:N association 検証（ランタイム正本）
+        #     content JSON の adx_entitypermission_webrole 配列だけでは association が空になりうる
         if permissions:
             missing = [p["name"] for p in permissions
-                       if not _content_has_webrole(p.get("content"))]
-            check("3.7", f"全 {len(permissions)} 権限の content に adx_entitypermission_webrole あり"
+                       if not _assoc_has_webrole(p)]
+            check("3.7", f"全 {len(permissions)} 権限に N:N association で Web ロール紐付けあり"
                          + (f"（未設定: {', '.join(missing)}）" if missing else ""),
                   len(missing) == 0)
 

--- a/.github/skills/power-pages/scripts/setup_contact_self.py
+++ b/.github/skills/power-pages/scripts/setup_contact_self.py
@@ -5,17 +5,22 @@ Power Pages contact テーブル Self 権限セットアップ（/profile 機能
 以下を content JSON 正本方式で冪等に作成する（EDM 2.0 / Code Site 対応）:
 
 1. contact テーブル権限 (powerpagecomponent type=18, scope=Self=756150004)
-   read/write=true, create/delete=false, Authenticated Users を content に紐付け
+   read/write=true, create/delete=false, Authenticated Users を content と
+   **N:N association** の両方で紐付け
 2. Webapi/contact/enabled  (powerpagecomponent type=9) = true
 3. Webapi/contact/fields    (powerpagecomponent type=9) = 使用する全列
 
-重要な教訓:
+重要な教訓（実機 m365status で確定）:
 - mspp_scope (API 確認済み): 756150000=Global / 756150001=Contact /
   756150002=Account / 756150003=Parent / **756150004=Self**
-- Web ロール紐付けの正本は content JSON の adx_entitypermission_webrole。
-  自己参照 N:N $ref POST は幽霊リンク（204 を返すが認識されない）。
-- Web API は fields 許可リスト外の列を要求すると **403** を返す。
-  クライアントが SELECT する全列（例: fullname）を必ず網羅すること。
+- Web ロール紐付けのランタイム正本は自己参照 N:N
+  `powerpagecomponent_powerpagecomponent` **アソシエーション**。
+  content JSON の adx_entitypermission_webrole だけでは association が空のまま
+  残り 403 (90040120 EntityPermissionReadIsMissing) になる。$ref POST で
+  association を作成して初めてランタイムが認識する。
+- Web API は fields 許可リスト外の列を要求すると **403**
+  (90040101 AttributePermissionIsMissing) を返す。$select なし取得は
+  全列 (`*`) 要求と同等なので、fields は `*` が最も安全。
 - 設定変更後はサイト再起動が必要（PP_SUBDOMAIN 設定時に自動実行）。
 
 前提: .env に DATAVERSE_URL, ENV_ID。再起動には PP_SUBDOMAIN。
@@ -36,10 +41,9 @@ SUBDOMAIN = os.environ.get("PP_SUBDOMAIN", "")
 API = f"{DATAVERSE_URL}/api/data/v9.2"
 
 SELF_SCOPE = 756150004  # mspp_scope: セルフ
-# /profile の checkAuth + 編集で使う全列を網羅（fields 許可リスト外は 403 になる）
-CONTACT_FIELDS = os.environ.get(
-    "CONTACT_WEBAPI_FIELDS", "firstname,lastname,emailaddress1,telephone1,fullname"
-)
+# /profile の checkAuth + 編集で使う全列。fields 許可リスト外は 403 になるため
+# `*`（全列許可）が最も安全。$select なし取得は `*` 要求と同等。
+CONTACT_FIELDS = os.environ.get("CONTACT_WEBAPI_FIELDS", "*")
 
 
 def get_headers(scope: str = None):
@@ -110,7 +114,8 @@ def create_component(site_id: str, ctype: int, name: str, content: dict, headers
 
 
 def setup_contact_permission(site_id: str, role_id: str, headers: dict):
-    """contact Self テーブル権限 (type=18) を content JSON 正本方式で作成/更新"""
+    """contact Self テーブル権限 (type=18) を content JSON と N:N association の
+    両方で作成/更新する。ランタイム正本は association。"""
     name = "Contact - Self"
     existing = find_component(site_id, 18, name, headers)
     content = {
@@ -125,6 +130,7 @@ def setup_contact_permission(site_id: str, role_id: str, headers: dict):
         "permissionfetchxml": None,
     }
     if existing:
+        perm_id = existing["powerpagecomponentid"]
         cur = json.loads(existing.get("content") or "{}")
         roles = cur.get("adx_entitypermission_webrole") or []
         if role_id not in roles:
@@ -132,12 +138,38 @@ def setup_contact_permission(site_id: str, role_id: str, headers: dict):
         cur["adx_entitypermission_webrole"] = roles
         cur["websiteid"] = site_id
         requests.patch(
-            f"{API}/powerpagecomponents({existing['powerpagecomponentid']})",
+            f"{API}/powerpagecomponents({perm_id})",
             headers=headers, json={"content": json.dumps(cur)},
         ).raise_for_status()
-        print(f"  UPDATED: {name} の Web ロール紐付けを確認/補正")
+        print(f"  UPDATED: {name} の content Web ロール紐付けを確認/補正")
     else:
-        create_component(site_id, 18, name, content, headers)
+        perm_id = create_component(site_id, 18, name, content, headers)
+
+    # ランタイム正本: N:N association を冪等作成（content だけでは 403）
+    ensure_association(perm_id, role_id, headers)
+
+
+def ensure_association(perm_id: str, role_id: str, headers: dict):
+    """権限(type=18)→Web ロール(type=11) の N:N association を冪等作成。
+    これがランタイム正本。content JSON 配列だけでは 403 になる。"""
+    r = requests.get(
+        f"{API}/powerpagecomponents({perm_id})"
+        f"?$select=powerpagecomponentid"
+        f"&$expand=powerpagecomponent_powerpagecomponent($select=powerpagecomponentid)",
+        headers=headers,
+    )
+    r.raise_for_status()
+    assoc = {a["powerpagecomponentid"]
+             for a in r.json().get("powerpagecomponent_powerpagecomponent", [])}
+    if role_id in assoc:
+        print("  ASSOC OK: N:N association は既に存在")
+        return
+    requests.post(
+        f"{API}/powerpagecomponents({perm_id})/powerpagecomponent_powerpagecomponent/$ref",
+        headers=headers,
+        json={"@odata.id": f"{API}/powerpagecomponents({role_id})"},
+    ).raise_for_status()
+    print("  ASSOC CREATED: N:N association を作成（ランタイム正本）")
 
 
 def setup_webapi_setting(site_id: str, key: str, value: str, headers: dict):

--- a/.github/skills/power-pages/scripts/setup_contact_self.py
+++ b/.github/skills/power-pages/scripts/setup_contact_self.py
@@ -1,0 +1,202 @@
+"""
+Power Pages contact テーブル Self 権限セットアップ（/profile 機能の前提）
+
+ログインユーザー自身の取引先担当者（contact）を編集する `/profile` 画面のために、
+以下を content JSON 正本方式で冪等に作成する（EDM 2.0 / Code Site 対応）:
+
+1. contact テーブル権限 (powerpagecomponent type=18, scope=Self=756150004)
+   read/write=true, create/delete=false, Authenticated Users を content に紐付け
+2. Webapi/contact/enabled  (powerpagecomponent type=9) = true
+3. Webapi/contact/fields    (powerpagecomponent type=9) = 使用する全列
+
+重要な教訓:
+- mspp_scope (API 確認済み): 756150000=Global / 756150001=Contact /
+  756150002=Account / 756150003=Parent / **756150004=Self**
+- Web ロール紐付けの正本は content JSON の adx_entitypermission_webrole。
+  自己参照 N:N $ref POST は幽霊リンク（204 を返すが認識されない）。
+- Web API は fields 許可リスト外の列を要求すると **403** を返す。
+  クライアントが SELECT する全列（例: fullname）を必ず網羅すること。
+- 設定変更後はサイト再起動が必要（PP_SUBDOMAIN 設定時に自動実行）。
+
+前提: .env に DATAVERSE_URL, ENV_ID。再起動には PP_SUBDOMAIN。
+"""
+import os
+import sys
+import json
+import requests
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from auth_helper import get_token
+
+DATAVERSE_URL = os.environ["DATAVERSE_URL"].rstrip("/")
+ENV_ID = os.environ.get("ENV_ID", "")
+SUBDOMAIN = os.environ.get("PP_SUBDOMAIN", "")
+
+API = f"{DATAVERSE_URL}/api/data/v9.2"
+
+SELF_SCOPE = 756150004  # mspp_scope: セルフ
+# /profile の checkAuth + 編集で使う全列を網羅（fields 許可リスト外は 403 になる）
+CONTACT_FIELDS = os.environ.get(
+    "CONTACT_WEBAPI_FIELDS", "firstname,lastname,emailaddress1,telephone1,fullname"
+)
+
+
+def get_headers(scope: str = None):
+    token = get_token(scope=scope) if scope else get_token()
+    return {
+        "Authorization": f"Bearer {token}",
+        "OData-MaxVersion": "4.0",
+        "OData-Version": "4.0",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+def get_site_id(headers: dict) -> str:
+    r = requests.get(
+        f"{API}/powerpagesites?$top=1&$orderby=createdon desc&$select=powerpagesiteid,name",
+        headers=headers,
+    )
+    r.raise_for_status()
+    sites = r.json()["value"]
+    if not sites:
+        print("ERROR: powerpagesites にレコードが見つかりません")
+        sys.exit(1)
+    print(f"  site: {sites[0]['name']} ({sites[0]['powerpagesiteid']})")
+    return sites[0]["powerpagesiteid"]
+
+
+def get_auth_webrole_id(site_id: str, headers: dict) -> str:
+    r = requests.get(
+        f"{API}/powerpagecomponents?$filter=_powerpagesiteid_value eq {site_id} "
+        f"and powerpagecomponenttype eq 11&$select=powerpagecomponentid,name&$top=200",
+        headers=headers,
+    )
+    r.raise_for_status()
+    for c in r.json().get("value", []):
+        if "authenticated" in (c.get("name") or "").lower():
+            print(f"  webrole: {c.get('name')} ({c['powerpagecomponentid']})")
+            return c["powerpagecomponentid"]
+    print("ERROR: Authenticated Users Web ロールが見つかりません")
+    sys.exit(1)
+
+
+def find_component(site_id: str, ctype: int, exact_name: str, headers: dict):
+    r = requests.get(
+        f"{API}/powerpagecomponents?$filter=_powerpagesiteid_value eq {site_id} "
+        f"and powerpagecomponenttype eq {ctype}&$select=powerpagecomponentid,name,content&$top=500",
+        headers=headers,
+    )
+    r.raise_for_status()
+    for c in r.json().get("value", []):
+        if (c.get("name") or "") == exact_name:
+            return c
+    return None
+
+
+def create_component(site_id: str, ctype: int, name: str, content: dict, headers: dict) -> str:
+    body = {
+        "powerpagecomponenttype": ctype,
+        "name": name,
+        "content": json.dumps(content),
+        "powerpagesiteid@odata.bind": f"/powerpagesites({site_id})",
+    }
+    r = requests.post(f"{API}/powerpagecomponents", headers=headers, json=body)
+    r.raise_for_status()
+    cid = r.headers.get("OData-EntityId", "").split("(")[-1].rstrip(")")
+    print(f"  CREATED type={ctype}: {name} ({cid})")
+    return cid
+
+
+def setup_contact_permission(site_id: str, role_id: str, headers: dict):
+    """contact Self テーブル権限 (type=18) を content JSON 正本方式で作成/更新"""
+    name = "Contact - Self"
+    existing = find_component(site_id, 18, name, headers)
+    content = {
+        "filecontent": None,
+        "append": False, "appendto": False, "create": False, "delete": False,
+        "entitylogicalname": "contact", "entityname": name,
+        "parententitypermission": None, "read": True, "scope": SELF_SCOPE,
+        "websiteid": site_id, "write": True,
+        "adx_entitypermission_webrole": [role_id],
+        "parentrelationship": None, "contactrelationship": None,
+        "accountrelationship": None, "childTablePermissions": [],
+        "permissionfetchxml": None,
+    }
+    if existing:
+        cur = json.loads(existing.get("content") or "{}")
+        roles = cur.get("adx_entitypermission_webrole") or []
+        if role_id not in roles:
+            roles.append(role_id)
+        cur["adx_entitypermission_webrole"] = roles
+        cur["websiteid"] = site_id
+        requests.patch(
+            f"{API}/powerpagecomponents({existing['powerpagecomponentid']})",
+            headers=headers, json={"content": json.dumps(cur)},
+        ).raise_for_status()
+        print(f"  UPDATED: {name} の Web ロール紐付けを確認/補正")
+    else:
+        create_component(site_id, 18, name, content, headers)
+
+
+def setup_webapi_setting(site_id: str, key: str, value: str, headers: dict):
+    """Webapi/contact/* サイト設定 (type=9) を content JSON 方式で作成/更新"""
+    existing = find_component(site_id, 9, key, headers)
+    content = {"value": value, "websiteid": site_id}
+    if existing:
+        requests.patch(
+            f"{API}/powerpagecomponents({existing['powerpagecomponentid']})",
+            headers=headers, json={"content": json.dumps(content)},
+        ).raise_for_status()
+        print(f"  UPDATED: {key} = {value}")
+    else:
+        create_component(site_id, 9, key, content, headers)
+
+
+def restart_site():
+    if not SUBDOMAIN or not ENV_ID:
+        print("  SKIP restart: PP_SUBDOMAIN / ENV_ID 未設定")
+        return
+    headers = get_headers(scope="https://api.powerplatform.com/.default")
+    base = f"https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites"
+    r = requests.get(f"{base}?api-version=2024-10-01", headers=headers)
+    r.raise_for_status()
+    for site in r.json()["value"]:
+        if site.get("subdomain", "") == SUBDOMAIN:
+            requests.post(
+                f"{base}/{site['id']}/restart?api-version=2024-10-01", headers=headers
+            ).raise_for_status()
+            print(f"  RESTARTED: {SUBDOMAIN}")
+            return
+    print(f"  WARNING: subdomain '{SUBDOMAIN}' が見つかりません")
+
+
+def main():
+    print("=== contact Self 権限セットアップ（/profile の前提） ===\n")
+    headers = get_headers()
+
+    print("[1/5] サイト ID を取得...")
+    site_id = get_site_id(headers)
+    print()
+
+    print("[2/5] Authenticated Users Web ロールを取得...")
+    role_id = get_auth_webrole_id(site_id, headers)
+    print()
+
+    print("[3/5] contact Self テーブル権限を作成/更新...")
+    setup_contact_permission(site_id, role_id, headers)
+    print()
+
+    print("[4/5] Webapi/contact サイト設定を作成/更新...")
+    setup_webapi_setting(site_id, "Webapi/contact/enabled", "true", headers)
+    setup_webapi_setting(site_id, "Webapi/contact/fields", CONTACT_FIELDS, headers)
+    print()
+
+    print("[5/5] ポータルを再起動...")
+    restart_site()
+    print("\n完了! 再起動後 60-90秒で /profile が利用可能。")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/power-pages/scripts/setup_permissions.py
+++ b/.github/skills/power-pages/scripts/setup_permissions.py
@@ -32,8 +32,12 @@ SUBDOMAIN = os.environ.get("PP_SUBDOMAIN", "")
 # テーブル名と権限レベルのリスト
 TABLES = [
     # (logical_name, scope, read, write, create, delete, fields)
-    # scope: 756150000=Global, 756150001=Self(Contact), 756150002=Parent, 756150003=Account
-    ("contact", 756150001, True, True, False, False, "firstname,lastname,emailaddress1,telephone1,fullname"),
+    # mspp_scope (API で確認済み): 756150000=Global / 756150001=Contact /
+    #   756150002=Account / 756150003=Parent / 756150004=Self
+    # contact 自身（ログインユーザーの取引先担当者）の編集には Self(756150004) を使う。
+    # 注意: fields 許可リストにアプリが SELECT する全列を列挙すること。
+    #   許可リスト外の列を要求すると Web API は 403 を返す（例: fullname の付け忘れ）。
+    ("contact", 756150004, True, True, False, False, "firstname,lastname,emailaddress1,telephone1,fullname"),
     # 以下に必要なテーブルを追加:
     # ("geek_incident", 756150000, True, True, True, False, "*"),
 ]
@@ -153,7 +157,7 @@ def create_table_permission(
     注意: 自己参照 N:N `powerpagecomponent_powerpagecomponent` への $ref POST は
     204 を返すがポータルは認識しない（幽霊リンク）。content が唯一の正本。
     """
-    scope_names = {756150000: "Global", 756150001: "Self", 756150002: "Parent", 756150003: "Account"}
+    scope_names = {756150000: "Global", 756150001: "Contact", 756150002: "Account", 756150003: "Parent", 756150004: "Self"}
     perm_name = f"{table} - {scope_names.get(scope, 'Custom')}"
 
     # 検証済みの content スキーマ（adx_* キー＋websiteid＋adx_entitypermission_webrole）

--- a/.github/skills/power-pages/scripts/setup_permissions.py
+++ b/.github/skills/power-pages/scripts/setup_permissions.py
@@ -5,12 +5,14 @@ Power Pages Web API テーブル権限設定スクリプト
 1. Site Settings (Webapi/{table}/enabled, fields) を adx_sitesettings に作成
 2. powerpagecomponent (type=18) でテーブル権限を作成
 3. Web Role (type=11) を取得または作成
-4. テーブル権限の content JSON に adx_entitypermission_webrole（＋websiteid）を
-   書き込んで Web ロールを紐付ける（＝ランタイム正本）
+4. テーブル権限に Web ロールを (a) content JSON の adx_entitypermission_webrole
+   （YAML/git シリアライズ形）と (b) 自己参照 N:N association（ランタイム正本）の
+   両方で紐付ける
 
-注意: 自己参照 N:N `powerpagecomponent_powerpagecomponent` への $ref POST は
-204 を返すがポータルは認識しない（幽霊リンク）ため使用しない。
-正本は type=18 の content JSON 内 adx_entitypermission_webrole 配列。
+重要（実機 m365status で確定）: ランタイム正本は N:N
+`powerpagecomponent_powerpagecomponent` への $ref POST で作成する association。
+content JSON 配列だけでは association が空のまま残り 403
+(90040120 EntityPermissionReadIsMissing) になる。両方を作成すること。
 
 前提: .env に DATAVERSE_URL, ENV_ID が設定済み。
 """
@@ -151,11 +153,15 @@ def create_table_permission(
     table: str, scope: int, read: bool, write: bool, create: bool, delete: bool,
     site_id: str, role_id: str, website_id: str, headers: dict,
 ) -> str:
-    """テーブル権限 (powerpagecomponent type=18) を作成し、content JSON の
-    adx_entitypermission_webrole に Web ロールを紐付ける（＝ランタイム正本）。
+    """テーブル権限 (powerpagecomponent type=18) を作成し、Web ロールを
+    (1) content JSON の adx_entitypermission_webrole（YAML/git シリアライズ形）
+    (2) 自己参照 N:N `powerpagecomponent_powerpagecomponent` アソシエーション
+    の両方で紐付ける。
 
-    注意: 自己参照 N:N `powerpagecomponent_powerpagecomponent` への $ref POST は
-    204 を返すがポータルは認識しない（幽霊リンク）。content が唯一の正本。
+    重要（実機 m365status で確定）: ランタイム正本は N:N association。
+    content JSON 配列だけでは association が空のまま残り 403
+    (90040120 EntityPermissionReadIsMissing) になるため、$ref POST で
+    association を作成することが必須。
     """
     scope_names = {756150000: "Global", 756150001: "Contact", 756150002: "Account", 756150003: "Parent", 756150004: "Self"}
     perm_name = f"{table} - {scope_names.get(scope, 'Custom')}"
@@ -200,6 +206,7 @@ def create_table_permission(
             headers=headers, json={"content": json.dumps(cur)},
         ).raise_for_status()
         print(f"    Table Permission: content の Web ロール紐付けを更新 ({perm_id})")
+        ensure_association(perm_id, role_id, headers)
         return perm_id
 
     body = {
@@ -215,7 +222,32 @@ def create_table_permission(
     r.raise_for_status()
     ppc_id = r.headers.get("OData-EntityId", "").split("(")[-1].rstrip(")")
     print(f"    Table Permission CREATED: {perm_name} ({ppc_id})")
+    ensure_association(ppc_id, role_id, headers)
     return ppc_id
+
+
+def ensure_association(perm_id: str, role_id: str, headers: dict):
+    """権限(type=18)→Web ロール(type=11) の N:N association を冪等作成。
+    これがランタイム正本。content JSON 配列だけでは 403 になる。"""
+    r = requests.get(
+        f"{DATAVERSE_URL}/api/data/v9.2/powerpagecomponents({perm_id})"
+        f"?$select=powerpagecomponentid"
+        f"&$expand=powerpagecomponent_powerpagecomponent($select=powerpagecomponentid)",
+        headers=headers,
+    )
+    r.raise_for_status()
+    assoc = {a["powerpagecomponentid"]
+             for a in r.json().get("powerpagecomponent_powerpagecomponent", [])}
+    if role_id in assoc:
+        print("    ASSOC OK: N:N association は既に存在")
+        return
+    requests.post(
+        f"{DATAVERSE_URL}/api/data/v9.2/powerpagecomponents({perm_id})"
+        f"/powerpagecomponent_powerpagecomponent/$ref",
+        headers=headers,
+        json={"@odata.id": f"{DATAVERSE_URL}/api/data/v9.2/powerpagecomponents({role_id})"},
+    ).raise_for_status()
+    print("    ASSOC CREATED: N:N association を作成（ランタイム正本）")
 
 
 def restart_site():


### PR DESCRIPTION
## 概要

実案件 IncidentPortal の `/profile`（contact Self 編集）導入で得た知見をスキル化。
`upload-code-site` 後に Web ロール紐付けが消える問題と、Web API の fields 許可リスト外列で 403 になる問題を、再現性のあるスクリプト＋教訓として追加。

## 追加スクリプト

- `scripts/relink_table_permissions.py`（新規）: サイト上の全 type=18 テーブル権限の content.adx_entitypermission_webrole に Web ロール（既定 Authenticated Users）を冪等再付与＋再起動。`upload-code-site` のたびに実行する想定。
- `scripts/setup_contact_self.py`（新規）: contact Self 権限（scope=756150004）＋ Webapi/contact/enabled|fields を content JSON 正本方式で冪等作成。fields はクライアントの SELECT 全列（fullname 含む）を網羅。

## 修正

- `scripts/setup_permissions.py`: mspp_scope コメントの誤りを修正（756150001=Contact、Self=**756150004**）。contact 既定行を Self=756150004 に修正。scope_names を API 確認値に統一。
- `SKILL.md`: 教訓 15（upload-code-site が Web ロール紐付けを消す→デプロイ後 relink 必須）、教訓 16（fields 許可リスト外列で 403）を追加。エラーコード早見表・チェックリスト・Step 3 再デプロイ手順に反映。

## 検証

- 実環境 m365status で全4権限の Authenticated Users 再付与と /profile の 403 解消を確認。
- `py -m py_compile` で3スクリプトの構文 OK。
