### PR TITLE
feat(power-pages): 報告者は Contact Lookup で追跡する設計標準を追加 (教訓 19)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,13 @@ PAGES_SITE_NAME={SiteName}
 PAGES_SUBDOMAIN={subdomain}
 PORTAL_TABLE_LOGICAL={prefix}_incident
 
+# 報告者 Contact Lookup 設定（setup_inquiry_reporter.py 用）
+# Power Pages では createdby はアプリユーザーになるため、報告者は Contact Lookup で追跡する。
+# REPORTER_LOOKUP_ATTR と REPORTER_RELATIONSHIP_SCHEMA はデフォルトが自動生成されるため
+# 変更が必要な場合のみ設定する。
+# REPORTER_LOOKUP_ATTR={prefix}_inquirerid
+# REPORTER_RELATIONSHIP_SCHEMA={prefix}_inquiry_contact
+
 # Power Pages サイト ID（PP API での再起動・アクティブ化に使用）
 # 取得元: GET https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites?api-version=2024-10-01 の value[].id
 # 注意: powerpages.config.json の siteName と PP API 登録名が異なると deploy_site.py の

--- a/.github/skills/dataverse/SKILL.md
+++ b/.github/skills/dataverse/SKILL.md
@@ -141,6 +141,8 @@ existing_tables = api_get(f"EntityDefinitions?$filter=startswith(SchemaName,'{PR
 | **スキーマ名は英語のみ** | 日本語スキーマ名は `npx power-apps add-data-source` で失敗する |
 | **ユーザー参照は SystemUser テーブル** | カスタムユーザーテーブルを作らない |
 | **作成者・報告者は `createdby` システム列を利用** | カスタム ReportedBy Lookup は不要 |
+
+> ⚠️ **Power Pages 例外**: Power Pages では Web API 経由のレコード作成時に `createdby` がアプリケーションユーザー（サービスアカウント）になるため、`createdby` で報告者を追跡できない。Power Pages 向けテーブルでは **Contact テーブルへの Lookup 列で報告者を追跡する**設計が必須。詳細は power-pages スキルの教訓 19 を参照。
 | **Choice 値は `100000000` 始まり** | 0, 1, 2... はカスタム Choice では使用不可 |
 | **マスタテーブルは要件から網羅的に洗い出す** | カテゴリ・場所・設備等、ユーザーが言及した分類はすべてマスタ化 |
 | **全 Lookup リレーションシップを設計書に明記** | 漏れると Lookup が機能しない |

--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -630,6 +630,13 @@ const user = await checkAuth(); // PPUser { contactId, userName, email, ... }
 > カスタム Lookup は不要。Dataverse スキルの「報告者は createdby を利用」ルールは
 > Code Apps（モデル駆動型アプリ含む）に適用される。
 
+**セットアップスクリプト:**
+```bash
+python .github/skills/power-pages/scripts/setup_inquiry_reporter.py
+```
+Lookup 列作成・ローカライズ・Contact AppendTo 付与・Web API 確認・サイト再起動を冪等に実行する。
+`.env` に `PORTAL_TABLE_LOGICAL` を設定するだけで動作する（詳細は `.env.example` 参照）。
+
 ---
 
 ### エラーコード→教訓マッピング
@@ -667,6 +674,7 @@ const user = await checkAuth(); // PPUser { contactId, userName, email, ... }
   → pac pages upload-code-site          ← Inactive Sites に作成
   → py portal/scripts/activate_site.py  ← PP API でアクティブ化 (api-version=2022-03-01-preview)
   → py portal/scripts/setup_contact_webapi.py
+  → py .github/skills/power-pages/scripts/setup_inquiry_reporter.py  ← 報告者 Contact Lookup (教訓 19)
   → Restart (deploy.py --skip-build or PP API restart)
 
 2回目以降:

--- a/.github/skills/power-pages/SKILL.md
+++ b/.github/skills/power-pages/SKILL.md
@@ -576,6 +576,62 @@ create_table_permission(
 | 756150002 | Account | 必要 | 自分の Account 配下 |
 | 756150003 | Parent | 必要 | 親権限に紐づくレコード |
 
+### 教訓 19: Power Pages では `createdby` はアプリケーションユーザーになる → 報告者は Contact Lookup で追跡する
+
+> **Code Apps との違い**: Code Apps では `createdby` = 操作ユーザー（SystemUser）なので報告者追跡に使える。
+> Power Pages では Web API 経由のレコード作成は**ポータルアプリケーションユーザー**が `createdby` に
+> 設定されるため、**実際のログインユーザー（報告者）は `createdby` では追跡できない**。
+
+```
+❌ NG（Power Pages）: createdby で報告者を追跡する設計
+       → createdby = Power Pages アプリケーションユーザー（サービスアカウント）
+       → 誰が報告したか分からない
+
+❌ NG（Power Pages）: 報告者名・メールアドレスを手入力させるフリーテキスト列
+       → ログインユーザーの Contact からすべて取得可能
+       → 入力ミス・なりすましリスク・UX 劣化
+
+✅ OK（Power Pages）: Contact テーブルへの Lookup 列で報告者を追跡
+       → POST 時に bindLookup(body, "geek_inquirerid", "contacts", user.contactId)
+       → ログインユーザーの Contact 情報（氏名・メール・会社・組織）は checkAuth() で自動取得
+       → フォームでは報告者情報を読み取り専用表示（入力不要）
+```
+
+**Power Pages の報告者パターン（標準設計）:**
+
+| 列 | 用途 | 入力 |
+|---|---|---|
+| `{prefix}_inquirerid`（Contact Lookup） | 真の報告者追跡 | 自動（`user.contactId` を `@odata.bind`） |
+| `{prefix}_contactname`（文字列、任意） | 非正規化スナップショット | 自動（`user.userName` を保存） |
+| `{prefix}_contactemail`（文字列、任意） | 非正規化スナップショット | 自動（`user.email` を保存） |
+
+**Contact Self 権限に AppendTo が必須:**
+- Inquiry → Contact の Lookup を POST 時にバインドするには、Contact 側に `appendto: true` が必要
+- 不足すると 403 / 90040106 (AppendTo permission missing)
+
+**フォーム UX パターン:**
+```tsx
+// ログインユーザーの Contact 情報を checkAuth() から取得
+const user = await checkAuth(); // PPUser { contactId, userName, email, ... }
+
+// Lookup で追跡されるため、フォームでは入力不要。読み取り専用表示のみ。
+{hasContactProfile ? (
+  <div className="...">
+    <span>報告者: {reporterName}（{reporterEmail}）</span>
+    <p>ログイン中のアカウント情報が報告者として記録されます。</p>
+  </div>
+) : (
+  // フォールバック: Contact 情報取得不可の場合のみ手入力
+  <input ... />
+)}
+```
+
+> **この設計原則は Power Pages 固有**。Code Apps では `createdby` = 操作ユーザーなので
+> カスタム Lookup は不要。Dataverse スキルの「報告者は createdby を利用」ルールは
+> Code Apps（モデル駆動型アプリ含む）に適用される。
+
+---
+
 ### エラーコード→教訓マッピング
 
 | HTTP | OData Code | メッセージ | 原因 | 教訓 |
@@ -601,6 +657,7 @@ create_table_permission(
 7. **環境のクリーンアップ時は PP API のサイト一覧と照合してから削除する** — 誤削除で 500 エラー
 8. **`credentials: "same-origin"` を使う** — `"include"` ではない（same-site Cookie 認証）
 9. **powerpagecomponent type=18 には `powerpagesitelanguageid` が必須** — 未設定だと 404 になる
+10. **報告者・作成者は Contact Lookup で追跡する** — Power Pages では `createdby` はアプリケーションユーザーになるため使えない。ログインユーザーの Contact 情報を自動取得し入力不要にする（教訓 19）
 
 ## ワークフロー
 

--- a/.github/skills/power-pages/reviews/pre-design-review.md
+++ b/.github/skills/power-pages/reviews/pre-design-review.md
@@ -11,7 +11,7 @@
 
 | # | チェック項目 | 根拠 |
 |---|---|---|
-| 1.1 | 報告者・作成者にカスタム Lookup 列を作っていない（`createdby` で代用） | 教訓4: @odata.bind ターゲット不一致 404 / AppendTo 403 の連鎖を防止 |
+| 1.1 | 報告者・作成者の追跡に Contact への Lookup 列を使用している（`createdby` はアプリユーザーになるため使えない） | 教訓 19: Power Pages では createdby ≠ ログインユーザー |
 | 1.2 | ユーザー参照は `systemuser` テーブルへの Lookup（カスタムユーザーテーブルを作っていない） | Dataverse 標準 |
 | 1.3 | テーブル / 列のスキーマ名が英語（日本語スキーマ名は pac code add-data-source で失敗） | Dataverse 標準 |
 | 1.4 | Choice 値は `100000000` 始まり | カスタム Choice の制約 |
@@ -34,7 +34,7 @@
 | 3.2 | POST/PATCH/DELETE に __RequestVerificationToken を付与する設計 | 教訓1: 401 anti-forgery |
 | 3.3 | `credentials: "same-origin"` を使用（`"include"` ではない） | 核心原則8 |
 | 3.4 | `redirect: "manual"` で認証切れを検知する設計 | 教訓7: 302 → ログインページ追従防止 |
-| 3.5 | 報告者はPOST時に送らず、GET時に `_createdby_value` で取得する設計 | CreatedBy 標準 |
+| 3.5 | 報告者はPOST時に Contact Lookup（`@odata.bind`）でバインドし、フォームでは入力させない設計 | 教訓 19: ログインユーザーの Contact を自動取得 |
 | 3.6 | @odata.bind 使用列の参照先テーブルが ManyToOneRelationships で確認済み | 教訓4: 404 9004010D |
 
 ### 4. テーブル権限設計
@@ -77,7 +77,7 @@ python ../.github/skills/power-pages/scripts/review_pre_design.py
 - `powerpages.config.json` の存在と `compiledPath`
 - `src/lib/api.ts` の `credentials`/`redirect`/`__RequestVerificationToken` パターン
 - `src/**/*.ts{x}` で `@odata.bind` 使用時の参照先確認
-- `src/**/*.ts{x}` で `createdby` 標準の遵守（カスタム reporter 列不使用）
+- `src/**/*.ts{x}` で Contact Lookup パターンの使用確認（`@odata.bind` で contacts にバインド / `checkAuth()` でユーザー情報取得）
 - ルーターが `HashRouter` であること
 
 ---
@@ -86,7 +86,7 @@ python ../.github/skills/power-pages/scripts/review_pre_design.py
 
 | 不合格項目 | 次のアクション |
 |---|---|
-| 1.1 報告者にカスタム Lookup | テーブルから列を削除し createdby 利用に設計変更 |
+| 1.1 報告者に Contact Lookup がない | Contact への Lookup 列を追加し、フォームでは checkAuth() からログインユーザー情報を自動セット（教訓 19） |
 | 2.2 contacts クエリ | Portal.User + セッション Cookie に変更 |
 | 3.6 @odata.bind 未確認 | `EntityDefinitions/ManyToOneRelationships` で参照先を確認 |
 | 4.6 languageid 計画なし | setup_permissions.py に languageid 設定を追加 |

--- a/.github/skills/power-pages/scripts/review_pre_design.py
+++ b/.github/skills/power-pages/scripts/review_pre_design.py
@@ -142,37 +142,35 @@ def check_api_patterns():
           "__RequestVerificationToken" in content or "RequestVerificationToken" in content)
 
 
-def check_createdby_standard():
-    """[1.1, 3.5] CreatedBy 標準の遵守確認."""
-    print("\n[4] CreatedBy 標準")
+def check_contact_lookup_standard():
+    """[1.1, 3.5] Power Pages 報告者パターンの確認.
+    Power Pages では createdby はアプリケーションユーザーになるため、
+    報告者の追跡は Contact テーブルへの Lookup で行う。
+    checkAuth() でログインユーザー情報を取得し入力不要にする設計。
+    """
+    print("\n[4] 報告者 Contact Lookup 標準 (教訓 19)")
 
     tsx_files = find_files(SRC_DIR, "*.tsx") + find_files(SRC_DIR, "*.ts")
 
-    # カスタム reporter @odata.bind パターンを探す
-    reporter_bind_pattern = re.compile(r'(reporter|inquirer|reportedby).*@odata\.bind', re.IGNORECASE)
-    # カスタム reporter Lookup 使用パターン
-    reporter_lookup_pattern = re.compile(r'_geek_(reporter|inquirer)id_value', re.IGNORECASE)
-    # createdby の正しい使用
-    createdby_pattern = re.compile(r'_createdby_value')
+    # Contact への @odata.bind パターン（正しいパターン）
+    contact_bind_pattern = re.compile(r'(inquirer|reporter|contact).*@odata\.bind.*contacts', re.IGNORECASE)
+    # checkAuth / useAuthUser でログインユーザー取得（正しいパターン）
+    check_auth_pattern = re.compile(r'checkAuth|useAuthUser', re.IGNORECASE)
 
-    violations = []
-    uses_createdby = False
+    uses_contact_lookup = False
+    uses_auth_for_reporter = False
 
     for f in tsx_files:
         content = read_text(f)
-        if reporter_bind_pattern.search(content):
-            violations.append(f"  → {f.relative_to(PORTAL_ROOT)}: @odata.bind にカスタム reporter")
-        if reporter_lookup_pattern.search(content):
-            violations.append(f"  → {f.relative_to(PORTAL_ROOT)}: カスタム reporter Lookup 参照")
-        if createdby_pattern.search(content):
-            uses_createdby = True
+        if contact_bind_pattern.search(content):
+            uses_contact_lookup = True
+        if check_auth_pattern.search(content):
+            uses_auth_for_reporter = True
 
-    check("1.1", "カスタム reporter @odata.bind を使用していない", len(violations) == 0)
-    if violations:
-        for v in violations:
-            print(f"    {v}")
-
-    check("3.5", "報告者表示に _createdby_value を使用している", uses_createdby)
+    check("1.1", "報告者追跡に Contact Lookup (@odata.bind → contacts) を使用している",
+          uses_contact_lookup)
+    check("3.5", "ログインユーザー情報を checkAuth()/useAuthUser() で自動取得している",
+          uses_auth_for_reporter)
 
 
 def check_auth_design():
@@ -209,7 +207,7 @@ def main():
     check_powerpages_config()
     check_router()
     check_api_patterns()
-    check_createdby_standard()
+    check_contact_lookup_standard()
     check_auth_design()
 
     # サマリー

--- a/.github/skills/power-pages/scripts/setup_inquiry_reporter.py
+++ b/.github/skills/power-pages/scripts/setup_inquiry_reporter.py
@@ -1,0 +1,360 @@
+"""
+Power Pages 問い合わせ報告者 Contact Lookup セットアップ
+
+Power Pages では createdby がアプリケーションユーザー（サービスアカウント）になるため、
+ログインユーザー（報告者）を追跡するには Contact テーブルへの Lookup 列が必要。
+このスクリプトは以下を冪等に実行する:
+
+1. カスタムテーブルに Contact への Lookup 列を作成（Dataverse メタデータ API）
+2. Contact テーブル権限に appendto=true を付与（Lookup バインドに必須）
+3. カスタムテーブルの Web API 有効化を確認
+
+前提:
+  - .env に DATAVERSE_URL, ENV_ID, SOLUTION_NAME, PUBLISHER_PREFIX
+  - .env に PORTAL_TABLE_LOGICAL（対象テーブルの論理名）
+  - Contact Self 権限は setup_contact_self.py で作成済み
+
+設計原則（教訓 19）:
+  - Power Pages では createdby ≠ ログインユーザー → Contact Lookup で追跡
+  - フォームでは checkAuth() で Contact 情報を自動取得し入力不要にする
+  - Code Apps では createdby = 操作ユーザーなのでこのスクリプトは不要
+
+Usage:
+  python .github/skills/power-pages/scripts/setup_inquiry_reporter.py
+"""
+import os
+import sys
+import json
+import time
+import requests
+from pathlib import Path
+
+# auth_helper を読み込む（スキルルート → skills/standard/scripts）
+SKILL_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(SKILL_ROOT))
+from auth_helper import get_token, retry_metadata
+
+# === 環境変数 ===
+DATAVERSE_URL = os.environ["DATAVERSE_URL"].rstrip("/")
+ENV_ID = os.environ.get("ENV_ID", "")
+SOLUTION_NAME = os.environ.get("SOLUTION_NAME", "")
+PREFIX = os.environ.get("PUBLISHER_PREFIX", "")
+SUBDOMAIN = os.environ.get("PP_SUBDOMAIN", "")
+
+# 対象テーブル（レコードを作成するテーブル。報告者 Lookup を追加する先）
+TABLE_LOGICAL = os.environ.get("PORTAL_TABLE_LOGICAL", "")
+# Lookup 列名（デフォルト: {prefix}_inquirerid）
+LOOKUP_ATTR = os.environ.get("REPORTER_LOOKUP_ATTR", f"{PREFIX}_inquirerid")
+# リレーション スキーマ名
+RELATIONSHIP_SCHEMA = os.environ.get(
+    "REPORTER_RELATIONSHIP_SCHEMA", f"{PREFIX}_{TABLE_LOGICAL.replace(PREFIX + '_', '')}_contact"
+)
+
+API = f"{DATAVERSE_URL}/api/data/v9.2"
+
+
+def get_headers(scope: str = None) -> dict:
+    token = get_token(scope=scope) if scope else get_token()
+    return {
+        "Authorization": f"Bearer {token}",
+        "OData-MaxVersion": "4.0",
+        "OData-Version": "4.0",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+def check_env():
+    """必須環境変数の確認"""
+    missing = []
+    if not DATAVERSE_URL:
+        missing.append("DATAVERSE_URL")
+    if not SOLUTION_NAME:
+        missing.append("SOLUTION_NAME")
+    if not PREFIX:
+        missing.append("PUBLISHER_PREFIX")
+    if not TABLE_LOGICAL:
+        missing.append("PORTAL_TABLE_LOGICAL")
+    if missing:
+        print(f"ERROR: 必須環境変数が未設定: {', '.join(missing)}")
+        print("  .env.example を参照して設定してください")
+        sys.exit(1)
+
+
+def check_table_exists(headers: dict) -> bool:
+    """対象テーブルの存在確認"""
+    r = requests.get(
+        f"{API}/EntityDefinitions(LogicalName='{TABLE_LOGICAL}')?$select=LogicalName",
+        headers=headers,
+    )
+    return r.status_code == 200
+
+
+def check_lookup_exists(headers: dict) -> bool:
+    """Lookup 列が既に存在するか確認"""
+    r = requests.get(
+        f"{API}/EntityDefinitions(LogicalName='{TABLE_LOGICAL}')"
+        f"/Attributes(LogicalName='{LOOKUP_ATTR}')?$select=LogicalName",
+        headers=headers,
+    )
+    return r.status_code == 200
+
+
+def create_contact_lookup(headers: dict):
+    """Contact テーブルへの Lookup 列 (ManyToOne) を作成"""
+
+    body = {
+        "@odata.type": "#Microsoft.Dynamics.CRM.OneToManyRelationshipMetadata",
+        "SchemaName": RELATIONSHIP_SCHEMA,
+        "ReferencedEntity": "contact",
+        "ReferencingEntity": TABLE_LOGICAL,
+        "Lookup": {
+            "SchemaName": LOOKUP_ATTR,
+            "DisplayName": {
+                "@odata.type": "#Microsoft.Dynamics.CRM.Label",
+                "LocalizedLabels": [
+                    {"@odata.type": "#Microsoft.Dynamics.CRM.LocalizedLabel",
+                     "Label": "Inquirer", "LanguageCode": 1033},
+                    {"@odata.type": "#Microsoft.Dynamics.CRM.LocalizedLabel",
+                     "Label": "報告者", "LanguageCode": 1041},
+                ],
+            },
+            "RequiredLevel": {"Value": "None"},
+        },
+    }
+
+    sol_header = {"MSCRM.SolutionName": SOLUTION_NAME} if SOLUTION_NAME else {}
+    h = {**headers, **sol_header}
+
+    r = requests.post(f"{API}/RelationshipDefinitions", headers=h, json=body)
+    if r.status_code in (200, 201, 204):
+        print(f"  CREATED: Lookup '{LOOKUP_ATTR}' (→ contact)")
+        return True
+    elif "already exists" in r.text.lower() or r.status_code == 409:
+        print(f"  SKIP: リレーション '{RELATIONSHIP_SCHEMA}' は既に存在")
+        return True
+    else:
+        print(f"  ERROR: {r.status_code} — {r.text[:500]}")
+        return False
+
+
+def localize_lookup(headers: dict):
+    """Lookup 列の日本語ラベルを設定"""
+    r = requests.get(
+        f"{API}/EntityDefinitions(LogicalName='{TABLE_LOGICAL}')"
+        f"/Attributes(LogicalName='{LOOKUP_ATTR}')?$select=MetadataId",
+        headers=headers,
+    )
+    if r.status_code != 200:
+        print("  SKIP ローカライズ: 列が見つかりません")
+        return
+    mid = r.json()["MetadataId"]
+    body = {
+        "@odata.type": "#Microsoft.Dynamics.CRM.LookupAttributeMetadata",
+        "MetadataId": mid,
+        "DisplayName": {
+            "@odata.type": "#Microsoft.Dynamics.CRM.Label",
+            "LocalizedLabels": [
+                {"@odata.type": "#Microsoft.Dynamics.CRM.LocalizedLabel",
+                 "Label": "報告者", "LanguageCode": 1041},
+                {"@odata.type": "#Microsoft.Dynamics.CRM.LocalizedLabel",
+                 "Label": "Inquirer", "LanguageCode": 1033},
+            ],
+        },
+    }
+    h = {**headers, "MSCRM.MergeLabels": "true"}
+    r = requests.put(
+        f"{API}/EntityDefinitions(LogicalName='{TABLE_LOGICAL}')/Attributes({mid})",
+        headers=h, json=body,
+    )
+    if r.status_code in (200, 204):
+        print("  LOCALIZED: 報告者 / Inquirer")
+    else:
+        print(f"  WARN: ローカライズ失敗 {r.status_code}")
+
+
+def publish_all(headers: dict):
+    """カスタマイズ公開"""
+    r = requests.post(f"{API}/PublishAllXml", headers=headers, json={})
+    if r.status_code in (200, 204):
+        print("  PublishAllXml: OK")
+    else:
+        print(f"  PublishAllXml: {r.status_code} (再実行してください)")
+
+
+def ensure_contact_appendto(headers: dict):
+    """Contact Self テーブル権限に appendto=true を付与。
+    Lookup バインド時に Contact 側に AppendTo 権限がないと 403 になる。"""
+    # サイト ID を取得
+    r = requests.get(
+        f"{API}/powerpagesites?$top=1&$orderby=createdon desc&$select=powerpagesiteid",
+        headers=headers,
+    )
+    r.raise_for_status()
+    sites = r.json()["value"]
+    if not sites:
+        print("  SKIP: powerpagesites が見つかりません")
+        return
+    site_id = sites[0]["powerpagesiteid"]
+
+    # Contact - Self 権限を検索
+    r = requests.get(
+        f"{API}/powerpagecomponents?$filter=_powerpagesiteid_value eq {site_id} "
+        f"and powerpagecomponenttype eq 18&$select=powerpagecomponentid,name,content&$top=500",
+        headers=headers,
+    )
+    r.raise_for_status()
+    contact_perm = None
+    for c in r.json().get("value", []):
+        content = json.loads(c.get("content") or "{}")
+        if content.get("entitylogicalname") == "contact" and content.get("scope") == 756150004:
+            contact_perm = c
+            break
+
+    if not contact_perm:
+        print("  SKIP: Contact Self 権限が見つかりません（先に setup_contact_self.py を実行してください）")
+        return
+
+    content = json.loads(contact_perm.get("content") or "{}")
+    if content.get("appendto"):
+        print("  OK: Contact Self 権限の appendto は既に true")
+        return
+
+    # appendto を有効化
+    content["appendto"] = True
+    r = requests.patch(
+        f"{API}/powerpagecomponents({contact_perm['powerpagecomponentid']})",
+        headers=headers,
+        json={"content": json.dumps(content)},
+    )
+    r.raise_for_status()
+    print("  UPDATED: Contact Self 権限に appendto=true を設定")
+
+
+def verify_webapi_settings(headers: dict):
+    """Webapi/{table}/enabled と fields の存在を確認（警告のみ）"""
+    # adx_websites からサイトを取得
+    r = requests.get(
+        f"{API}/adx_websites?$top=1&$orderby=createdon desc&$select=adx_websiteid",
+        headers=headers,
+    )
+    if r.status_code != 200 or not r.json().get("value"):
+        print("  SKIP: adx_websites が見つかりません")
+        return
+    website_id = r.json()["value"][0]["adx_websiteid"]
+
+    # EntitySetName を取得
+    r = requests.get(
+        f"{API}/EntityDefinitions(LogicalName='{TABLE_LOGICAL}')?$select=EntitySetName",
+        headers=headers,
+    )
+    if r.status_code != 200:
+        print("  SKIP: EntitySetName 取得失敗")
+        return
+    entity_set = r.json()["EntitySetName"]
+
+    # サイト設定確認
+    enabled_name = f"Webapi/{entity_set}/enabled"
+    r = requests.get(
+        f"{API}/adx_sitesettings?$filter=adx_name eq '{enabled_name}' "
+        f"and _adx_websiteid_value eq '{website_id}'&$select=adx_sitesettingid",
+        headers=headers,
+    )
+    if r.status_code == 200 and r.json().get("value"):
+        print(f"  OK: {enabled_name} = true")
+    else:
+        print(f"  WARN: {enabled_name} が見つかりません。setup_permissions.py で作成してください")
+
+
+def restart_site(headers: dict):
+    """PP API でサイトを再起動"""
+    if not SUBDOMAIN or not ENV_ID:
+        print("  SKIP: PP_SUBDOMAIN / ENV_ID 未設定")
+        return
+    pp_headers = get_headers(scope="https://api.powerplatform.com/.default")
+    base = f"https://api.powerplatform.com/powerpages/environments/{ENV_ID}/websites"
+    r = requests.get(f"{base}?api-version=2024-10-01", headers=pp_headers)
+    if r.status_code != 200:
+        print(f"  WARN: PP API リスト取得失敗 ({r.status_code})")
+        return
+    for site in r.json().get("value", []):
+        if site.get("subdomain", "") == SUBDOMAIN:
+            requests.post(
+                f"{base}/{site['id']}/restart?api-version=2024-10-01", headers=pp_headers
+            ).raise_for_status()
+            print(f"  RESTARTED: {SUBDOMAIN}")
+            return
+    print(f"  WARN: subdomain '{SUBDOMAIN}' が見つかりません")
+
+
+def main():
+    print("=" * 60)
+    print("  Power Pages 報告者 Contact Lookup セットアップ（教訓 19）")
+    print("=" * 60)
+    print(f"  環境:       {DATAVERSE_URL}")
+    print(f"  対象テーブル: {TABLE_LOGICAL}")
+    print(f"  Lookup 列:  {LOOKUP_ATTR}")
+    print(f"  リレーション: {RELATIONSHIP_SCHEMA}")
+    print()
+
+    check_env()
+    headers = get_headers()
+
+    # --- Step 1: テーブル存在確認 ---
+    print("[1/6] テーブル存在確認...")
+    if not check_table_exists(headers):
+        print(f"  ERROR: テーブル '{TABLE_LOGICAL}' が存在しません")
+        print("  先に setup_dataverse.py でテーブルを作成してください")
+        sys.exit(1)
+    print(f"  OK: {TABLE_LOGICAL}")
+    print()
+
+    # --- Step 2: Lookup 列作成 ---
+    print("[2/6] Contact Lookup 列を作成...")
+    if check_lookup_exists(headers):
+        print(f"  SKIP: Lookup '{LOOKUP_ATTR}' は既に存在")
+    else:
+        def _create():
+            create_contact_lookup(headers)
+        retry_metadata(_create, f"Lookup {RELATIONSHIP_SCHEMA}")
+        time.sleep(5)
+    print()
+
+    # --- Step 3: ローカライズ ---
+    print("[3/6] 日本語ローカライズ...")
+    localize_lookup(headers)
+    print()
+
+    # --- Step 4: カスタマイズ公開 ---
+    print("[4/6] カスタマイズ公開...")
+    publish_all(headers)
+    print()
+
+    # --- Step 5: Contact Self 権限に AppendTo 付与 ---
+    print("[5/6] Contact Self 権限に AppendTo を付与...")
+    ensure_contact_appendto(headers)
+    print()
+
+    # --- Step 6: Web API 設定確認 + 再起動 ---
+    print("[6/6] Web API 設定確認 + サイト再起動...")
+    verify_webapi_settings(headers)
+    restart_site(headers)
+
+    print()
+    print("=" * 60)
+    print("  完了!")
+    print()
+    print("  次のステップ:")
+    print("  1. フロントエンドで checkAuth() → user.contactId を取得")
+    print(f"  2. POST 時に bindLookup(body, \"{LOOKUP_ATTR}\", \"contacts\", contactId)")
+    print("  3. フォームでは報告者情報を読み取り専用で表示（入力不要）")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except ImportError:
+        pass
+    main()


### PR DESCRIPTION
## 概要

Power Pages では `createdby` がアプリケーションユーザー（サービスアカウント）になるため、ログインユーザー（報告者）の追跡に `createdby` は使えない。

本PRでは「Power Pages の報告者追跡は Contact テーブルへの Lookup で行う」ことを**開発標準として追加**する。

## Code Apps との違い

| 観点 | Code Apps | Power Pages |
|---|---|---|
| createdby | 操作ユーザー（SystemUser）→ **報告者追跡に使える** | アプリケーションユーザー → **使えない** |
| 報告者追跡 | createdby で代用（カスタム列不要） | **Contact への Lookup 列が必須** |
| フォーム入力 | 不要（createdby 自動） | 不要（checkAuth() で Contact 情報を自動取得、読み取り専用表示） |

## 変更内容

### power-pages SKILL.md
- **教訓 19 追加**: Power Pages で createdby がアプリユーザーになる仕組み、正しい Contact Lookup パターン、フォーム UX パターンを記述
- **核心原則 10 追加**: 報告者・作成者は Contact Lookup で追跡する

### dataverse SKILL.md
- `createdby` ルールに **Power Pages 例外注記**を追加（Code Apps のルールは変更なし）

### pre-design-review.md
- チェック 1.1: Contact Lookup を使っているか確認する方向に修正
- チェック 3.5: `checkAuth()` でログインユーザーを自動取得しているか確認する方向に修正
- 不合格時アクション: Contact Lookup 追加の指示に変更

### review_pre_design.py
- `check_createdby_standard()` → `check_contact_lookup_standard()` にリネーム
- ロジック: Contact へのバインドパターンと checkAuth/useAuthUser の使用を検出するよう変更

## テスト

IncidentPortal の問い合わせフォームで実証済み:
- ログインユーザーの Contact 情報を `checkAuth()` で取得
- `bindLookup(body, "geek_inquirerid", "contacts", user.contactId)` で報告者をバインド
- フォームでは報告者名・メール・組織名・報告者種別の入力欄を削除し読み取り専用表示
