### PR TITLE
fix: power.config.json は npx power-apps init で先に生成が必須

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -155,15 +155,15 @@ PUBLISHER_PREFIX={prefix}          ← ソリューション発行者の prefix
    pac auth create --name {profile-name} --environment {ENVIRONMENT_ID}
    pac auth list  # * が付いているのがアクティブ
 
-3. power.config.json は npx power-apps init で生成する
+3. power.config.json は pac code init で生成する
    → テンプレートから手動コピーしない
    → 別環境の appId が残っていると: AppLeaseMissing (409) エラー
-   → 新規環境では必ず npx power-apps init で新規生成
+   → 新規環境では必ず pac code init で新規生成
 ```
 
-### `npx power-apps init` でスキャフォールドされるファイル（手動作成禁止）
+### `pac code init` でスキャフォールドされるファイル（手動作成禁止）
 
-`npx power-apps init` は以下のファイルを自動生成する。**これらを手動作成・他プロジェクトからコピーしてはならない。**
+`pac code init` / `npx power-apps init` は以下のファイルを自動生成する。**これらを手動作成・他プロジェクトからコピーしてはならない。**
 
 | ファイル | 役割 | カスタマイズ |
 |---|---|---|
@@ -178,6 +178,8 @@ PUBLISHER_PREFIX={prefix}          ← ソリューション発行者の prefix
 | `components.json` | shadcn/ui 設定 | ⚠ 通常変更不要 |
 
 > **原則**: SDK がスキャフォールドしたインフラファイル（`plugin-power-apps.ts`、`power.config.json`）は変更しない。開発者がカスタマイズするのは `src/` 配下のアプリコードのみ。
+>
+> **`pac code init` vs `npx power-apps init`**: 両方とも `power.config.json` を生成するが、`pac code init` は PAC CLI 認証プロファイルを使用するためテナント不一致の問題が発生しない。`npx power-apps init` は npm パッケージ独自の MSAL 認証を使用し、マルチテナント環境で `Environment not found` エラーが出ることがある。**本開発標準では `pac code init` を標準とする。**
 
 ### .power/ と src/generated/ は SDK コマンドで生成（手動作成禁止）
 
@@ -203,9 +205,9 @@ PUBLISHER_PREFIX={prefix}          ← ソリューション発行者の prefix
 
 ```bash
 # ── Step 1: スキャフォールド ──
-# ⚠ --display-name は必ず英語（ASCII）で指定する。日本語を含めると環境検証で失敗する。
-npx power-apps init --display-name "AppName" --environment-id {ENVIRONMENT_ID} --non-interactive
+pac code init -env {ENVIRONMENT_ID} -n "AppName"
 # ↑ power.config.json がここで生成される（environmentId, buildPath 等が記録される）
+# PAC CLI 認証プロファイルを使用するためテナント不一致なし
 npm install
 
 # ── Step 2: テンプレートクリーンアップ ──
@@ -248,12 +250,14 @@ npm run build && pac code push -env {ENVIRONMENT_ID} -s {SOLUTION_NAME}
 
 | コマンド | 認証基盤 | テナント問題 | 推奨度 |
 |---|---|---|---|
+| `pac code init -env {ID} -n "Name"` | PAC CLI プロファイル | なし | ✅ 標準 |
 | `pac code push -env {ID} -s {SOL}` | PAC CLI プロファイル | なし | ✅ 標準 |
-| `npx power-apps push` | npm パッケージ独自キャッシュ | 403/404 頻発 | ⚠ 動くならOK |
+| `npx power-apps init` | npm パッケージ独自 MSAL | Environment not found 頻発 | ⚠ 動くならOK |
+| `npx power-apps push` | npm パッケージ独自 MSAL | 403/404 頻発 | ⚠ 動くならOK |
 
 > **注**: Microsoft は `npx power-apps` を推奨ツールとしているが、テナント解決の不具合が
-> 2026-05 時点で未修正のため、本開発標準では `pac code push` を標準採用する。
-> `npx power-apps push` が正常動作する環境ではそちらを使っても良い。
+> 2026-06 時点で未修正のため、本開発標準では `pac code init` + `pac code push` を標準採用する。
+> `npx power-apps` が正常動作する環境ではそちらを使っても良い。
 
 ### データソース追加の判断フロー
 
@@ -1502,14 +1506,14 @@ try {
 
 ## Code Apps 開発 Tips（検証済み 2026-05-21）
 
-### 初回デプロイ: `npx power-apps init` → `pac code push`
+### 初回デプロイ: `pac code init` → `pac code push`
 
-`npx power-apps push` はテナント不一致で 403 になるケースがある（troubleshooting.md #10 参照）。
-**初回デプロイは `pac code push` を推奨**:
+`npx power-apps init` / `npx power-apps push` はテナント不一致で失敗するケースがある（troubleshooting.md #10 参照）。
+**初回は `pac code init` + `pac code push` を使用する**:
 
 ```bash
-# ⚠ Step 1: power.config.json の生成が必須（--display-name は英語で指定）
-npx power-apps init --display-name "AppName" --environment-id {ENVIRONMENT_ID} --non-interactive
+# Step 1: power.config.json の生成（PAC CLI 認証プロファイルを使用）
+pac code init -env {ENVIRONMENT_ID} -n "AppName"
 
 # Step 2: ビルド＆デプロイ
 npm run build
@@ -1517,8 +1521,9 @@ pac code push -env {ENVIRONMENT_ID} -s {SOLUTION_NAME}
 ```
 
 - `power.config.json` が未存在だと `pac code push` は `power.config.json is required to push an app` エラーで失敗する
-- `npx power-apps init` で `power.config.json` を先に生成すること（`environmentId`, `buildPath` 等が記録される）
-- `--display-name` に日本語を含めると環境検証（`getEnvironmentByName`）で失敗するため、必ず英語名を指定する
+- `pac code init` で `power.config.json` を先に生成すること（`environmentId`, `buildPath` 等が記録される）
+- `pac code init` は PAC CLI 認証プロファイルを使用するためテナント不一致の問題が発生しない
+- `npx power-apps init` は npm パッケージ独自の MSAL 認証を使用し `Environment not found` が出ることがある
 - 初回デプロイ後に `power.config.json` に `appId` が追記される
 - 2回目以降は引数省略可能
 

--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -203,7 +203,9 @@ PUBLISHER_PREFIX={prefix}          ← ソリューション発行者の prefix
 
 ```bash
 # ── Step 1: スキャフォールド ──
-npx power-apps init --display-name "アプリ名" --environment-id {ENVIRONMENT_ID} --non-interactive
+# ⚠ --display-name は必ず英語（ASCII）で指定する。日本語を含めると環境検証で失敗する。
+npx power-apps init --display-name "AppName" --environment-id {ENVIRONMENT_ID} --non-interactive
+# ↑ power.config.json がここで生成される（environmentId, buildPath 等が記録される）
 npm install
 
 # ── Step 2: テンプレートクリーンアップ ──
@@ -213,10 +215,11 @@ Remove-Item "src/types/incident.ts" -Force -ErrorAction SilentlyContinue
 # ❌ Remove-Item "src/hooks/*" は禁止（use-theme.ts が消える）
 
 # ── Step 3: 初回ビルド＆デプロイ ──
+# ⚠ power.config.json が存在しないと pac code push は失敗する（Step 1 の init が必須）
 npm run build
 pac code push -env {ENVIRONMENT_ID} -s {SOLUTION_NAME}
 # この時点で Power Platform にアプリが登録され Dataverse 接続が確立
-# power.config.json が自動生成される
+# power.config.json に appId が追記される
 
 # ── Step 4: データソース追加 ──
 # テーブル論理名は .env の ${PUBLISHER_PREFIX} を変数展開して組み立てる。
@@ -1499,17 +1502,24 @@ try {
 
 ## Code Apps 開発 Tips（検証済み 2026-05-21）
 
-### 初回デプロイ: `pac code push` を使う
+### 初回デプロイ: `npx power-apps init` → `pac code push`
 
 `npx power-apps push` はテナント不一致で 403 になるケースがある（troubleshooting.md #10 参照）。
 **初回デプロイは `pac code push` を推奨**:
 
 ```bash
+# ⚠ Step 1: power.config.json の生成が必須（--display-name は英語で指定）
+npx power-apps init --display-name "AppName" --environment-id {ENVIRONMENT_ID} --non-interactive
+
+# Step 2: ビルド＆デプロイ
+npm run build
 pac code push -env {ENVIRONMENT_ID} -s {SOLUTION_NAME}
 ```
 
-- `power.config.json` が未存在でも `-env` + `-s` 指定で初回デプロイ可能
-- 初回デプロイ後に `power.config.json` が自動生成される（appId が記録される）
+- `power.config.json` が未存在だと `pac code push` は `power.config.json is required to push an app` エラーで失敗する
+- `npx power-apps init` で `power.config.json` を先に生成すること（`environmentId`, `buildPath` 等が記録される）
+- `--display-name` に日本語を含めると環境検証（`getEnvironmentByName`）で失敗するため、必ず英語名を指定する
+- 初回デプロイ後に `power.config.json` に `appId` が追記される
 - 2回目以降は引数省略可能
 
 ### Dataverse テーブル作成時のメタデータロック回避

--- a/.github/skills/code-apps/references/build-reference.md
+++ b/.github/skills/code-apps/references/build-reference.md
@@ -5,9 +5,8 @@
 ### Step 1: プロジェクト初期化
 
 ```bash
-# ⚠ --display-name は必ず英語（ASCII）で指定する。日本語だと環境検証で失敗する。
-npx power-apps init --display-name "AppName" \
-  --environment-id {ENVIRONMENT_ID} --non-interactive
+# PAC CLI 認証プロファイルを使用（テナント不一致なし）
+pac code init -env {ENVIRONMENT_ID} -n "AppName"
 # ↑ power.config.json がここで生成される
 npm install
 ```

--- a/.github/skills/code-apps/references/build-reference.md
+++ b/.github/skills/code-apps/references/build-reference.md
@@ -5,8 +5,10 @@
 ### Step 1: プロジェクト初期化
 
 ```bash
-npx power-apps init --display-name "アプリ名" \
+# ⚠ --display-name は必ず英語（ASCII）で指定する。日本語だと環境検証で失敗する。
+npx power-apps init --display-name "AppName" \
   --environment-id {ENVIRONMENT_ID} --non-interactive
+# ↑ power.config.json がここで生成される
 npm install
 ```
 

--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -483,21 +483,27 @@ const myRecords = allRecords.filter(
 
 ### 対処
 
-**初回デプロイは `pac code push` を使用する**:
+**初回デプロイは `npx power-apps init` → `pac code push` の順で実行する**:
 
 ```bash
-# ✅ PAC CLI 認証プロファイルを使用（テナント問題なし）
+# ✅ Step 1: power.config.json を生成（--display-name は英語で指定すること）
+npx power-apps init --display-name "AppName" --environment-id {ENVIRONMENT_ID} --non-interactive
+
+# ✅ Step 2: PAC CLI 認証プロファイルを使用してデプロイ（テナント問題なし）
+npm run build
 pac code push -env {ENVIRONMENT_ID} -s {SOLUTION_NAME}
 
-# power.config.json が未生成でも -env + -s で初回デプロイ可能
-# 初回デプロイ後に power.config.json が自動生成される
+# ⚠ power.config.json が未生成だと pac code push は失敗する
+#   エラー: "power.config.json is required to push an app"
 ```
 
 ### 備考
 
+- `npx power-apps init` で `power.config.json` を先に生成すること（`environmentId`, `buildPath` 等が記録される）
+- `--display-name` に日本語を含めると環境検証で失敗する。必ず英語名（ASCII）を指定する
 - `pac code push` は `npm run build` の成果物（`dist/`）を Power Platform にアップロードする
 - `-env` でターゲット環境、`-s` でソリューションを指定
-- 2回目以降は `power.config.json` に appId が記録されるため `-env` `-s` は省略可能
+- 初回デプロイ後に `power.config.json` に `appId` が追記され、2回目以降は `-env` `-s` は省略可能
 
 ---
 

--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -483,13 +483,13 @@ const myRecords = allRecords.filter(
 
 ### 対処
 
-**初回デプロイは `npx power-apps init` → `pac code push` の順で実行する**:
+**初回デプロイは `pac code init` → `pac code push` の順で実行する**:
 
 ```bash
-# ✅ Step 1: power.config.json を生成（--display-name は英語で指定すること）
-npx power-apps init --display-name "AppName" --environment-id {ENVIRONMENT_ID} --non-interactive
+# ✅ Step 1: power.config.json を生成（PAC CLI 認証プロファイルを使用）
+pac code init -env {ENVIRONMENT_ID} -n "AppName"
 
-# ✅ Step 2: PAC CLI 認証プロファイルを使用してデプロイ（テナント問題なし）
+# ✅ Step 2: ビルド＆デプロイ（テナント問題なし）
 npm run build
 pac code push -env {ENVIRONMENT_ID} -s {SOLUTION_NAME}
 
@@ -499,8 +499,8 @@ pac code push -env {ENVIRONMENT_ID} -s {SOLUTION_NAME}
 
 ### 備考
 
-- `npx power-apps init` で `power.config.json` を先に生成すること（`environmentId`, `buildPath` 等が記録される）
-- `--display-name` に日本語を含めると環境検証で失敗する。必ず英語名（ASCII）を指定する
+- `pac code init` は PAC CLI 認証プロファイルを使用するためテナント不一致の問題が発生しない
+- `npx power-apps init` は npm パッケージ独自の MSAL 認証を使用し `Environment not found` が出ることがある
 - `pac code push` は `npm run build` の成果物（`dist/`）を Power Platform にアップロードする
 - `-env` でターゲット環境、`-s` でソリューションを指定
 - 初回デプロイ後に `power.config.json` に `appId` が追記され、2回目以降は `-env` `-s` は省略可能

--- a/.github/skills/standard/references/power-platform-development-standard.md
+++ b/.github/skills/standard/references/power-platform-development-standard.md
@@ -139,13 +139,14 @@ npx power-apps add-data-source --api-id dataverse \
 
 ### 1.4 `power.config.json` は SDK で生成
 
-`power.config.json` は **`npx power-apps init` コマンドで自動生成** する。手動でテンプレートを作成したり、他のプロジェクトからコピーしない。
+`power.config.json` は **`pac code init` コマンドで自動生成** する。手動でテンプレートを作成したり、他のプロジェクトからコピーしない。
 
 ```bash
-# ✅ SDK コマンドで生成（appId, environmentId, region が自動設定される）
-# ⚠ --display-name は必ず英語（ASCII）で指定する。日本語だと環境検証で失敗する。
-npx power-apps init --display-name "AppName" \
-  --environment-id {ENVIRONMENT_ID} --non-interactive
+# ✅ PAC CLI で生成（appId, environmentId, region が自動設定される）
+pac code init -env {ENVIRONMENT_ID} -n "AppName"
+
+# ✅ npx 版でもOK（ただしマルチテナントで Environment not found になることがある）
+# npx power-apps init --display-name "AppName" --environment-id {ENVIRONMENT_ID} --non-interactive
 
 # ❌ 手動で power.config.json を作成・編集する
 # ❌ 別プロジェクトの power.config.json をコピーする（appId が環境固有のため失敗する）
@@ -154,7 +155,7 @@ npx power-apps init --display-name "AppName" \
 
 | エラー                                          | 原因                                      | 対策                             |
 | ----------------------------------------------- | ----------------------------------------- | -------------------------------- |
-| `AppLeaseMissing` (409)                         | 別環境の `appId` がハードコードされている | `npx power-apps init` で新規生成 |
+| `AppLeaseMissing` (409)                         | 別環境の `appId` がハードコードされている | `pac code init` で新規生成 |
 | `CodeAppOperationNotAllowedInEnvironment` (403) | 環境で Code Apps が未許可                 | §1.5 参照                        |
 
 ### 1.5 環境の Code Apps 有効化（前提条件）

--- a/.github/skills/standard/references/power-platform-development-standard.md
+++ b/.github/skills/standard/references/power-platform-development-standard.md
@@ -143,11 +143,13 @@ npx power-apps add-data-source --api-id dataverse \
 
 ```bash
 # ✅ SDK コマンドで生成（appId, environmentId, region が自動設定される）
-npx power-apps init --display-name "アプリ名" \
+# ⚠ --display-name は必ず英語（ASCII）で指定する。日本語だと環境検証で失敗する。
+npx power-apps init --display-name "AppName" \
   --environment-id {ENVIRONMENT_ID} --non-interactive
 
 # ❌ 手動で power.config.json を作成・編集する
 # ❌ 別プロジェクトの power.config.json をコピーする（appId が環境固有のため失敗する）
+# ❌ power.config.json なしで pac code push を実行する（"power.config.json is required" エラー）
 ```
 
 | エラー                                          | 原因                                      | 対策                             |


### PR DESCRIPTION
## 概要

\pac code push\ は \power.config.json\ なしでは動作しません。スキルに「\power.config.json\ が未存在でも初回デプロイ可能」と記載されていましたが、実際には以下のエラーで失敗します:

\\\
power.config.json is required to push an app
\\\

## 修正内容

### 1. \
px power-apps init\ → \pac code push\ の順序を明確化
- \power.config.json\ は \
px power-apps init\ で事前に生成する必要がある
- \pac code push\ 実行時に \ppId\ が追記される（初回生成ではない）

### 2. \--display-name\ は英語（ASCII）で指定する
- 日本語を含めると \getEnvironmentByName\ の環境検証で \Environment not found\ エラーになる

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| \.github/skills/code-apps/SKILL.md\ | 標準ワークフロー + Tips セクション修正 |
| \.github/skills/code-apps/references/troubleshooting.md\ | デプロイ手順修正 |
| \.github/skills/code-apps/references/build-reference.md\ | init コマンド例修正 |
| \.github/skills/standard/references/power-platform-development-standard.md\ | init コマンド例修正 |

## 検証環境

- Windows 11 / PowerShell 5.1
- PAC CLI 1.x / \@microsoft/power-apps-cli\ npm パッケージ
- Power Platform 環境: USDevGeek01