### PR TITLE
feat: auth_helper にFlow/PowerApps APIヘルパー追加 & サマリー同期フロー

### DIFF
--- a/.github/agents/GeekPowerCode.agent.md
+++ b/.github/agents/GeekPowerCode.agent.md
@@ -37,6 +37,39 @@ SDK が `.power/schemas/appschemas/dataSourcesInfo.ts` を自動生成する。
 `src/lib/dataSourcesInfo.ts` には、SDK で追加できないシステムテーブル
 （systemuser, bot, conversationtranscript 等）とコネクタのみ手動追記する。
 
+## 認証（auth_helper.py 必須）
+
+Python デプロイスクリプトでは **必ず `auth_helper.py` の公開 API を使う**。
+直接 `requests.get/post` + `get_token` で外部 API を呼ばない。
+
+| やりたいこと | 使うヘルパー |
+|---|---|
+| Dataverse Web API (GET/POST/PATCH/DELETE) | `api_get`, `api_post`, `api_patch`, `api_delete` |
+| Flow Management API | `flow_api_call(method, path, body)` |
+| PowerApps API（接続検索等） | `powerapps_api_call(method, path, params, body)` |
+| 環境 ID 逆引き | `resolve_environment_id()` |
+| Connected な接続 ID 検索 | `find_connection(env_id, connector_name, display_name)` |
+| メタデータ操作リトライ | `retry_metadata(fn, description)` |
+
+```python
+# ★ 正しいパターン
+from auth_helper import (
+    api_get, api_post, api_patch, api_delete,
+    flow_api_call, powerapps_api_call,
+    resolve_environment_id, find_connection,
+    retry_metadata, DATAVERSE_URL,
+)
+
+env_id = resolve_environment_id()
+conn_id = find_connection(env_id, "shared_commondataserviceforapps", "Dataverse")
+```
+
+```python
+# ❌ 禁止パターン（認証キャッシュを活かせない、コード重複）
+token = get_token(scope="https://service.flow.microsoft.com/.default")
+r = requests.get("https://api.flow.microsoft.com/...", headers={"Authorization": f"Bearer {token}"})
+```
+
 | 作業 | スキル |
 |---|---|
 | Dataverse | .github/skills/dataverse/SKILL.md |

--- a/auth_helper.py
+++ b/auth_helper.py
@@ -1,0 +1,539 @@
+"""
+Power Platform Dataverse デプロイスクリプト用 共通認証ヘルパーモジュール
+
+テーブル作成・フロー・Copilot Studio 等の Python デプロイスクリプトは
+このモジュールを使って認証する。
+※ Power Apps を利用するエンドユーザーの認証は Power Apps SDK が処理するため、
+  本モジュールの対象外。
+
+認証の仕組み（2 層キャッシュ）:
+  1. AuthenticationRecord (.auth_record.json)
+     - アカウント情報（テナント・ユーザー等）を保存
+     - これだけではトークンは保存されない
+  2. TokenCachePersistenceOptions (MSAL 永続トークンキャッシュ)
+     - リフレッシュトークン・アクセストークンをOS資格情報ストアに永続化
+     - AuthenticationRecord と組み合わせることでサイレントリフレッシュが可能
+
+動作:
+  - 初回: DeviceCodeCredential でデバイスコード認証
+         → AuthenticationRecord をファイルに保存
+         → MSAL トークンキャッシュにリフレッシュトークンを永続化
+  - 2回目以降: AuthenticationRecord をロード
+         → MSAL キャッシュからリフレッシュトークンを取得
+         → サイレントリフレッシュ（デバイスコード不要）
+
+使い方:
+  from auth_helper import get_token, get_session, retry_metadata
+
+  # Dataverse Web API 用トークン
+  token = get_token()
+
+  # Flow API 用トークン
+  token = get_token(scope="https://service.flow.microsoft.com/.default")
+
+  # requests.Session（Bearer ヘッダー付き）
+  session = get_session()
+  resp = session.get(f"{DATAVERSE_URL}/api/data/v9.2/accounts")
+
+  # メタデータ操作のリトライ
+  retry_metadata(lambda: api_post("EntityDefinitions", body), "テーブル作成")
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import requests
+from azure.core.exceptions import ClientAuthenticationError
+from azure.identity import (
+    AuthenticationRecord,
+    DeviceCodeCredential,
+    TokenCachePersistenceOptions,
+)
+from dotenv import load_dotenv
+
+# ---------- 設定 ----------
+
+load_dotenv()
+
+TENANT_ID: str = os.getenv("TENANT_ID", "")
+DATAVERSE_URL: str = os.getenv("DATAVERSE_URL", "").rstrip("/")
+
+# AuthenticationRecord の保存先（プロジェクトルートの .auth_record.json）
+_PROJECT_ROOT = Path(__file__).resolve().parent
+AUTH_RECORD_PATH: Path = _PROJECT_ROOT / ".auth_record.json"
+
+# Dataverse Web API のデフォルトスコープ
+_DEFAULT_SCOPE = f"{DATAVERSE_URL}/.default" if DATAVERSE_URL else ""
+
+# ---------- 内部キャッシュ ----------
+
+_credential: DeviceCodeCredential | None = None
+
+
+def _device_code_callback(verification_uri: str, user_code: str, expires_on: object) -> None:
+    """デバイスコード認証のプロンプトを表示する。"""
+    print(
+        "\n========================================\n"
+        "  デバイスコード認証\n"
+        "========================================\n"
+        f"  1. ブラウザで {verification_uri} を開く\n"
+        f"  2. コード {user_code} を入力\n"
+        "========================================\n",
+        file=sys.stderr,
+    )
+
+
+def _build_credential() -> DeviceCodeCredential:
+    """DeviceCodeCredential を構築する（2 層キャッシュ付き）。
+
+    1. TokenCachePersistenceOptions — MSAL 永続トークンキャッシュ
+       リフレッシュトークン・アクセストークンを OS 資格情報ストアに保存。
+       AuthenticationRecord だけではトークンは保存されないため、
+       この設定が無いと毎回デバイスコード認証が必要になる。
+    2. AuthenticationRecord — アカウント情報キャッシュ
+       テナント・ユーザー情報を保存し、MSAL キャッシュから正しい
+       トークンエントリを検索するキーとして機能する。
+    """
+    # OS 永続トークンキャッシュが壊れることがあるため、
+    # 環境変数 PP_NO_PERSISTENT_CACHE=1 で無効化可能
+    use_persistent_cache = not os.environ.get("PP_NO_PERSISTENT_CACHE")
+
+    kwargs: dict = {
+        "tenant_id": TENANT_ID or None,
+        "prompt_callback": _device_code_callback,
+    }
+
+    if use_persistent_cache:
+        cache_options = TokenCachePersistenceOptions(
+            name="power_platform_token_cache_v3",
+            allow_unencrypted_storage=True,
+        )
+        kwargs["cache_persistence_options"] = cache_options
+
+    auth_record: AuthenticationRecord | None = None
+    if AUTH_RECORD_PATH.exists():
+        try:
+            serialized = AUTH_RECORD_PATH.read_text(encoding="utf-8")
+            auth_record = AuthenticationRecord.deserialize(serialized)
+            print(
+                f"[auth_helper] 認証キャッシュをロードしました: {AUTH_RECORD_PATH}",
+                file=sys.stderr,
+            )
+        except (ValueError, OSError, json.JSONDecodeError) as exc:
+            print(
+                f"[auth_helper] 認証キャッシュの読み込みに失敗（初回認証に切り替え）: {exc}",
+                file=sys.stderr,
+            )
+
+    # None の値を除外（未設定パラメータはライブラリの既定値を使う）
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
+    if auth_record is not None:
+        kwargs["authentication_record"] = auth_record
+
+    return DeviceCodeCredential(**kwargs)
+
+
+def _ensure_credential() -> DeviceCodeCredential:
+    """モジュールレベルのシングルトン credential を返す。"""
+    global _credential  # noqa: PLW0603
+    if _credential is None:
+        _credential = _build_credential()
+    return _credential
+
+
+def _save_auth_record(record: AuthenticationRecord) -> None:
+    """AuthenticationRecord をファイルに永続化する。"""
+    AUTH_RECORD_PATH.write_text(record.serialize(), encoding="utf-8")
+    print(
+        f"[auth_helper] 認証レコードを保存しました: {AUTH_RECORD_PATH}",
+        file=sys.stderr,
+    )
+
+
+# ---------- 公開 API ----------
+
+# Python 3.14 で MSAL 内部トークンキャッシュが壊れる問題の回避策:
+# 自前でスコープ別のインメモリキャッシュを管理する。
+# credential.get_token() は同じスコープで 1 回だけ呼び、結果をキャッシュする。
+_inmemory_tokens: dict[str, tuple[str, float]] = {}  # scope -> (token_str, expires_on)
+
+
+def get_token(scope: str | None = None) -> str:
+    """
+    指定スコープのアクセストークン文字列を返す。
+
+    初回はデバイスコード認証が走り、AuthenticationRecord が保存される。
+    2回目以降はインメモリキャッシュから取得する。
+
+    Args:
+        scope: OAuth2 スコープ。省略時は ``{DATAVERSE_URL}/.default``。
+
+    Returns:
+        Bearer トークン文字列。
+    """
+    if scope is None:
+        scope = _DEFAULT_SCOPE
+    if not scope:
+        raise ValueError(
+            "スコープが未指定です。DATAVERSE_URL を .env に設定するか scope 引数を渡してください。"
+        )
+
+    # インメモリキャッシュから返す（有効期限 60 秒前まで）
+    if scope in _inmemory_tokens:
+        token_str, expires_on = _inmemory_tokens[scope]
+        if time.time() < expires_on - 60:
+            return token_str
+
+    credential = _ensure_credential()
+
+    # キャッシュが存在しない場合は明示的に authenticate() を呼んで
+    # AuthenticationRecord を永続化してからトークンを取得する
+    if not AUTH_RECORD_PATH.exists():
+        record = credential.authenticate(scopes=[scope])
+        _save_auth_record(record)
+
+    try:
+        token = credential.get_token(scope)
+    except (ClientAuthenticationError, TypeError) as exc:
+        # MSAL 内部キャッシュ破損時のフォールバック:
+        # 新しい credential を永続キャッシュなしで構築し直す
+        print(
+            f"[auth_helper] MSAL キャッシュ破損を検出 — 再構築中: {type(exc).__name__}",
+            file=sys.stderr,
+        )
+        global _credential  # noqa: PLW0603
+        _credential = None
+        kwargs_nocache: dict = {
+            "tenant_id": TENANT_ID or None,
+            "prompt_callback": _device_code_callback,
+        }
+        kwargs_nocache = {k: v for k, v in kwargs_nocache.items() if v is not None}
+        # 認証レコードは使わない（内部キャッシュが壊れる原因になる）
+        _credential = DeviceCodeCredential(**kwargs_nocache)
+        record = _credential.authenticate(scopes=[scope])
+        _save_auth_record(record)
+        token = _credential.get_token(scope)
+
+    _inmemory_tokens[scope] = (token.token, token.expires_on)
+    return token.token
+
+
+def authenticate(scope: str | None = None) -> AuthenticationRecord:
+    """
+    明示的に対話認証を実行し、AuthenticationRecord を保存して返す。
+
+    通常は get_token() を呼ぶだけで十分だが、
+    スクリプトの冒頭で確実に認証を通したい場合にはこの関数を使う。
+
+    Args:
+        scope: OAuth2 スコープ。省略時は ``{DATAVERSE_URL}/.default``。
+
+    Returns:
+        AuthenticationRecord インスタンス。
+    """
+    if scope is None:
+        scope = _DEFAULT_SCOPE
+    if not scope:
+        raise ValueError(
+            "スコープが未指定です。DATAVERSE_URL を .env に設定するか scope 引数を渡してください。"
+        )
+
+    credential = _ensure_credential()
+    record = credential.authenticate(scopes=[scope])
+    _save_auth_record(record)
+    return record
+
+
+def get_session(scope: str | None = None) -> requests.Session:
+    """
+    Bearer トークンが設定された requests.Session を返す。
+
+    Args:
+        scope: OAuth2 スコープ。省略時は ``{DATAVERSE_URL}/.default``。
+
+    Returns:
+        Authorization ヘッダー付き requests.Session。
+    """
+    token = get_token(scope)
+    session = requests.Session()
+    session.headers.update(
+        {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "OData-MaxVersion": "4.0",
+            "OData-Version": "4.0",
+        }
+    )
+    return session
+
+
+# ---------- Dataverse ヘルパー ----------
+
+
+def api_get(path: str, scope: str | None = None) -> dict:
+    """Dataverse Web API に GET リクエストを送る。"""
+    url = f"{DATAVERSE_URL}/api/data/v9.2/{path.lstrip('/')}"
+    session = get_session(scope)
+    resp = session.get(url)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def api_post(path: str, body: dict, scope: str | None = None, *, solution: str = "") -> str | None:
+    """Dataverse Web API に POST リクエストを送る。作成されたレコードの ID を返す。"""
+    url = f"{DATAVERSE_URL}/api/data/v9.2/{path.lstrip('/')}"
+    session = get_session(scope)
+    if solution:
+        session.headers["MSCRM.SolutionName"] = solution
+    resp = session.post(url, json=body)
+    resp.raise_for_status()
+    odata_id = resp.headers.get("OData-EntityId", "")
+    if "(" in odata_id and ")" in odata_id:
+        return odata_id.split("(")[-1].rstrip(")")
+    return None
+
+
+def api_patch(path: str, body: dict, scope: str | None = None) -> None:
+    """Dataverse Web API に PATCH リクエストを送る。"""
+    url = f"{DATAVERSE_URL}/api/data/v9.2/{path.lstrip('/')}"
+    session = get_session(scope)
+    resp = session.patch(url, json=body)
+    resp.raise_for_status()
+
+
+def api_delete(path: str, scope: str | None = None) -> None:
+    """Dataverse Web API に DELETE リクエストを送る。"""
+    url = f"{DATAVERSE_URL}/api/data/v9.2/{path.lstrip('/')}"
+    session = get_session(scope)
+    resp = session.delete(url)
+    resp.raise_for_status()
+
+
+def api_request(path: str, body: dict, method: str = "PUT", scope: str | None = None) -> None:
+    """Dataverse Web API に任意のメソッドでリクエストを送る（PUT ローカライズ等）。"""
+    url = f"{DATAVERSE_URL}/api/data/v9.2/{path.lstrip('/')}"
+    session = get_session(scope)
+    session.headers["MSCRM.MergeLabels"] = "true"
+    resp = session.request(method, url, json=body)
+    resp.raise_for_status()
+
+
+# ---------- Flow API ヘルパー ----------
+
+
+FLOW_API = "https://api.flow.microsoft.com"
+FLOW_API_VERSION = "api-version=2016-11-01"
+
+POWERAPPS_API = "https://api.powerapps.com"
+
+
+def flow_api_call(
+    method: str,
+    path: str,
+    body: dict | None = None,
+) -> dict:
+    """
+    Flow Management API を呼び出す。
+
+    自動的に ``https://service.flow.microsoft.com/.default`` スコープで認証する。
+    """
+    token = get_token(scope="https://service.flow.microsoft.com/.default")
+    url = f"{FLOW_API}{path}"
+    separator = "&" if "?" in url else "?"
+    url = f"{url}{separator}{FLOW_API_VERSION}"
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    resp = requests.request(method, url, headers=headers, json=body)
+    resp.raise_for_status()
+    if resp.status_code == 204 or not resp.text:
+        return {}
+    return resp.json()
+
+
+def powerapps_api_call(
+    method: str,
+    path: str,
+    params: dict | None = None,
+    body: dict | None = None,
+    timeout: int = 120,
+) -> dict:
+    """
+    PowerApps API を呼び出す。
+
+    自動的に ``https://service.powerapps.com/.default`` スコープで認証する。
+    """
+    token = get_token(scope="https://service.powerapps.com/.default")
+    url = f"{POWERAPPS_API}{path}"
+    if params is None:
+        params = {}
+    params.setdefault("api-version", "2016-11-01")
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    resp = requests.request(method, url, headers=headers, params=params, json=body, timeout=timeout)
+    resp.raise_for_status()
+    if resp.status_code == 204 or not resp.text:
+        return {}
+    return resp.json()
+
+
+# ---------- Flow / PowerApps ユーティリティ ----------
+
+
+def resolve_environment_id() -> str:
+    """DATAVERSE_URL から環境 ID を逆引きする。"""
+    data = flow_api_call(
+        "GET",
+        "/providers/Microsoft.ProcessSimple/environments",
+    )
+    dv_url = DATAVERSE_URL.rstrip("/")
+    for env in data.get("value", []):
+        instance_url = (
+            env.get("properties", {})
+            .get("linkedEnvironmentMetadata", {})
+            .get("instanceUrl", "")
+            or ""
+        ).rstrip("/")
+        if instance_url == dv_url:
+            return env["name"]
+    raise RuntimeError(f"環境が見つかりません: {dv_url}")
+
+
+def find_connection(env_id: str, connector_name: str, display_name: str = "") -> str:
+    """環境内で Connected な接続 ID を検索する。見つからなければ sys.exit(1)。"""
+    import sys as _sys
+
+    label = display_name or connector_name
+    for attempt in range(3):
+        try:
+            data = powerapps_api_call(
+                "GET",
+                f"/providers/Microsoft.PowerApps/apis/{connector_name}/connections",
+                params={"$filter": f"environment eq '{env_id}'"},
+            )
+        except requests.exceptions.Timeout:
+            wait = 15 * (attempt + 1)
+            print(f"  ⚠ {label}: タイムアウト → {wait}s 待機してリトライ...")
+            time.sleep(wait)
+            continue
+        except requests.HTTPError as e:
+            if e.response is not None and e.response.status_code == 504:
+                wait = 15 * (attempt + 1)
+                print(f"  ⚠ {label}: 504 → {wait}s 待機してリトライ...")
+                time.sleep(wait)
+                continue
+            raise
+
+        for conn in data.get("value", []):
+            statuses = conn.get("properties", {}).get("statuses", [])
+            if any(s.get("status") == "Connected" for s in statuses):
+                return conn["name"]
+        break
+
+    print(f"  ❌ {label} ({connector_name}): Connected な接続が見つかりません")
+    print(f"     → https://make.powerautomate.com/connections で作成してください")
+    _sys.exit(1)
+
+
+# ---------- メタデータ操作リトライ ----------
+
+
+def _extract_error_detail(exc: Exception) -> str:
+    """例外からエラー詳細文字列を抽出する。
+
+    requests.HTTPError の場合はレスポンスボディに Dataverse のエラーコード
+    （0x80040237, 0x80044363 等）が含まれるため、str(e) ではなく
+    response.text から取得する必要がある。
+    """
+    parts = [str(exc)]
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        try:
+            parts.append(exc.response.text)
+        except Exception:  # noqa: BLE001 — response.text の読み取り失敗は無視
+            pass
+    return "\n".join(parts)
+
+
+def retry_metadata(
+    fn: Callable[[], object],
+    description: str,
+    max_attempts: int = 5,
+) -> object | None:
+    """メタデータ操作をリトライする。ロック競合時は累進的に待機。
+
+    Dataverse のメタデータ操作（テーブル作成、列追加、リレーションシップ等）は
+    排他ロックにより同時実行すると失敗する。このヘルパーは以下のエラーを検出して
+    自動リトライまたはスキップする。
+
+    | エラーコード / パターン         | 対処     | 説明                                 |
+    |-------------------------------|---------|--------------------------------------|
+    | ``already exists``            | スキップ | 既に存在する（べき等パターン）            |
+    | ``0x80040237``                | スキップ | メタデータ排他ロック競合（already exists系）|
+    | ``0x80044363``                | スキップ | ソリューション内に同名コンポーネント重複    |
+    | ``another ... running``       | リトライ | 別のメタデータ操作が実行中                |
+
+    Args:
+        fn: 実行する callable（引数なし）。
+        description: ログ用の操作説明文字列。
+        max_attempts: 最大リトライ回数（デフォルト 5）。
+
+    Returns:
+        fn() の戻り値。エラーをスキップした場合は None。
+    """
+    for attempt in range(max_attempts):
+        try:
+            return fn()
+        except Exception as exc:
+            detail = _extract_error_detail(exc)
+            detail_lower = detail.lower()
+
+            # --- 既に存在する場合はスキップ ---
+            if (
+                "already exists" in detail_lower
+                or "0x80040237" in detail
+                or "0x80044363" in detail
+            ):
+                print(f"  {description}: already exists, skipping")
+                return None
+
+            # --- メタデータロック競合 → リトライ ---
+            if "another" in detail_lower and "running" in detail_lower:
+                wait = 10 * (attempt + 1)
+                print(
+                    f"  {description}: lock contention, waiting {wait}s "
+                    f"(attempt {attempt + 1}/{max_attempts})..."
+                )
+                time.sleep(wait)
+                continue
+
+            # --- 想定外のエラー → 再送出 ---
+            raise
+
+    print(f"  {description}: max retries ({max_attempts}) exceeded")
+    return None
+
+
+# ---------- CLI エントリーポイント ----------
+
+if __name__ == "__main__":
+    print("=== Power Platform 認証テスト ===")
+    if not DATAVERSE_URL:
+        print("DATAVERSE_URL が .env に設定されていません。", file=sys.stderr)
+        sys.exit(1)
+
+    record = authenticate()
+    print(f"認証成功: {record.username}")
+    print(f"テナント: {record.tenant_id}")
+    print(f"認証レコード保存先: {AUTH_RECORD_PATH}")

--- a/scripts/backfill_summaries.py
+++ b/scripts/backfill_summaries.py
@@ -1,0 +1,141 @@
+"""
+初回バックフィル: 既存 conversationtranscript → geek_conversationsummary
+================================================================
+全トランスクリプトをパースして集計テーブルに書き込む。
+transcriptid で冪等（既存レコードはスキップ）。
+"""
+import sys, os, json, time
+from pathlib import Path
+from dotenv import load_dotenv
+load_dotenv()
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from auth_helper import api_get, api_post, get_token, DATAVERSE_URL
+
+PREFIX = os.environ.get("PUBLISHER_PREFIX", "geek").strip()
+
+OUTCOME_MAP = {
+    "Resolved": 100000000,
+    "Abandoned": 100000001,
+    "Escalated": 100000002,
+    "None": 100000003,
+}
+
+def get_entity_set_name(logical_name):
+    meta = api_get(f"EntityDefinitions(LogicalName='{logical_name}')?$select=EntitySetName")
+    return meta["EntitySetName"]
+
+def fetch_all_transcripts():
+    rows = []
+    url = "conversationtranscripts?$select=conversationtranscriptid,name,conversationstarttime,metadata,content"
+    res = api_get(url)
+    rows.extend(res.get("value", []))
+    # OData paging
+    while "@odata.nextLink" in res:
+        next_url = res["@odata.nextLink"].replace(f"{DATAVERSE_URL}/api/data/v9.2/", "")
+        res = api_get(next_url)
+        rows.extend(res.get("value", []))
+    return rows
+
+def parse_transcript(r):
+    """1件のトランスクリプトをパースしてサマリー dict を返す"""
+    meta = {}
+    try:
+        meta = json.loads(r.get("metadata") or "{}")
+    except Exception:
+        pass
+
+    content = {}
+    try:
+        content = json.loads(r.get("content") or "{}")
+    except Exception:
+        pass
+
+    acts = content.get("activities", [])
+    ts_list = []
+    user_msgs = 0
+    bot_msgs = 0
+    tool_events = 0
+    outcome = None
+    channel = None
+    first_user_text = None
+    tool_servers = set()
+
+    for a in acts:
+        tms = a.get("timestampMs")
+        if tms:
+            ts_list.append(tms)
+        ch = a.get("channelId")
+        if ch and not channel:
+            channel = ch
+        if a.get("valueType") == "ConversationInfo":
+            outcome = (a.get("value") or {}).get("lastSessionOutcome")
+        atype = a.get("type")
+        if atype == "message":
+            role = (a.get("from") or {}).get("role")
+            if role == 1:
+                user_msgs += 1
+                if first_user_text is None:
+                    first_user_text = (a.get("text") or "")[:4000]
+            else:
+                bot_msgs += 1
+        if atype == "event":
+            tool_events += 1
+            val = a.get("value") or {}
+            srv = (((val.get("initializationResult") or {}).get("serverInfo")) or {}).get("name")
+            if srv:
+                tool_servers.add(srv)
+
+    dur = round((max(ts_list) - min(ts_list)) / 1000.0, 1) if ts_list else 0
+
+    return {
+        f"{PREFIX}_name": (r.get("name") or "")[:200],
+        f"{PREFIX}_transcriptid": r.get("conversationtranscriptid", ""),
+        f"{PREFIX}_botname": (meta.get("BotName") or "")[:200],
+        f"{PREFIX}_botid": (meta.get("BotId") or "")[:100],
+        f"{PREFIX}_starttime": r.get("conversationstarttime"),
+        f"{PREFIX}_outcome": OUTCOME_MAP.get(outcome or "None", 100000003),
+        f"{PREFIX}_channel": (channel or "")[:100],
+        f"{PREFIX}_usermsgcount": user_msgs,
+        f"{PREFIX}_botmsgcount": bot_msgs,
+        f"{PREFIX}_tooleventcount": tool_events,
+        f"{PREFIX}_durationsec": dur,
+        f"{PREFIX}_toolservers": ", ".join(sorted(tool_servers))[:500],
+        f"{PREFIX}_firstusertext": first_user_text or "",
+    }
+
+
+def main():
+    print("=== Backfill: conversationtranscript -> geek_conversationsummary ===")
+    eset = get_entity_set_name(f"{PREFIX}_conversationsummary")
+    print(f"  Target EntitySet: {eset}")
+
+    # 既存レコードの transcriptid を取得（冪等チェック用）
+    existing = api_get(f"{eset}?$select={PREFIX}_transcriptid")
+    existing_ids = {r[f"{PREFIX}_transcriptid"] for r in existing.get("value", [])}
+    print(f"  Existing summaries: {len(existing_ids)}")
+
+    transcripts = fetch_all_transcripts()
+    print(f"  Transcripts to process: {len(transcripts)}")
+
+    created = 0
+    skipped = 0
+    for r in transcripts:
+        tid = r.get("conversationtranscriptid", "")
+        if tid in existing_ids:
+            skipped += 1
+            continue
+        summary = parse_transcript(r)
+        try:
+            api_post(eset, summary)
+            created += 1
+            print(f"    Created: {summary[f'{PREFIX}_botname']} | {summary[f'{PREFIX}_starttime']}")
+        except Exception as e:
+            print(f"    ERROR: {tid}: {e}")
+        time.sleep(0.5)  # throttle
+
+    print(f"\n  Done: created={created}, skipped={skipped}, total={len(transcripts)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy_flow_backfill.py
+++ b/scripts/deploy_flow_backfill.py
@@ -1,0 +1,481 @@
+"""
+Power Automate フローデプロイ: サマリー同期（バックフィル）
+================================================================
+会話トランスクリプトをパースしてサマリーテーブルに書き込むフロー。
+PowerApps トリガー → 即座にレスポンス（非同期パターン）→ バックグラウンドで同期。
+
+使い方:
+  1. .env に DATAVERSE_URL, TENANT_ID, SOLUTION_NAME, PUBLISHER_PREFIX を設定
+  2. Power Automate 接続ページで Dataverse 接続を事前作成
+     https://make.powerautomate.com/connections
+  3. pip install azure-identity requests python-dotenv
+  4. python scripts/deploy_flow_backfill.py
+"""
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# 共通認証モジュール
+_repo = str(Path(__file__).resolve().parents[1])
+sys.path.insert(0, _repo)
+sys.path.insert(0, os.path.join(_repo, ".github", "skills", "standard", "scripts"))
+
+from auth_helper import (
+    api_get,
+    api_patch,
+    api_post,
+    api_delete,
+    get_token,
+    flow_api_call,
+    retry_metadata,
+    resolve_environment_id,
+    find_connection,
+    DATAVERSE_URL,
+)
+
+# ── 環境変数 ──
+PREFIX = os.environ.get("PUBLISHER_PREFIX", "geek")
+SOLUTION_NAME = os.environ.get("SOLUTION_NAME", "CopilotStudioAnalysis")
+
+FLOW_DISPLAY_NAME = "サマリー同期"
+FLOW_DESCRIPTION = "会話トランスクリプトを解析してサマリーテーブルに書き込む（冪等・非同期 PowerApps トリガー）"
+
+CONNECTOR_DV = "shared_commondataserviceforapps"
+CONNREF_DATAVERSE = f"{PREFIX}_sharedcommondataserviceforapps"
+
+
+# ══════════════════════════════════════════════════════════════
+# Step 1 & 2: 環境 ID 解決 + 接続検索（auth_helper ユーティリティ）
+# ══════════════════════════════════════════════════════════════
+def setup_environment():
+    """環境 ID と接続 ID を取得する。"""
+    print("\n=== Step 1: 環境 ID 解決 ===")
+    env_id = resolve_environment_id()
+    print(f"  ✓ 環境 ID: {env_id}")
+
+    print("\n=== Step 2: 接続検索 ===")
+    conn_id = find_connection(env_id, CONNECTOR_DV, "Dataverse")
+    print(f"  ✓ Dataverse: {conn_id}")
+    return env_id, {CONNECTOR_DV: conn_id}
+
+
+# ══════════════════════════════════════════════════════════════
+# Step 3: 接続参照
+# ══════════════════════════════════════════════════════════════
+def ensure_connection_reference(logical_name, display_name, connector_id, connection_id):
+    existing = api_get(
+        f"connectionreferences?$filter=connectionreferencelogicalname eq '{logical_name}'"
+        "&$select=connectionreferenceid,connectionid"
+    )
+    if existing.get("value"):
+        ref = existing["value"][0]
+        if ref.get("connectionid") != connection_id:
+            api_patch(f"connectionreferences({ref['connectionreferenceid']})", {"connectionid": connection_id})
+            print(f"    接続更新: {logical_name}")
+        else:
+            print(f"    既存OK: {logical_name}")
+        return
+    body = {
+        "connectionreferencelogicalname": logical_name,
+        "connectionreferencedisplayname": display_name,
+        "connectorid": f"/providers/Microsoft.PowerApps/apis/{connector_id}",
+        "connectionid": connection_id,
+    }
+    retry_metadata(
+        lambda: api_post("connectionreferences", body, solution=SOLUTION_NAME),
+        f"接続参照: {logical_name}",
+    )
+    print(f"    作成完了: {logical_name}")
+
+
+def create_connection_references(connections: dict):
+    print("\n=== Step 3: 接続参照の作成 ===")
+    ensure_connection_reference(
+        CONNREF_DATAVERSE, "Dataverse",
+        CONNECTOR_DV, connections[CONNECTOR_DV],
+    )
+    print("  ✓ 接続参照 OK")
+
+
+# ══════════════════════════════════════════════════════════════
+# Step 4: フロー定義構築 + Draft 作成
+# ══════════════════════════════════════════════════════════════
+def build_flow_definition() -> dict:
+    """サマリー同期フロー定義を構築
+
+    パターン: PowerApps V2 トリガー → 即時レスポンス → バックグラウンド同期
+    - 既存サマリーの transcriptid を取得し、未処理トランスクリプトのみ処理
+    - 各トランスクリプトの content JSON をパースしてメッセージ数・結果を集計
+    """
+    summary_table = f"{PREFIX}_conversationsummaries"
+
+    # -- 内部アクション（Apply_to_each 内部）--
+    inner_actions = {
+        # 1. フルレコード取得（content含む）
+        "Get_Full_Transcript": {
+            "type": "OpenApiConnection",
+            "runAfter": {},
+            "inputs": {
+                "host": {
+                    "apiId": f"/providers/Microsoft.PowerApps/apis/{CONNECTOR_DV}",
+                    "connectionName": CONNECTOR_DV,
+                    "operationId": "GetItem",
+                },
+                "parameters": {
+                    "entityName": "conversationtranscripts",
+                    "recordId": "@items('Apply_to_each')?['conversationtranscriptid']",
+                    "$select": "content",
+                },
+                "authentication": "@parameters('$authentication')",
+            },
+        },
+        # 2. メタデータパース
+        "Compose_Metadata": {
+            "type": "Compose",
+            "runAfter": {},
+            "inputs": "@if(empty(items('Apply_to_each')?['metadata']),json('{}'),json(items('Apply_to_each')?['metadata']))",
+        },
+        # 3-4. コンテンツパース → activities 取得
+        "Compose_Safe_Content": {
+            "type": "Compose",
+            "runAfter": {"Get_Full_Transcript": ["Succeeded"]},
+            "inputs": "@if(empty(outputs('Get_Full_Transcript')?['body/content']),'{}',outputs('Get_Full_Transcript')?['body/content'])",
+        },
+        "Compose_Parsed": {
+            "type": "Compose",
+            "runAfter": {"Compose_Safe_Content": ["Succeeded"]},
+            "inputs": "@json(outputs('Compose_Safe_Content'))",
+        },
+        "Compose_Activities": {
+            "type": "Compose",
+            "runAfter": {"Compose_Parsed": ["Succeeded"]},
+            "inputs": "@coalesce(outputs('Compose_Parsed')?['activities'],json('[]'))",
+        },
+        # 5-8. フィルタリング（並列）
+        "Filter_User_Msgs": {
+            "type": "Query",
+            "runAfter": {"Compose_Activities": ["Succeeded"]},
+            "inputs": {
+                "from": "@outputs('Compose_Activities')",
+                "where": "@and(equals(item()?['type'],'message'),equals(item()?['from']?['role'],1))",
+            },
+        },
+        "Filter_Bot_Msgs": {
+            "type": "Query",
+            "runAfter": {"Compose_Activities": ["Succeeded"]},
+            "inputs": {
+                "from": "@outputs('Compose_Activities')",
+                "where": "@and(equals(item()?['type'],'message'),not(equals(item()?['from']?['role'],1)))",
+            },
+        },
+        "Filter_Events": {
+            "type": "Query",
+            "runAfter": {"Compose_Activities": ["Succeeded"]},
+            "inputs": {
+                "from": "@outputs('Compose_Activities')",
+                "where": "@equals(item()?['type'],'event')",
+            },
+        },
+        "Filter_Outcome_Activities": {
+            "type": "Query",
+            "runAfter": {"Compose_Activities": ["Succeeded"]},
+            "inputs": {
+                "from": "@outputs('Compose_Activities')",
+                "where": "@equals(item()?['valueType'],'ConversationInfo')",
+            },
+        },
+        # 9. 結果マッピング
+        "Compose_Outcome": {
+            "type": "Compose",
+            "runAfter": {"Filter_Outcome_Activities": ["Succeeded"]},
+            "inputs": (
+                "@if(greater(length(body('Filter_Outcome_Activities')),0),"
+                "if(equals(first(body('Filter_Outcome_Activities'))?['value']?['lastSessionOutcome'],'Resolved'),100000000,"
+                "if(equals(first(body('Filter_Outcome_Activities'))?['value']?['lastSessionOutcome'],'Abandoned'),100000001,"
+                "if(equals(first(body('Filter_Outcome_Activities'))?['value']?['lastSessionOutcome'],'Escalated'),100000002,"
+                "100000003))),"
+                "100000003)"
+            ),
+        },
+        # 10. 所要時間
+        "Compose_Duration": {
+            "type": "Compose",
+            "runAfter": {"Compose_Activities": ["Succeeded"]},
+            "inputs": (
+                "@if(greater(length(outputs('Compose_Activities')),1),"
+                "div(sub(last(outputs('Compose_Activities'))?['timestampMs'],"
+                "first(outputs('Compose_Activities'))?['timestampMs']),1000),0)"
+            ),
+        },
+        # 11-12. ツールサーバー抽出
+        "Filter_With_Server": {
+            "type": "Query",
+            "runAfter": {"Filter_Events": ["Succeeded"]},
+            "inputs": {
+                "from": "@body('Filter_Events')",
+                "where": "@not(empty(coalesce(item()?['value']?['initializationResult']?['serverInfo']?['name'],'')))",
+            },
+        },
+        "Select_Server_Names": {
+            "type": "Select",
+            "runAfter": {"Filter_With_Server": ["Succeeded"]},
+            "inputs": {
+                "from": "@body('Filter_With_Server')",
+                "select": "@item()?['value']?['initializationResult']?['serverInfo']?['name']",
+            },
+        },
+        # 13. サマリーレコード作成
+        "Create_Summary": {
+            "type": "OpenApiConnection",
+            "runAfter": {
+                "Compose_Metadata": ["Succeeded"],
+                "Filter_User_Msgs": ["Succeeded"],
+                "Filter_Bot_Msgs": ["Succeeded"],
+                "Compose_Outcome": ["Succeeded"],
+                "Compose_Duration": ["Succeeded"],
+                "Select_Server_Names": ["Succeeded"],
+            },
+            "inputs": {
+                "host": {
+                    "apiId": f"/providers/Microsoft.PowerApps/apis/{CONNECTOR_DV}",
+                    "connectionName": CONNECTOR_DV,
+                    "operationId": "CreateRecord",
+                },
+                "parameters": {
+                    "entityName": summary_table,
+                    f"item/{PREFIX}_name": "@coalesce(items('Apply_to_each')?['name'],'')",
+                    f"item/{PREFIX}_transcriptid": "@items('Apply_to_each')?['conversationtranscriptid']",
+                    f"item/{PREFIX}_botname": "@coalesce(outputs('Compose_Metadata')?['BotName'],'')",
+                    f"item/{PREFIX}_botid": "@coalesce(outputs('Compose_Metadata')?['BotId'],'')",
+                    f"item/{PREFIX}_starttime": "@items('Apply_to_each')?['conversationstarttime']",
+                    f"item/{PREFIX}_outcome": "@outputs('Compose_Outcome')",
+                    f"item/{PREFIX}_channel": "@coalesce(first(outputs('Compose_Activities'))?['channelId'],'')",
+                    f"item/{PREFIX}_usermsgcount": "@length(body('Filter_User_Msgs'))",
+                    f"item/{PREFIX}_botmsgcount": "@length(body('Filter_Bot_Msgs'))",
+                    f"item/{PREFIX}_tooleventcount": "@length(body('Filter_Events'))",
+                    f"item/{PREFIX}_durationsec": "@outputs('Compose_Duration')",
+                    f"item/{PREFIX}_toolservers": "@join(union(body('Select_Server_Names'),json('[]')),', ')",
+                    f"item/{PREFIX}_firstusertext": "@coalesce(first(body('Filter_User_Msgs'))?['text'],'')",
+                },
+                "authentication": "@parameters('$authentication')",
+            },
+        },
+    }
+
+    # -- メインフロー定義 --
+    definition = {
+        "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+        "contentVersion": "1.0.0.0",
+        "parameters": {
+            "$authentication": {"defaultValue": {}, "type": "SecureObject"},
+            "$connections": {"defaultValue": {}, "type": "Object"},
+        },
+        "triggers": {
+            "manual": {
+                "type": "Request",
+                "kind": "PowerAppV2",
+                "inputs": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                    },
+                },
+            },
+        },
+        "actions": {
+            # ★ 即座にレスポンス（非同期パターンの肝）
+            "Respond_Started": {
+                "type": "Response",
+                "kind": "PowerApp",
+                "runAfter": {},
+                "inputs": {
+                    "statusCode": 200,
+                    "body": {
+                        "status": "started",
+                        "message": "サマリー同期を開始しました",
+                    },
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "status": {"type": "string"},
+                            "message": {"type": "string"},
+                        },
+                    },
+                },
+            },
+            # 既存サマリーの transcriptid を取得
+            "List_Existing_Summaries": {
+                "type": "OpenApiConnection",
+                "runAfter": {"Respond_Started": ["Succeeded"]},
+                "inputs": {
+                    "host": {
+                        "apiId": f"/providers/Microsoft.PowerApps/apis/{CONNECTOR_DV}",
+                        "connectionName": CONNECTOR_DV,
+                        "operationId": "ListRecords",
+                    },
+                    "parameters": {
+                        "entityName": summary_table,
+                        "$select": f"{PREFIX}_transcriptid",
+                    },
+                    "authentication": "@parameters('$authentication')",
+                },
+                "runtimeConfiguration": {
+                    "paginationPolicy": {"minimumItemCount": 5000},
+                },
+            },
+            "Select_Existing_IDs": {
+                "type": "Select",
+                "runAfter": {"List_Existing_Summaries": ["Succeeded"]},
+                "inputs": {
+                    "from": "@body('List_Existing_Summaries')?['value']",
+                    "select": f"@item()?['{PREFIX}_transcriptid']",
+                },
+            },
+            # トランスクリプト一覧（content なし → GetItem で個別取得）
+            "List_Transcripts": {
+                "type": "OpenApiConnection",
+                "runAfter": {"Select_Existing_IDs": ["Succeeded"]},
+                "inputs": {
+                    "host": {
+                        "apiId": f"/providers/Microsoft.PowerApps/apis/{CONNECTOR_DV}",
+                        "connectionName": CONNECTOR_DV,
+                        "operationId": "ListRecords",
+                    },
+                    "parameters": {
+                        "entityName": "conversationtranscripts",
+                        "$select": "conversationtranscriptid,name,conversationstarttime,metadata",
+                    },
+                    "authentication": "@parameters('$authentication')",
+                },
+                "runtimeConfiguration": {
+                    "paginationPolicy": {"minimumItemCount": 5000},
+                },
+            },
+            # 未処理のみ抽出
+            "Filter_New_Transcripts": {
+                "type": "Query",
+                "runAfter": {"List_Transcripts": ["Succeeded"]},
+                "inputs": {
+                    "from": "@body('List_Transcripts')?['value']",
+                    "where": "@not(contains(body('Select_Existing_IDs'),item()?['conversationtranscriptid']))",
+                },
+            },
+            # 各トランスクリプトを処理（順次実行 — スロットリング対策）
+            "Apply_to_each": {
+                "type": "Foreach",
+                "runAfter": {"Filter_New_Transcripts": ["Succeeded"]},
+                "foreach": "@body('Filter_New_Transcripts')",
+                "actions": inner_actions,
+                "runtimeConfiguration": {
+                    "concurrency": {"repetitions": 1},
+                },
+            },
+        },
+    }
+
+    return definition
+
+
+def deploy_flow_draft() -> str:
+    print("\n=== Step 4: フロー Draft 作成 ===")
+
+    # べき等: 既存フロー削除
+    existing = api_get(
+        f"workflows?$filter=name eq '{FLOW_DISPLAY_NAME}' and category eq 5"
+        "&$select=workflowid,statecode"
+    )
+    for f in existing.get("value", []):
+        wf_id = f["workflowid"]
+        if f["statecode"] == 1:
+            api_patch(f"workflows({wf_id})", {"statecode": 0, "statuscode": 1})
+            time.sleep(2)
+        api_delete(f"workflows({wf_id})")
+        print(f"  削除: {wf_id}")
+        time.sleep(3)
+
+    definition = build_flow_definition()
+
+    clientdata = {
+        "properties": {
+            "definition": definition,
+            "connectionReferences": {
+                CONNECTOR_DV: {
+                    "runtimeSource": "embedded",
+                    "connection": {"connectionReferenceLogicalName": CONNREF_DATAVERSE},
+                    "api": {"name": CONNECTOR_DV},
+                },
+            },
+        },
+        "schemaVersion": "1.0.0.0",
+    }
+
+    workflow_body = {
+        "name": FLOW_DISPLAY_NAME,
+        "type": 1,
+        "category": 5,
+        "statecode": 0,
+        "statuscode": 1,
+        "primaryentity": "none",
+        "clientdata": json.dumps(clientdata, ensure_ascii=False),
+        "description": FLOW_DESCRIPTION,
+    }
+
+    try:
+        wf_id = api_post("workflows", workflow_body, solution=SOLUTION_NAME)
+        print(f"  ✓ フロー Draft 作成: {wf_id}")
+        return wf_id
+    except Exception as e:
+        debug_path = "flow_backfill_debug.json"
+        with open(debug_path, "w", encoding="utf-8") as fp:
+            json.dump(workflow_body, fp, ensure_ascii=False, indent=2)
+        print(f"  ❌ Draft 作成失敗: {e}")
+        print(f"  デバッグ JSON 保存: {debug_path}")
+        sys.exit(1)
+
+
+# ══════════════════════════════════════════════════════════════
+# Step 5: 有効化（PowerApps トリガーは /start 不要）
+# ══════════════════════════════════════════════════════════════
+def activate_flow(wf_id: str):
+    print("\n=== Step 5: フロー有効化 ===")
+    time.sleep(3)
+    try:
+        api_patch(f"workflows({wf_id})", {"statecode": 1, "statuscode": 2})
+        print("  ✓ フロー有効化成功")
+    except Exception as e:
+        print(f"  ❌ 有効化失敗: {e}")
+        print(f"  → Power Automate UI で手動有効化してください")
+        print(f"     https://make.powerautomate.com/flows/{wf_id}")
+        sys.exit(1)
+
+
+# ══════════════════════════════════════════════════════════════
+# メイン
+# ══════════════════════════════════════════════════════════════
+def main():
+    print("=" * 60)
+    print("  Power Automate フローデプロイ: サマリー同期")
+    print(f"  フロー名: {FLOW_DISPLAY_NAME}")
+    print("=" * 60)
+
+    env_id, connections = setup_environment()
+    create_connection_references(connections)
+    wf_id = deploy_flow_draft()
+    activate_flow(wf_id)
+
+    print("\n" + "=" * 60)
+    print("  ✅ デプロイ完了!")
+    print(f"  フロー ID: {wf_id}")
+    print(f"  → Power Automate: https://make.powerautomate.com/flows/{wf_id}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/explore/01_discover_tables.py
+++ b/scripts/explore/01_discover_tables.py
@@ -1,0 +1,30 @@
+"""Copilot Studio 関連テーブルの探索スクリプト（Step 1: テーブル発見）"""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from auth_helper import api_get
+
+def main():
+    # メタデータは contains() 非対応のため全件取得してクライアント側フィルタ
+    res = api_get(
+        "EntityDefinitions?$select=LogicalName,SchemaName,DisplayName,"
+        "PrimaryIdAttribute,PrimaryNameAttribute,IsManaged,EntitySetName"
+    )
+    patterns = ["conversation", "transcript", "bot", "copilot", "msdyn_ai", "session", "analytics"]
+    rows = []
+    for ent in res.get("value", []):
+        ln = ent["LogicalName"]
+        if not any(p in ln for p in patterns):
+            continue
+        disp = ent.get("DisplayName", {})
+        label = ""
+        if disp and disp.get("UserLocalizedLabel"):
+            label = disp["UserLocalizedLabel"]["Label"]
+        rows.append((ln, ent.get("EntitySetName", ""), label))
+
+    print(f"=== 会話/Bot関連テーブル ({len(rows)}件) ===")
+    for ln, eset, label in sorted(rows):
+        print(f"  {ln:45s} | {eset:40s} | {label}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/explore/02_table_structure.py
+++ b/scripts/explore/02_table_structure.py
@@ -1,0 +1,46 @@
+"""Step 2: 主要テーブルの列構造とレコード件数を確認"""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from auth_helper import api_get
+
+TABLES = {
+    "conversationtranscript": "conversationtranscripts",
+    "agentconversationmessage": "agentconversationmessages",
+    "bot": "bots",
+    "msdyn_copilotinteractions": "msdyn_copilotinteractionses",
+}
+
+def show_attributes(logical):
+    res = api_get(
+        f"EntityDefinitions(LogicalName='{logical}')/Attributes"
+        "?$select=LogicalName,AttributeType,DisplayName,IsValidForRead"
+    )
+    attrs = []
+    for a in res.get("value", []):
+        if not a.get("IsValidForRead"):
+            continue
+        disp = a.get("DisplayName", {})
+        label = ""
+        if disp and disp.get("UserLocalizedLabel"):
+            label = disp["UserLocalizedLabel"]["Label"]
+        attrs.append((a["LogicalName"], a.get("AttributeType", ""), label))
+    return sorted(attrs)
+
+def count_rows(eset):
+    try:
+        res = api_get(f"{eset}?$count=true&$top=1")
+        return res.get("@odata.count", "?")
+    except Exception as e:
+        return f"ERR {e}"
+
+def main():
+    for logical, eset in TABLES.items():
+        print(f"\n{'='*70}\n■ {logical}  ({eset})")
+        cnt = count_rows(eset)
+        print(f"  レコード件数: {cnt}")
+        for ln, t, label in show_attributes(logical):
+            print(f"    {ln:40s} | {t:18s} | {label}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/explore/03_sample_data.py
+++ b/scripts/explore/03_sample_data.py
@@ -1,0 +1,56 @@
+"""Step 3: 実データのサンプリング"""
+import sys, json
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from auth_helper import api_get
+
+def dump_transcripts():
+    print("="*70)
+    print("■ conversationtranscript サンプル（3件）")
+    res = api_get(
+        "conversationtranscripts?$top=3"
+        "&$select=name,conversationstarttime,schematype,schemaversion,metadata,content"
+    )
+    for r in res.get("value", []):
+        print(f"\n--- name={r.get('name')} | start={r.get('conversationstarttime')} | bot={r.get('bot_conversationtranscriptidname')}")
+        print(f"    schematype={r.get('schematype')} schemaversion={r.get('schemaversion')}")
+        md = r.get("metadata")
+        if md:
+            print(f"    metadata: {md[:500]}")
+        content = r.get("content") or ""
+        try:
+            parsed = json.loads(content)
+            print(f"    content(JSON keys): {list(parsed.keys()) if isinstance(parsed, dict) else type(parsed)}")
+            print(f"    content(先頭1500字):\n{json.dumps(parsed, ensure_ascii=False, indent=1)[:1500]}")
+        except Exception:
+            print(f"    content(raw 800字): {content[:800]}")
+
+def dump_messages():
+    print("\n"+"="*70)
+    print("■ agentconversationmessage サンプル（6件）")
+    res = api_get("agentconversationmessages?$top=6")
+    for r in res.get("value", []):
+        print(f"\n--- sender={r.get('messagesender')} | regarding={r.get('_regardingobjectid_value')} | {r.get('createdon')}")
+        print(f"    name: {r.get('name')}")
+        print(f"    message: {(r.get('message') or '')[:400]}")
+        ctx = r.get("messagecontext")
+        if ctx:
+            print(f"    context: {ctx[:300]}")
+
+def dump_bots():
+    print("\n"+"="*70)
+    print("■ bot（エージェント）一覧 上位20件")
+    res = api_get(
+        "bots?$top=20&$orderby=modifiedon desc"
+        "&$select=name,schemaname,statecode,createdon,modifiedon,publishedon,language"
+    )
+    for r in res.get("value", []):
+        print(f"  {r.get('name'):40s} | state={r.get('statecode')} | published={r.get('publishedon')}")
+
+def main():
+    dump_transcripts()
+    dump_messages()
+    dump_bots()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/explore/04_analyze_transcripts.py
+++ b/scripts/explore/04_analyze_transcripts.py
@@ -1,0 +1,118 @@
+"""Step 4: 全トランスクリプトを解析し、分析可能な指標を抽出（結果はJSONに出力）"""
+import sys, json
+from pathlib import Path
+from collections import Counter, defaultdict
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from auth_helper import api_get
+
+OUT = Path(__file__).resolve().parent / "analysis_result.json"
+
+def fetch_all_transcripts():
+    rows, url = [], (
+        "conversationtranscripts?$select=name,conversationstarttime,metadata,content,createdon&$top=200"
+    )
+    res = api_get(url)
+    rows.extend(res.get("value", []))
+    return rows
+
+def analyze():
+    rows = fetch_all_transcripts()
+    summary = {
+        "total_transcripts": len(rows),
+        "per_bot": defaultdict(lambda: {"count":0, "outcomes":Counter(), "user_msgs":0, "bot_msgs":0,
+                                         "tool_events":0, "durations":[], "sample_user_texts":[]}),
+        "outcomes_total": Counter(),
+        "channels": Counter(),
+        "event_names": Counter(),
+        "tool_servers": Counter(),
+    }
+    convo_records = []
+    for r in rows:
+        meta = {}
+        try:
+            meta = json.loads(r.get("metadata") or "{}")
+        except Exception:
+            pass
+        bot = meta.get("BotName", "unknown")
+        b = summary["per_bot"][bot]
+        b["count"] += 1
+        content = {}
+        try:
+            content = json.loads(r.get("content") or "{}")
+        except Exception:
+            pass
+        acts = content.get("activities", [])
+        ts_list = []
+        user_texts = []
+        outcome = None
+        for a in acts:
+            atype = a.get("type")
+            tms = a.get("timestampMs")
+            if tms: ts_list.append(tms)
+            ch = a.get("channelId")
+            if ch: summary["channels"][ch]+=1
+            if a.get("valueType") == "ConversationInfo":
+                outcome = (a.get("value") or {}).get("lastSessionOutcome")
+            if atype == "message":
+                role = (a.get("from") or {}).get("role")
+                if role == 1:
+                    b["user_msgs"]+=1
+                    t = a.get("text")
+                    if t: user_texts.append(t)
+                else:
+                    b["bot_msgs"]+=1
+            if atype == "event":
+                b["tool_events"]+=1
+                ename = a.get("name")
+                if ename: summary["event_names"][ename]+=1
+                val = a.get("value") or {}
+                srv = (((val.get("initializationResult") or {}).get("serverInfo")) or {}).get("name")
+                if srv: summary["tool_servers"][srv]+=1
+        if outcome:
+            b["outcomes"][outcome]+=1
+            summary["outcomes_total"][outcome]+=1
+        if ts_list:
+            dur = (max(ts_list)-min(ts_list))/1000.0
+            b["durations"].append(round(dur,1))
+        for t in user_texts[:1]:
+            if len(b["sample_user_texts"]) < 5:
+                b["sample_user_texts"].append(t[:120])
+        convo_records.append({
+            "bot": bot, "start": r.get("conversationstarttime"),
+            "outcome": outcome, "user_msgs": len(user_texts),
+            "activities": len(acts),
+            "duration_sec": round((max(ts_list)-min(ts_list))/1000.0,1) if ts_list else None,
+        })
+
+    # Counter/defaultdict を通常dictへ
+    out = {
+        "total_transcripts": summary["total_transcripts"],
+        "outcomes_total": dict(summary["outcomes_total"]),
+        "channels": dict(summary["channels"]),
+        "event_names": dict(summary["event_names"]),
+        "tool_servers": dict(summary["tool_servers"]),
+        "per_bot": {},
+        "conversations": convo_records,
+    }
+    for bot, b in summary["per_bot"].items():
+        durs = b["durations"]
+        out["per_bot"][bot] = {
+            "count": b["count"],
+            "outcomes": dict(b["outcomes"]),
+            "user_msgs": b["user_msgs"],
+            "bot_msgs": b["bot_msgs"],
+            "tool_events": b["tool_events"],
+            "avg_duration_sec": round(sum(durs)/len(durs),1) if durs else None,
+            "sample_user_texts": b["sample_user_texts"],
+        }
+    OUT.write_text(json.dumps(out, ensure_ascii=False, indent=2), encoding="utf-8")
+    # コンソールには要約のみ(ASCII安全)
+    print(f"total_transcripts={out['total_transcripts']}")
+    print(f"outcomes={out['outcomes_total']}")
+    print(f"channels={out['channels']}")
+    print(f"tool_servers={out['tool_servers']}")
+    print(f"bots={len(out['per_bot'])}")
+    print(f"-> {OUT}")
+
+if __name__ == "__main__":
+    analyze()

--- a/scripts/explore/05_check_publisher.py
+++ b/scripts/explore/05_check_publisher.py
@@ -1,0 +1,46 @@
+"""Step 0: パブリッシャー確認 + ソリューション/テーブル名衝突チェック"""
+import sys, os
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from auth_helper import api_get
+from dotenv import load_dotenv
+load_dotenv()
+
+SOLUTION_NAME = os.getenv("SOLUTION_NAME", "")
+PREFIX = os.getenv("PUBLISHER_PREFIX", "")
+
+def main():
+    # 1. 既存パブリッシャー一覧
+    pubs = api_get("publishers?$filter=customizationprefix ne 'none'&$select=friendlyname,uniquename,customizationprefix&$orderby=friendlyname")
+    print("=== Existing Publishers ===")
+    for p in pubs.get("value", []):
+        print(f"  {p['customizationprefix']:8s} | {p['friendlyname']} ({p['uniquename']})")
+
+    # 2. ソリューション名の重複チェック
+    print(f"\n=== Solution check: {SOLUTION_NAME} ===")
+    sol = api_get(f"solutions?$filter=uniquename eq '{SOLUTION_NAME}'&$select=solutionid,friendlyname")
+    vals = sol.get("value", [])
+    if vals:
+        print(f"  EXISTS: {vals[0]['friendlyname']} ({vals[0]['solutionid']})")
+    else:
+        print("  Not found (will be created)")
+
+    # 3. テーブルスキーマ名の重複チェック
+    print(f"\n=== Table check: {PREFIX}_conversationsummary ===")
+    # All entities with geek_ prefix
+    ents = api_get(f"EntityDefinitions?$select=LogicalName,DisplayName")
+    geek_tables = [e for e in ents.get("value", []) if e["LogicalName"].startswith(f"{PREFIX}_")]
+    print(f"  Tables with prefix '{PREFIX}_': {len(geek_tables)}")
+    for e in geek_tables:
+        dn = (e.get("DisplayName") or {}).get("UserLocalizedLabel") or {}
+        print(f"    {e['LogicalName']:40s} | {dn.get('Label','')}")
+
+    target = f"{PREFIX}_conversationsummary"
+    match = [e for e in geek_tables if e["LogicalName"] == target]
+    if match:
+        print(f"\n  WARNING: {target} already exists!")
+    else:
+        print(f"\n  OK: {target} does not exist yet")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/explore/analysis_result.json
+++ b/scripts/explore/analysis_result.json
@@ -1,0 +1,498 @@
+{
+  "total_transcripts": 45,
+  "outcomes_total": {
+    "Resolved": 42,
+    "None": 2,
+    "Abandoned": 1
+  },
+  "channels": {
+    "pva-autonomous": 1355,
+    "pva-studio": 81
+  },
+  "event_names": {
+    "DynamicServerInitialize": 71,
+    "DynamicServerInitializeConfirmation": 71,
+    "DynamicServerToolsList": 71,
+    "DynamicPlanReceived": 132,
+    "DynamicPlanReceivedDebug": 132,
+    "DynamicPlanStepTriggered": 178,
+    "DynamicPlanStepBindUpdate": 211,
+    "DynamicPlanStepFinished": 177,
+    "DynamicPlanFinished": 47,
+    "ResponseGeneratorSupportData": 6,
+    "UniversalSearchToolTraceData": 17,
+    "startConversation": 4,
+    "DialogTracing": 4
+  },
+  "tool_servers": {
+    "EmailsManagement": 33,
+    "Microsoft Dataverse MCP Server": 38
+  },
+  "per_bot": {
+    "geek_recxexpenseagent": {
+      "count": 33,
+      "outcomes": {
+        "Resolved": 33
+      },
+      "user_msgs": 33,
+      "bot_msgs": 33,
+      "tool_events": 944,
+      "avg_duration_sec": 35.6,
+      "sample_user_texts": [
+        "未承認の経費申請のリストのapproverごとに承認依頼の内容のメールを送信する。\n承認者の名前、申請者の名前、経費申請の内容、経費申請のリンクを含めたメールにする。",
+        "未承認の経費申請のリストのapproverごとに承認依頼の内容のメールを送信する。\n承認者の名前、申請者の名前、経費申請の内容、経費申請のリンクを含めたメールにする。",
+        "未承認の経費申請のリストのapproverごとに承認依頼の内容のメールを送信する。\n承認者の名前、申請者の名前、経費申請の内容、経費申請のリンクを含めたメールにする。",
+        "未承認の経費申請のリストのapproverごとに承認依頼の内容のメールを送信する。\n承認者の名前、申請者の名前、経費申請の内容、経費申請のリンクを含めたメールにする。",
+        "未承認の経費申請のリストのapproverごとに承認依頼の内容のメールを送信する。\n承認者の名前、申請者の名前、経費申請の内容、経費申請のリンクを含めたメールにする。"
+      ]
+    },
+    "geek_invoiceCreateAgent": {
+      "count": 5,
+      "outcomes": {
+        "None": 1,
+        "Resolved": 4
+      },
+      "user_msgs": 5,
+      "bot_msgs": 5,
+      "tool_events": 58,
+      "avg_duration_sec": 13.8,
+      "sample_user_texts": [
+        "Use content from {\"value\":[{\"id\":\"AAMkADhiMmJhYWYxLWVkYTgtNDU1NC04NzZhLTEzNTZlNDQ4NjNmNABGAAAAAACoUjN6tW1QTZssYRXVb4VXBw",
+        "Use content from {\"value\":[{\"id\":\"AAMkADhiMmJhYWYxLWVkYTgtNDU1NC04NzZhLTEzNTZlNDQ4NjNmNABGAAAAAACoUjN6tW1QTZssYRXVb4VXBw",
+        "Use content from {\"value\":[{\"id\":\"AAMkADhiMmJhYWYxLWVkYTgtNDU1NC04NzZhLTEzNTZlNDQ4NjNmNABGAAAAAACoUjN6tW1QTZssYRXVb4VXBw",
+        "Use content from {\"value\":[{\"id\":\"AAMkADhiMmJhYWYxLWVkYTgtNDU1NC04NzZhLTEzNTZlNDQ4NjNmNABGAAAAAACoUjN6tW1QTZssYRXVb4VXBw",
+        "Use content from {\"value\":[{\"id\":\"AAMkADhiMmJhYWYxLWVkYTgtNDU1NC04NzZhLTEzNTZlNDQ4NjNmNABGAAAAAACoUjN6tW1QTZssYRXVb4VXBw"
+      ]
+    },
+    "geek_teai": {
+      "count": 2,
+      "outcomes": {
+        "Resolved": 2
+      },
+      "user_msgs": 5,
+      "bot_msgs": 7,
+      "tool_events": 29,
+      "avg_duration_sec": 201.9,
+      "sample_user_texts": [
+        "データバースの中にあるメンターテーブルの説明をしてください",
+        "キャリアについて相談したいです"
+      ]
+    },
+    "geek_Nbf5mZtaucLsieoBXMgNG": {
+      "count": 1,
+      "outcomes": {
+        "None": 1
+      },
+      "user_msgs": 1,
+      "bot_msgs": 1,
+      "tool_events": 4,
+      "avg_duration_sec": 29.5,
+      "sample_user_texts": [
+        "## イベントの詳細\n件名: 社内定例\nイベントの内容: \n開始時間: 2026-05-25T10:00:00.0000000"
+      ]
+    },
+    "geek_dataverseTableCreator": {
+      "count": 2,
+      "outcomes": {
+        "Resolved": 1,
+        "Abandoned": 1
+      },
+      "user_msgs": 6,
+      "bot_msgs": 8,
+      "tool_events": 26,
+      "avg_duration_sec": 130.8,
+      "sample_user_texts": [
+        "Create fruits table",
+        "create a new fruits table"
+      ]
+    },
+    "geek_OvGmr0PZOo_AQEtCZ-D9m": {
+      "count": 1,
+      "outcomes": {
+        "Resolved": 1
+      },
+      "user_msgs": 1,
+      "bot_msgs": 0,
+      "tool_events": 25,
+      "avg_duration_sec": 32.4,
+      "sample_user_texts": [
+        "金融x生成AIに関するニュースを取得して、メールを送信する。"
+      ]
+    },
+    "geek_Ww7fTc2nwh-w_92Ubep9R": {
+      "count": 1,
+      "outcomes": {
+        "Resolved": 1
+      },
+      "user_msgs": 1,
+      "bot_msgs": 1,
+      "tool_events": 35,
+      "avg_duration_sec": 32.4,
+      "sample_user_texts": [
+        "金融x生成AIに関するニュースを取得して、メールを送信する。"
+      ]
+    }
+  },
+  "conversations": [
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-06-04T02:43:15Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 27.5
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-31T02:43:14Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 27.0
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-25T02:43:12Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 34.5
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-23T02:43:12Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 41,
+      "duration_sec": 38.5
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-13T02:43:10Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 38,
+      "duration_sec": 33.8
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-06-01T02:43:11Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 47,
+      "duration_sec": 37.0
+    },
+    {
+      "bot": "geek_invoiceCreateAgent",
+      "start": "2026-05-11T10:04:50Z",
+      "outcome": "None",
+      "user_msgs": 1,
+      "activities": 8,
+      "duration_sec": 11.0
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-06-05T02:43:12Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 38,
+      "duration_sec": 35.0
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-06-08T02:43:12Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 38,
+      "duration_sec": 35.3
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-15T02:43:07Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 41,
+      "duration_sec": 33.4
+    },
+    {
+      "bot": "geek_invoiceCreateAgent",
+      "start": "2026-06-08T10:06:28Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 15,
+      "duration_sec": 13.4
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-18T02:43:09Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 38,
+      "duration_sec": 41.8
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-19T02:43:09Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 41,
+      "duration_sec": 36.2
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-24T02:43:10Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 34.6
+    },
+    {
+      "bot": "geek_invoiceCreateAgent",
+      "start": "2026-05-18T10:09:36Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 15.2
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-06-03T02:43:13Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 30.3
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-26T02:43:11Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 50,
+      "duration_sec": 45.9
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-06-09T02:43:12Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 35,
+      "duration_sec": 32.4
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-14T02:43:08Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 47,
+      "duration_sec": 39.9
+    },
+    {
+      "bot": "geek_invoiceCreateAgent",
+      "start": "2026-06-01T10:04:20Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 16.6
+    },
+    {
+      "bot": "geek_teai",
+      "start": "2026-05-13T09:44:25Z",
+      "outcome": "Resolved",
+      "user_msgs": 2,
+      "activities": 26,
+      "duration_sec": 320.8
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-30T02:43:11Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 50,
+      "duration_sec": 40.1
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-06-07T02:43:14Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 25.2
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-06-02T02:43:14Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 41,
+      "duration_sec": 36.8
+    },
+    {
+      "bot": "geek_Nbf5mZtaucLsieoBXMgNG",
+      "start": "2026-05-22T02:49:09Z",
+      "outcome": "None",
+      "user_msgs": 1,
+      "activities": 10,
+      "duration_sec": 29.5
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-27T02:43:09Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 41,
+      "duration_sec": 38.9
+    },
+    {
+      "bot": "geek_dataverseTableCreator",
+      "start": "2026-06-08T12:54:16Z",
+      "outcome": "Resolved",
+      "user_msgs": 2,
+      "activities": 32,
+      "duration_sec": 227.1
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-06-10T02:43:14Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 35,
+      "duration_sec": 32.6
+    },
+    {
+      "bot": "geek_dataverseTableCreator",
+      "start": "2026-06-08T12:58:14Z",
+      "outcome": "Abandoned",
+      "user_msgs": 1,
+      "activities": 14,
+      "duration_sec": 34.5
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-06-06T02:43:12Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 24.3
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-29T02:43:11Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 38,
+      "duration_sec": 58.9
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-11T02:43:08Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 41,
+      "duration_sec": 40.0
+    },
+    {
+      "bot": "geek_OvGmr0PZOo_AQEtCZ-D9m",
+      "start": "2026-05-16T13:55:39Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 33,
+      "duration_sec": 32.4
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-12T02:43:08Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 26.2
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-28T02:43:10Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 27.7
+    },
+    {
+      "bot": "geek_Ww7fTc2nwh-w_92Ubep9R",
+      "start": "2026-05-16T13:54:26Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 45,
+      "duration_sec": 32.4
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-09T02:43:07Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 38.2
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-21T02:43:08Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 41,
+      "duration_sec": 25.2
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-16T02:43:08Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 50,
+      "duration_sec": 50.4
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-17T02:43:08Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 29,
+      "duration_sec": 33.8
+    },
+    {
+      "bot": "geek_invoiceCreateAgent",
+      "start": "2026-05-25T10:06:24Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 15,
+      "duration_sec": 12.7
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-20T02:43:08Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 53,
+      "duration_sec": 32.4
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-10T02:43:07Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 50,
+      "duration_sec": 46.3
+    },
+    {
+      "bot": "geek_recxexpenseagent",
+      "start": "2026-05-22T02:43:08Z",
+      "outcome": "Resolved",
+      "user_msgs": 1,
+      "activities": 41,
+      "duration_sec": 34.9
+    },
+    {
+      "bot": "geek_teai",
+      "start": "2026-05-13T09:50:35Z",
+      "outcome": "Resolved",
+      "user_msgs": 2,
+      "activities": 19,
+      "duration_sec": 83.0
+    }
+  ]
+}

--- a/scripts/setup_dataverse.py
+++ b/scripts/setup_dataverse.py
@@ -1,0 +1,351 @@
+"""
+Dataverse テーブル構築: geek_conversationsummary
+================================================
+Copilot Studio 会話トランスクリプトの日次集計テーブル。
+"""
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+from dotenv import load_dotenv
+load_dotenv()
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from auth_helper import (
+    api_get, api_post, api_patch, api_delete, api_request,
+    retry_metadata, DATAVERSE_URL,
+)
+
+SOLUTION_NAME = os.environ.get("SOLUTION_NAME", "").strip()
+PREFIX = os.environ.get("PUBLISHER_PREFIX", "").strip()
+SOLUTION_DISPLAY_NAME = os.environ.get("SOLUTION_DISPLAY_NAME", SOLUTION_NAME)
+
+if not all([DATAVERSE_URL, SOLUTION_NAME, PREFIX]):
+    print("ERROR: DATAVERSE_URL / SOLUTION_NAME / PUBLISHER_PREFIX required in .env", file=sys.stderr)
+    sys.exit(1)
+
+# ════════════════════════════════════════════════════════════════
+# テーブル定義
+# ════════════════════════════════════════════════════════════════
+
+TABLES = [
+    {
+        "logical": f"{PREFIX}_conversationsummary",
+        "display": "Conversation Summary",
+        "plural": "Conversation Summaries",
+        "description": "Copilot Studio 会話トランスクリプトの集計サマリー（1会話=1行）",
+        "columns": [
+            {"logical": f"{PREFIX}_transcriptid", "type": "String", "display": "Transcript ID", "maxLength": 100},
+            {"logical": f"{PREFIX}_botname", "type": "String", "display": "Bot Name", "maxLength": 200},
+            {"logical": f"{PREFIX}_botid", "type": "String", "display": "Bot ID", "maxLength": 100},
+            {"logical": f"{PREFIX}_starttime", "type": "DateTime", "display": "Start Time", "format": "DateAndTime"},
+            {
+                "logical": f"{PREFIX}_outcome", "type": "Picklist", "display": "Outcome",
+                "options": [
+                    (100000000, "Resolved"),
+                    (100000001, "Abandoned"),
+                    (100000002, "Escalated"),
+                    (100000003, "None"),
+                ],
+            },
+            {"logical": f"{PREFIX}_channel", "type": "String", "display": "Channel", "maxLength": 100},
+            {"logical": f"{PREFIX}_usermsgcount", "type": "Integer", "display": "User Messages"},
+            {"logical": f"{PREFIX}_botmsgcount", "type": "Integer", "display": "Bot Messages"},
+            {"logical": f"{PREFIX}_tooleventcount", "type": "Integer", "display": "Tool Events"},
+            {"logical": f"{PREFIX}_durationsec", "type": "Decimal", "display": "Duration (sec)", "precision": 1, "maxValue": 100000000},
+            {"logical": f"{PREFIX}_toolservers", "type": "String", "display": "Tool Servers", "maxLength": 500},
+            {"logical": f"{PREFIX}_firstusertext", "type": "Memo", "display": "First User Text", "maxLength": 4000},
+        ],
+    },
+]
+
+LOOKUPS = []
+
+LOCALIZE_TABLES = [
+    (f"{PREFIX}_conversationsummary", "会話サマリー", "会話サマリー"),
+]
+
+LOCALIZE_COLUMNS = [
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_name", "名前"),
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_transcriptid", "トランスクリプトID"),
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_botname", "エージェント名"),
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_botid", "エージェントID"),
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_starttime", "開始日時"),
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_outcome", "結果"),
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_channel", "チャネル"),
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_usermsgcount", "ユーザーメッセージ数"),
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_botmsgcount", "Botメッセージ数"),
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_tooleventcount", "ツールイベント数"),
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_durationsec", "所要時間(秒)"),
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_toolservers", "ツールサーバー"),
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_firstusertext", "最初のユーザー発話"),
+]
+
+LOCALIZE_OPTIONS = [
+    (f"{PREFIX}_conversationsummary", f"{PREFIX}_outcome", [
+        (100000000, "解決"),
+        (100000001, "放棄"),
+        (100000002, "エスカレーション"),
+        (100000003, "なし"),
+    ]),
+]
+
+
+# ── 共通ヘルパー ─────────────────────────────────────────────
+
+def label_jp(text):
+    return {"LocalizedLabels": [{"Label": text, "LanguageCode": 1041}]}
+
+def _save_env_value(key, value):
+    env_path = Path(__file__).resolve().parents[1] / ".env"
+    lines = []
+    found = False
+    if env_path.exists():
+        with open(env_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+    for i, line in enumerate(lines):
+        if line.startswith(f"{key}="):
+            lines[i] = f"{key}={value}\n"
+            found = True
+            break
+    if not found:
+        lines.append(f"{key}={value}\n")
+    with open(env_path, "w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+def get_entity_set_name(logical_name):
+    meta = api_get(f"EntityDefinitions(LogicalName='{logical_name}')?$select=EntitySetName")
+    return meta["EntitySetName"]
+
+
+# ── Step 1: ソリューション ──────────────────────────────────
+
+def ensure_solution():
+    global SOLUTION_DISPLAY_NAME
+    print("\n=== Step 1: Solution ===")
+    existing = api_get(f"solutions?$filter=uniquename eq '{SOLUTION_NAME}'&$select=solutionid,friendlyname")
+    if existing.get("value"):
+        dn = existing["value"][0].get("friendlyname", SOLUTION_DISPLAY_NAME)
+        print(f"  Exists: {SOLUTION_NAME} ({dn})")
+        SOLUTION_DISPLAY_NAME = dn
+        _save_env_value("SOLUTION_DISPLAY_NAME", dn)
+        return
+    print(f"  Creating '{SOLUTION_NAME}'...")
+    pubs = api_get(f"publishers?$filter=customizationprefix eq '{PREFIX}'&$select=publisherid")
+    if not pubs.get("value"):
+        raise RuntimeError(f"Publisher prefix='{PREFIX}' not found")
+    pub_id = pubs["value"][0]["publisherid"]
+    api_post("solutions", {
+        "uniquename": SOLUTION_NAME,
+        "friendlyname": SOLUTION_DISPLAY_NAME,
+        "version": "1.0.0.0",
+        "publisherid@odata.bind": f"/publishers({pub_id})",
+    })
+    _save_env_value("SOLUTION_DISPLAY_NAME", SOLUTION_DISPLAY_NAME)
+    print(f"  Created: {SOLUTION_DISPLAY_NAME}")
+
+
+# ── Step 2: テーブル ─────────────────────────────────────────
+
+def build_column_body(col):
+    base = {
+        "SchemaName": col["logical"],
+        "DisplayName": label_jp(col["display"]),
+        "RequiredLevel": {"Value": "None"},
+    }
+    t = col["type"]
+    if t == "Memo":
+        base["@odata.type"] = "#Microsoft.Dynamics.CRM.MemoAttributeMetadata"
+        base["Format"] = "Text"
+        base["MaxLength"] = col.get("maxLength", 2000)
+    elif t == "Picklist":
+        base["@odata.type"] = "#Microsoft.Dynamics.CRM.PicklistAttributeMetadata"
+        base["OptionSet"] = {
+            "@odata.type": "#Microsoft.Dynamics.CRM.OptionSetMetadata",
+            "IsGlobal": False, "OptionSetType": "Picklist",
+            "Options": [{"Value": v, "Label": label_jp(lbl)} for v, lbl in col["options"]],
+        }
+    elif t == "DateTime":
+        base["@odata.type"] = "#Microsoft.Dynamics.CRM.DateTimeAttributeMetadata"
+        base["Format"] = col.get("format", "DateAndTime")
+    elif t == "String":
+        base["@odata.type"] = "#Microsoft.Dynamics.CRM.StringAttributeMetadata"
+        base["FormatName"] = {"Value": "Text"}
+        base["MaxLength"] = col.get("maxLength", 200)
+    elif t == "Integer":
+        base["@odata.type"] = "#Microsoft.Dynamics.CRM.IntegerAttributeMetadata"
+        base["MinValue"] = col.get("minValue", 0)
+        base["MaxValue"] = col.get("maxValue", 100000)
+    elif t == "Decimal":
+        base["@odata.type"] = "#Microsoft.Dynamics.CRM.DecimalAttributeMetadata"
+        base["Precision"] = col.get("precision", 2)
+        base["MinValue"] = col.get("minValue", 0)
+        base["MaxValue"] = col.get("maxValue", 100000000000)
+    return base
+
+
+def create_tables():
+    print("\n=== Step 2: Tables ===")
+    for tbl in TABLES:
+        logical = tbl["logical"]
+        def _create(t=tbl):
+            body = {
+                "@odata.type": "#Microsoft.Dynamics.CRM.EntityMetadata",
+                "SchemaName": t["logical"],
+                "DisplayName": label_jp(t["display"]),
+                "DisplayCollectionName": label_jp(t["plural"]),
+                "Description": label_jp(t["description"]),
+                "OwnershipType": "UserOwned",
+                "IsActivity": False, "HasActivities": False,
+                "HasNotes": False, "HasFeedback": False,
+                "PrimaryNameAttribute": f"{PREFIX}_name",
+                "Attributes": [{
+                    "@odata.type": "#Microsoft.Dynamics.CRM.StringAttributeMetadata",
+                    "SchemaName": f"{PREFIX}_name",
+                    "DisplayName": label_jp("Name"),
+                    "IsPrimaryName": True,
+                    "RequiredLevel": {"Value": "ApplicationRequired"},
+                    "FormatName": {"Value": "Text"},
+                    "MaxLength": 200,
+                }],
+            }
+            api_post("EntityDefinitions", body, solution=SOLUTION_NAME)
+            print(f"  Table '{logical}' created")
+        retry_metadata(_create, f"Table {logical}")
+        time.sleep(10)
+
+        for col in tbl.get("columns", []):
+            col_logical = col["logical"]
+            try:
+                api_get(f"EntityDefinitions(LogicalName='{logical}')/Attributes(LogicalName='{col_logical}')?$select=LogicalName")
+                print(f"    Column '{col_logical}' exists, skip")
+                continue
+            except Exception:
+                pass
+            def _add(c=col, ln=logical):
+                api_post(f"EntityDefinitions(LogicalName='{ln}')/Attributes", build_column_body(c), solution=SOLUTION_NAME)
+                print(f"    Column '{c['logical']}' added")
+            retry_metadata(_add, f"Column {col_logical}")
+            time.sleep(5)
+
+
+# ── Step 3-4: Publish ────────────────────────────────────────
+
+def publish_all():
+    print("\n  Publishing...")
+    api_post("PublishAllXml", {})
+    print("  Published")
+
+
+# ── Step 5: Localize ─────────────────────────────────────────
+
+def localize():
+    print("\n=== Step 5: Localize ===")
+    for logical, disp, plural in LOCALIZE_TABLES:
+        data = api_get(f"EntityDefinitions(LogicalName='{logical}')?$select=MetadataId")
+        mid = data["MetadataId"]
+        api_request(f"EntityDefinitions({mid})", {
+            "@odata.type": "#Microsoft.Dynamics.CRM.EntityMetadata",
+            "MetadataId": mid,
+            "DisplayName": label_jp(disp),
+            "DisplayCollectionName": label_jp(plural),
+        }, method="PUT")
+        print(f"  Table '{logical}' -> '{disp}'")
+
+    for table, col, disp in LOCALIZE_COLUMNS:
+        data = api_get(f"EntityDefinitions(LogicalName='{table}')/Attributes(LogicalName='{col}')?$select=MetadataId,AttributeType")
+        mid = data["MetadataId"]
+        odata_map = {
+            "String": "#Microsoft.Dynamics.CRM.StringAttributeMetadata",
+            "Memo": "#Microsoft.Dynamics.CRM.MemoAttributeMetadata",
+            "Picklist": "#Microsoft.Dynamics.CRM.PicklistAttributeMetadata",
+            "DateTime": "#Microsoft.Dynamics.CRM.DateTimeAttributeMetadata",
+            "Integer": "#Microsoft.Dynamics.CRM.IntegerAttributeMetadata",
+            "Decimal": "#Microsoft.Dynamics.CRM.DecimalAttributeMetadata",
+        }
+        ot = odata_map.get(data.get("AttributeType", ""), "#Microsoft.Dynamics.CRM.AttributeMetadata")
+        api_request(f"EntityDefinitions(LogicalName='{table}')/Attributes({mid})", {
+            "@odata.type": ot, "MetadataId": mid, "DisplayName": label_jp(disp),
+        }, method="PUT")
+        print(f"  Column '{table}.{col}' -> '{disp}'")
+
+    for table, col, options in LOCALIZE_OPTIONS:
+        for value, label_text in options:
+            api_post("UpdateOptionValue", {
+                "EntityLogicalName": table, "AttributeLogicalName": col,
+                "Value": value, "Label": label_jp(label_text), "MergeLabels": True,
+            })
+            print(f"    Option {col}={value} -> '{label_text}'")
+
+
+# ── Step 7: Solution membership ──────────────────────────────
+
+def ensure_solution_membership():
+    print("\n=== Step 7: Solution membership ===")
+    sols = api_get(f"solutions?$filter=uniquename eq '{SOLUTION_NAME}'&$select=solutionid")
+    if not sols.get("value"):
+        print("  Solution not found!"); return
+    sol_id = sols["value"][0]["solutionid"]
+    comps = api_get(f"solutioncomponents?$filter=_solutionid_value eq {sol_id} and componenttype eq 1&$select=objectid")
+    existing_ids = {c["objectid"] for c in comps.get("value", [])}
+    for tbl in TABLES:
+        logical = tbl["logical"]
+        try:
+            meta = api_get(f"EntityDefinitions(LogicalName='{logical}')?$select=MetadataId")
+            mid = meta["MetadataId"]
+            if mid in existing_ids:
+                print(f"  OK: {logical}")
+            else:
+                api_post("AddSolutionComponent", {
+                    "ComponentId": mid, "ComponentType": 1,
+                    "SolutionUniqueName": SOLUTION_NAME,
+                    "AddRequiredComponents": False, "DoNotIncludeSubcomponents": False,
+                })
+                print(f"  Added: {logical}")
+        except Exception as e:
+            print(f"  ERR: {logical}: {e}")
+
+
+# ── Step 8: Verify ───────────────────────────────────────────
+
+def verify():
+    print("\n=== Step 8: Verify ===")
+    for tbl in TABLES:
+        logical = tbl["logical"]
+        try:
+            eset = get_entity_set_name(logical)
+            data = api_get(f"{eset}?$top=1&$select={PREFIX}_name")
+            print(f"  OK: {logical} ({eset}) rows={len(data.get('value', []))}")
+        except Exception as e:
+            print(f"  FAIL: {logical}: {e}")
+
+
+# ── Main ─────────────────────────────────────────────────────
+
+def main():
+    print("=" * 60)
+    print("  Dataverse Setup: geek_conversationsummary")
+    print("=" * 60)
+    print(f"  Env: {DATAVERSE_URL}")
+    print(f"  Solution: {SOLUTION_NAME}")
+    print(f"  Prefix: {PREFIX}")
+
+    ensure_solution()
+    create_tables()
+    publish_all()
+    localize()
+    publish_all()
+    ensure_solution_membership()
+    verify()
+
+    print("\n=== DONE ===")
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"\nERROR: {e}")
+        traceback.print_exc()
+        sys.exit(1)

--- a/scripts/toggle_table_lang.py
+++ b/scripts/toggle_table_lang.py
@@ -1,0 +1,63 @@
+"""
+テーブル表示名を英語⇔日本語で切り替えるユーティリティ。
+pac code add-data-source の日本語サニタイズ問題の回避用。
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+from auth_helper import api_get, api_request
+
+load_dotenv()
+
+PREFIX = os.environ.get("PUBLISHER_PREFIX", "").strip()
+if not PREFIX:
+    raise SystemExit(
+        "PUBLISHER_PREFIX が .env に設定されていません。"
+    )
+
+# (論理名, 英語DisplayName, 英語DisplayCollectionName, 日本語DisplayName, 日本語DisplayCollectionName)
+TABLES = [
+    (f"{PREFIX}_conversationsummary", "Conversation Summary", "Conversation Summaries", "会話サマリー", "会話サマリー一覧"),
+]
+
+
+def label_en(text):
+    return {"LocalizedLabels": [{"Label": text, "LanguageCode": 1033}]}
+
+
+def label_jp(text):
+    return {"LocalizedLabels": [{"Label": text, "LanguageCode": 1041}]}
+
+
+def set_display_names(to_english=True):
+    for logical, en_disp, en_plural, jp_disp, jp_plural in TABLES:
+        data = api_get(
+            f"EntityDefinitions(LogicalName='{logical}')?$select=MetadataId"
+        )
+        mid = data["MetadataId"]
+        lbl = label_en if to_english else label_jp
+        disp = en_disp if to_english else jp_disp
+        plural = en_plural if to_english else jp_plural
+        body = {
+            "@odata.type": "#Microsoft.Dynamics.CRM.EntityMetadata",
+            "MetadataId": mid,
+            "DisplayName": lbl(disp),
+            "DisplayCollectionName": lbl(plural),
+        }
+        api_request(f"EntityDefinitions({mid})", body, method="PUT")
+        print(f"  {logical} → {disp} / {plural}")
+
+
+if __name__ == "__main__":
+    mode = sys.argv[1] if len(sys.argv) > 1 else "en"
+    if mode == "en":
+        print("=== テーブル表示名を英語に変更 ===")
+        set_display_names(to_english=True)
+    elif mode == "jp":
+        print("=== テーブル表示名を日本語に復元 ===")
+        set_display_names(to_english=False)
+    else:
+        print("Usage: python toggle_table_lang.py [en|jp]")

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1,0 +1,3 @@
+export function CommandPalette() {
+  return null;
+}

--- a/src/components/conversation-chat-dialog.tsx
+++ b/src/components/conversation-chat-dialog.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from "react";
+import { useTranscriptContent } from "@/hooks/use-copilot-analytics";
+import {
+  parseTranscriptActivities,
+  OUTCOME_LABELS,
+  OUTCOME_COLORS,
+} from "@/types/copilot-analytics";
+import type { ConversationSummary } from "@/types/copilot-analytics";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+import { Bot, User, Wrench } from "lucide-react";
+
+function fmtTime(ms: number | null): string {
+  if (!ms) return "";
+  try {
+    return new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  } catch {
+    return "";
+  }
+}
+
+export function ConversationChatDialog({
+  summary,
+  open,
+  onOpenChange,
+}: {
+  summary: ConversationSummary | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const transcriptId = open ? summary?.geek_transcriptid ?? null : null;
+  const { data: content, isLoading, error } = useTranscriptContent(transcriptId);
+
+  const activities = useMemo(
+    () => (content ? parseTranscriptActivities(content) : []),
+    [content],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Bot className="size-4 text-primary" />
+            {summary?.geek_botname || "会話"}
+          </DialogTitle>
+          <DialogDescription className="flex flex-wrap items-center gap-2">
+            <span>{summary?.geek_starttime?.slice(0, 16).replace("T", " ")}</span>
+            {summary && (
+              <Badge
+                variant="outline"
+                style={{
+                  borderColor: OUTCOME_COLORS[summary.geek_outcome],
+                  color: OUTCOME_COLORS[summary.geek_outcome],
+                }}
+                className="text-xs"
+              >
+                {OUTCOME_LABELS[summary.geek_outcome] ?? summary.geek_outcome}
+              </Badge>
+            )}
+            {summary?.geek_channel && (
+              <Badge variant="secondary" className="text-xs">{summary.geek_channel}</Badge>
+            )}
+            <span className="text-xs">{summary?.geek_durationsec?.toFixed(0)}秒</span>
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="flex-1 -mx-2 px-2">
+          <div className="space-y-3 py-2">
+            {isLoading && <p className="text-sm text-muted-foreground py-8 text-center">読み込み中…</p>}
+            {error && <p className="text-sm text-destructive py-8 text-center">トランスクリプトを取得できませんでした</p>}
+            {!isLoading && !error && activities.length === 0 && (
+              <p className="text-sm text-muted-foreground py-8 text-center">表示できるメッセージがありません</p>
+            )}
+
+            {activities.map((a) => {
+              if (a.kind === "event") {
+                return (
+                  <div key={a.id} className="flex justify-center">
+                    <div className="flex items-center gap-1.5 text-xs text-muted-foreground bg-muted rounded-full px-3 py-1">
+                      <Wrench className="size-3" />
+                      <span>{a.text}</span>
+                    </div>
+                  </div>
+                );
+              }
+              const isUser = a.role === "user";
+              return (
+                <div key={a.id} className={`flex gap-2 ${isUser ? "flex-row-reverse" : "flex-row"}`}>
+                  <div
+                    className={`flex size-7 shrink-0 items-center justify-center rounded-full ${
+                      isUser ? "bg-primary text-primary-foreground" : "bg-muted text-foreground"
+                    }`}
+                  >
+                    {isUser ? <User className="size-4" /> : <Bot className="size-4" />}
+                  </div>
+                  <div className={`flex flex-col gap-0.5 max-w-[75%] ${isUser ? "items-end" : "items-start"}`}>
+                    <div
+                      className={`rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap break-words ${
+                        isUser
+                          ? "bg-primary text-primary-foreground rounded-tr-sm"
+                          : "bg-muted text-foreground rounded-tl-sm"
+                      }`}
+                    >
+                      {a.text}
+                    </div>
+                    {a.timestamp && (
+                      <span className="text-[10px] text-muted-foreground px-1">{fmtTime(a.timestamp)}</span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/quick-activity-fab.tsx
+++ b/src/components/quick-activity-fab.tsx
@@ -1,0 +1,3 @@
+export function QuickActivityFab() {
+  return null;
+}

--- a/src/hooks/use-copilot-analytics.ts
+++ b/src/hooks/use-copilot-analytics.ts
@@ -1,0 +1,38 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getConversationSummaries, getBots, getTranscriptContent, triggerSummaryRefresh } from "@/services/copilot-analytics-service";
+
+export function useConversationSummaries() {
+  return useQuery({
+    queryKey: ["conversationSummaries"],
+    queryFn: getConversationSummaries,
+  });
+}
+
+export function useBots() {
+  return useQuery({
+    queryKey: ["bots"],
+    queryFn: getBots,
+  });
+}
+
+export function useTranscriptContent(transcriptId: string | null) {
+  return useQuery({
+    queryKey: ["transcriptContent", transcriptId],
+    queryFn: () => getTranscriptContent(transcriptId!),
+    enabled: !!transcriptId,
+  });
+}
+
+export function useRefreshSummaries() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: triggerSummaryRefresh,
+    onSuccess: () => {
+      // 非同期処理のため少し待ってからリフレッシュ
+      setTimeout(() => {
+        qc.invalidateQueries({ queryKey: ["conversationSummaries"] });
+        qc.invalidateQueries({ queryKey: ["bots"] });
+      }, 15_000);
+    },
+  });
+}

--- a/src/lib/dataSourcesInfo.ts
+++ b/src/lib/dataSourcesInfo.ts
@@ -15,6 +15,20 @@ export const dataSourcesInfo = {
     dataSourceType: "Dataverse",
     apis: {},
   },
+  bots: {
+    tableId: "bot",
+    version: "",
+    primaryKey: "botid",
+    dataSourceType: "Dataverse",
+    apis: {},
+  },
+  conversationtranscripts: {
+    tableId: "conversationtranscript",
+    version: "",
+    primaryKey: "conversationtranscriptid",
+    dataSourceType: "Dataverse",
+    apis: {},
+  },
   geek_incidents: {
     tableId: "geek_incident",
     version: "",
@@ -73,6 +87,22 @@ export const dataSourcesInfo = {
         ],
         responseInfo: {
           events_json: { type: "string" },
+        },
+      },
+    },
+  },
+  RefreshSummaries: {
+    tableId: "",
+    version: "",
+    dataSourceType: "Connector",
+    apis: {
+      Run: {
+        path: "/triggers/manual/run",
+        method: "POST",
+        parameters: [],
+        responseInfo: {
+          status: { type: "string" },
+          message: { type: "string" },
         },
       },
     },

--- a/src/pages/agent-management.tsx
+++ b/src/pages/agent-management.tsx
@@ -1,0 +1,132 @@
+import { useBots, useConversationSummaries } from "@/hooks/use-copilot-analytics";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { LoadingSkeletonCard } from "@/components/loading-skeleton";
+import { useMemo } from "react";
+
+export default function AgentManagement() {
+  const { data: bots, isLoading: botsLoading } = useBots();
+  const { data: summaries, isLoading: sumLoading } = useConversationSummaries();
+
+  const agentStats = useMemo(() => {
+    if (!bots || !summaries) return [];
+    const statsMap: Record<string, { count: number; resolved: number; lastUsed: string | null }> = {};
+    for (const s of summaries) {
+      const bid = s.geek_botid;
+      if (!statsMap[bid]) statsMap[bid] = { count: 0, resolved: 0, lastUsed: null };
+      statsMap[bid].count++;
+      if (s.geek_outcome === 100000000) statsMap[bid].resolved++;
+      if (!statsMap[bid].lastUsed || s.geek_starttime > statsMap[bid].lastUsed!) {
+        statsMap[bid].lastUsed = s.geek_starttime;
+      }
+    }
+    return bots.map((b) => {
+      const s = statsMap[b.botid] ?? { count: 0, resolved: 0, lastUsed: null };
+      return {
+        ...b,
+        conversationCount: s.count,
+        resolveRate: s.count > 0 ? (s.resolved / s.count * 100) : null,
+        lastUsed: s.lastUsed,
+      };
+    });
+  }, [bots, summaries]);
+
+  if (botsLoading || sumLoading) return <LoadingSkeletonCard count={4} />;
+
+  const published = agentStats.filter((a) => a.publishedon);
+  const activeCount = agentStats.filter((a) => a.conversationCount > 0).length;
+  const dormant = published.filter((a) => a.conversationCount === 0);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">エージェント管理</h1>
+        <p className="text-muted-foreground">環境内の全エージェントを棚卸し・ガバナンス管理</p>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card>
+          <CardHeader className="pb-2"><CardTitle className="text-sm text-muted-foreground">総エージェント</CardTitle></CardHeader>
+          <CardContent><div className="text-2xl font-bold">{agentStats.length}</div></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2"><CardTitle className="text-sm text-muted-foreground">公開済み</CardTitle></CardHeader>
+          <CardContent><div className="text-2xl font-bold">{published.length}</div></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2"><CardTitle className="text-sm text-muted-foreground">利用実績あり</CardTitle></CardHeader>
+          <CardContent><div className="text-2xl font-bold text-green-600">{activeCount}</div></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2"><CardTitle className="text-sm text-muted-foreground">公開済み未使用</CardTitle></CardHeader>
+          <CardContent><div className="text-2xl font-bold text-amber-500">{dormant.length}</div></CardContent>
+        </Card>
+      </div>
+
+      {dormant.length > 0 && (
+        <Card className="border-amber-200 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-800">
+          <CardHeader>
+            <CardTitle className="text-sm text-amber-700 dark:text-amber-400">棚卸し推奨：公開済み・会話0件のエージェント</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-1 text-sm">
+              {dormant.map((a) => (
+                <li key={a.botid} className="flex items-center gap-2">
+                  <Badge variant="outline" className="text-xs">未使用</Badge>
+                  <span className="font-medium">{a.name}</span>
+                  <span className="text-muted-foreground">（公開: {a.publishedon?.slice(0, 10)}）</span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">全エージェント一覧</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-muted-foreground">
+                  <th className="py-2 pr-3">名前</th>
+                  <th className="py-2 pr-3">状態</th>
+                  <th className="py-2 pr-3 text-right">会話数</th>
+                  <th className="py-2 pr-3 text-right">解決率</th>
+                  <th className="py-2 pr-3">最終利用</th>
+                  <th className="py-2">公開日</th>
+                </tr>
+              </thead>
+              <tbody>
+                {agentStats.map((a) => (
+                  <tr key={a.botid} className="border-b last:border-0">
+                    <td className="py-2 pr-3 font-medium max-w-[250px] truncate" title={a.name}>{a.name}</td>
+                    <td className="py-2 pr-3">
+                      <Badge variant={a.publishedon ? "default" : "secondary"} className="text-xs">
+                        {a.publishedon ? "公開" : "下書き"}
+                      </Badge>
+                    </td>
+                    <td className="py-2 pr-3 text-right">{a.conversationCount}</td>
+                    <td className="py-2 pr-3 text-right">
+                      {a.resolveRate !== null ? (
+                        <Badge variant={a.resolveRate >= 80 ? "default" : "destructive"} className="text-xs">
+                          {a.resolveRate.toFixed(0)}%
+                        </Badge>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </td>
+                    <td className="py-2 pr-3 text-muted-foreground">{a.lastUsed?.slice(0, 10) ?? "—"}</td>
+                    <td className="py-2 text-muted-foreground">{a.publishedon?.slice(0, 10) ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/copilot-dashboard.tsx
+++ b/src/pages/copilot-dashboard.tsx
@@ -1,0 +1,572 @@
+import { useMemo, useState } from "react";
+import { useConversationSummaries, useBots, useRefreshSummaries } from "@/hooks/use-copilot-analytics";
+import { OUTCOME_LABELS, OUTCOME_COLORS } from "@/types/copilot-analytics";
+import type { ConversationSummary } from "@/types/copilot-analytics";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { LoadingSkeletonCard } from "@/components/loading-skeleton";
+import { ConversationChatDialog } from "@/components/conversation-chat-dialog";
+import { ArrowUp, ArrowDown, Minus, RefreshCw, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+// ── KPIカード（前週比デルタ対応） ──
+function KpiCard({ title, value, sub, color, delta }: {
+  title: string; value: string | number; sub?: string; color?: string;
+  delta?: { value: number; label: string; inverse?: boolean };
+}) {
+  const deltaColor = delta
+    ? delta.value === 0 ? undefined
+    : (delta.value > 0) !== !!delta.inverse ? "hsl(142,76%,36%)" : "hsl(0,84%,60%)"
+    : undefined;
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-end gap-2">
+          <div className="text-2xl font-bold" style={color ? { color } : undefined}>{value}</div>
+          {delta && delta.value !== 0 && (
+            <span className="flex items-center text-xs font-medium mb-0.5" style={{ color: deltaColor }}>
+              {delta.value > 0 ? <ArrowUp className="size-3" /> : <ArrowDown className="size-3" />}
+              {Math.abs(delta.value).toFixed(0)}{delta.label}
+            </span>
+          )}
+          {delta && delta.value === 0 && (
+            <span className="flex items-center text-xs text-muted-foreground mb-0.5">
+              <Minus className="size-3" /> 変化なし
+            </span>
+          )}
+        </div>
+        {sub && <p className="text-xs text-muted-foreground mt-1">{sub}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── 成果バー ──
+function OutcomeBar({ data }: { data: Record<number, number> }) {
+  const total = Object.values(data).reduce((a, b) => a + b, 0);
+  if (total === 0) return null;
+  return (
+    <div className="flex h-6 rounded-md overflow-hidden w-full">
+      {Object.entries(data).map(([k, v]) => {
+        const code = Number(k);
+        const pct = (v / total) * 100;
+        if (pct === 0) return null;
+        return (
+          <div
+            key={code}
+            className="flex items-center justify-center text-[10px] font-medium text-white"
+            style={{ width: `${pct}%`, backgroundColor: OUTCOME_COLORS[code] ?? "#888", minWidth: pct > 5 ? undefined : "20px" }}
+            title={`${OUTCOME_LABELS[code] ?? code}: ${v}件 (${pct.toFixed(0)}%)`}
+          >
+            {pct > 10 ? `${OUTCOME_LABELS[code]} ${v}` : v}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── 日次トレンド（テキストテーブル） ──
+function DailyTrend({ summaries }: { summaries: ConversationSummary[] }) {
+  const byDate = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const s of summaries) {
+      const d = s.geek_starttime?.slice(0, 10);
+      if (d) map[d] = (map[d] ?? 0) + 1;
+    }
+    return Object.entries(map).sort(([a], [b]) => a.localeCompare(b));
+  }, [summaries]);
+
+  const max = Math.max(...byDate.map(([, v]) => v), 1);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">日次会話トレンド</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1 max-h-[300px] overflow-y-auto">
+        {byDate.map(([date, count]) => (
+          <div key={date} className="flex items-center gap-2 text-xs">
+            <span className="w-20 text-muted-foreground">{date.slice(5)}</span>
+            <div className="flex-1 h-4 bg-muted rounded overflow-hidden">
+              <div className="h-full bg-primary rounded" style={{ width: `${(count / max) * 100}%` }} />
+            </div>
+            <span className="w-6 text-right font-medium">{count}</span>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── エージェント別テーブル ──
+function AgentTable({ summaries }: { summaries: ConversationSummary[] }) {
+  const agents = useMemo(() => {
+    const map: Record<string, { count: number; resolved: number; avgDur: number; durSum: number; tools: number }> = {};
+    for (const s of summaries) {
+      const n = s.geek_botname || "unknown";
+      if (!map[n]) map[n] = { count: 0, resolved: 0, avgDur: 0, durSum: 0, tools: 0 };
+      map[n].count++;
+      if (s.geek_outcome === 100000000) map[n].resolved++;
+      map[n].durSum += s.geek_durationsec ?? 0;
+      map[n].tools += s.geek_tooleventcount ?? 0;
+    }
+    return Object.entries(map)
+      .map(([name, v]) => ({ name, ...v, avgDur: v.durSum / v.count, resolveRate: v.count > 0 ? (v.resolved / v.count * 100) : 0 }))
+      .sort((a, b) => b.count - a.count);
+  }, [summaries]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">エージェント別パフォーマンス</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-muted-foreground">
+                <th className="py-2 pr-4">エージェント</th>
+                <th className="py-2 pr-4 text-right">会話数</th>
+                <th className="py-2 pr-4 text-right">解決率</th>
+                <th className="py-2 pr-4 text-right">平均時間</th>
+                <th className="py-2 text-right">ツール呼出</th>
+              </tr>
+            </thead>
+            <tbody>
+              {agents.map((a) => (
+                <tr key={a.name} className="border-b last:border-0">
+                  <td className="py-2 pr-4 font-medium max-w-[200px] truncate" title={a.name}>{a.name}</td>
+                  <td className="py-2 pr-4 text-right">{a.count}</td>
+                  <td className="py-2 pr-4 text-right">
+                    <Badge variant={a.resolveRate >= 80 ? "default" : "destructive"} className="text-xs">
+                      {a.resolveRate.toFixed(0)}%
+                    </Badge>
+                  </td>
+                  <td className="py-2 pr-4 text-right">{a.avgDur.toFixed(1)}秒</td>
+                  <td className="py-2 text-right">{a.tools}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── ツールサーバーランキング ──
+function ToolServerRanking({ summaries }: { summaries: ConversationSummary[] }) {
+  const servers = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const s of summaries) {
+      for (const srv of (s.geek_toolservers ?? "").split(",").map((x) => x.trim()).filter(Boolean)) {
+        map[srv] = (map[srv] ?? 0) + 1;
+      }
+    }
+    return Object.entries(map).sort(([, a], [, b]) => b - a);
+  }, [summaries]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">ツール（MCP サーバー）利用ランキング</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {servers.map(([name, count]) => (
+          <div key={name} className="flex items-center justify-between text-sm">
+            <span className="truncate max-w-[200px]" title={name}>{name}</span>
+            <Badge variant="secondary">{count}件</Badge>
+          </div>
+        ))}
+        {servers.length === 0 && <p className="text-sm text-muted-foreground">データなし</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── チャネル別分布 ──
+function ChannelDistribution({ summaries }: { summaries: ConversationSummary[] }) {
+  const channels = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const s of summaries) {
+      const ch = s.geek_channel || "不明";
+      map[ch] = (map[ch] ?? 0) + 1;
+    }
+    return Object.entries(map).sort(([, a], [, b]) => b - a);
+  }, [summaries]);
+
+  const total = summaries.length || 1;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">チャネル別分布</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {channels.map(([ch, count]) => (
+          <div key={ch} className="space-y-1">
+            <div className="flex items-center justify-between text-xs">
+              <span className="font-medium">{ch}</span>
+              <span className="text-muted-foreground">{count}件 ({((count / total) * 100).toFixed(0)}%)</span>
+            </div>
+            <div className="h-2 bg-muted rounded overflow-hidden">
+              <div className="h-full bg-primary rounded" style={{ width: `${(count / total) * 100}%` }} />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── 時間帯ヒートマップ（曜日×時間） ──
+const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+function HourlyHeatmap({ summaries }: { summaries: ConversationSummary[] }) {
+  const grid = useMemo(() => {
+    // grid[day][hour] = count
+    const g: number[][] = Array.from({ length: 7 }, () => Array(24).fill(0));
+    for (const s of summaries) {
+      if (!s.geek_starttime) continue;
+      const d = new Date(s.geek_starttime);
+      g[d.getDay()][d.getHours()]++;
+    }
+    return g;
+  }, [summaries]);
+
+  const maxVal = Math.max(1, ...grid.flat());
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">時間帯別利用ヒートマップ</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <TooltipProvider delayDuration={100}>
+          <div className="overflow-x-auto">
+            <div className="inline-grid gap-px" style={{ gridTemplateColumns: `2rem repeat(24, 1fr)` }}>
+              {/* header */}
+              <div />
+              {Array.from({ length: 24 }, (_, h) => (
+                <div key={h} className="text-[9px] text-center text-muted-foreground w-5">{h}</div>
+              ))}
+              {/* rows */}
+              {grid.map((row, day) => (
+                <>
+                  <div key={`d${day}`} className="text-[10px] font-medium flex items-center">{DAY_LABELS[day]}</div>
+                  {row.map((v, h) => {
+                    const intensity = v / maxVal;
+                    return (
+                      <Tooltip key={`${day}-${h}`}>
+                        <TooltipTrigger asChild>
+                          <div
+                            className="w-5 h-5 rounded-sm"
+                            style={{
+                              backgroundColor: v === 0
+                                ? "hsl(var(--muted))"
+                                : `hsl(142, 76%, ${80 - intensity * 50}%)`,
+                            }}
+                          />
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="text-xs">
+                          {DAY_LABELS[day]} {h}:00 — {v}件
+                        </TooltipContent>
+                      </Tooltip>
+                    );
+                  })}
+                </>
+              ))}
+            </div>
+          </div>
+        </TooltipProvider>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── 改善提案 ──
+function ImprovementSuggestions({ summaries }: { summaries: ConversationSummary[] }) {
+  const suggestions = useMemo(() => {
+    const items: { level: "warn" | "info"; text: string }[] = [];
+
+    // 解決率が低いエージェント
+    const agentMap: Record<string, { total: number; resolved: number; abandoned: number }> = {};
+    for (const s of summaries) {
+      const n = s.geek_botname || "unknown";
+      if (!agentMap[n]) agentMap[n] = { total: 0, resolved: 0, abandoned: 0 };
+      agentMap[n].total++;
+      if (s.geek_outcome === 100000000) agentMap[n].resolved++;
+      if (s.geek_outcome === 100000001) agentMap[n].abandoned++;
+    }
+    for (const [name, v] of Object.entries(agentMap)) {
+      if (v.total >= 2 && v.resolved / v.total < 0.8) {
+        items.push({ level: "warn", text: `${name} の解決率が ${(v.resolved / v.total * 100).toFixed(0)}% と低い（${v.abandoned}件放棄）` });
+      }
+    }
+
+    // 長時間会話
+    const longConvos = summaries.filter((s) => s.geek_durationsec > 120);
+    if (longConvos.length > 0) {
+      items.push({ level: "info", text: `${longConvos.length}件の会話が2分超（ボトルネック調査推奨）` });
+    }
+
+    // ツール未活用エージェント
+    const toolMap: Record<string, { total: number; withTool: number }> = {};
+    for (const s of summaries) {
+      const n = s.geek_botname || "unknown";
+      if (!toolMap[n]) toolMap[n] = { total: 0, withTool: 0 };
+      toolMap[n].total++;
+      if ((s.geek_tooleventcount ?? 0) > 0) toolMap[n].withTool++;
+    }
+    for (const [name, v] of Object.entries(toolMap)) {
+      if (v.total >= 5 && v.withTool / v.total < 0.1) {
+        items.push({ level: "info", text: `${name} のツール利用率が ${(v.withTool / v.total * 100).toFixed(0)}%（MCP連携の検討推奨）` });
+      }
+    }
+
+    // 高ターン数会話
+    const highTurn = summaries.filter((s) => s.geek_usermsgcount >= 8);
+    if (highTurn.length > 0) {
+      items.push({ level: "warn", text: `${highTurn.length}件が8ターン超（回答精度・ナレッジ不足の可能性）` });
+    }
+
+    return items;
+  }, [summaries]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">改善提案</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {suggestions.map((s, i) => (
+          <div key={i} className={`flex items-start gap-2 text-sm p-2 rounded ${s.level === "warn" ? "bg-destructive/10 text-destructive" : "bg-muted"}`}>
+            <span>{s.level === "warn" ? "⚠" : "💡"}</span>
+            <span>{s.text}</span>
+          </div>
+        ))}
+        {suggestions.length === 0 && <p className="text-sm text-muted-foreground">現在の指標に問題はありません</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── 最近の会話一覧 ──
+function RecentConversations({ summaries, onSelect }: { summaries: ConversationSummary[]; onSelect: (s: ConversationSummary) => void }) {
+  const recent = summaries.slice(0, 20);
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">最近の会話（直近20件）</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-muted-foreground">
+                <th className="py-2 pr-3">日時</th>
+                <th className="py-2 pr-3">エージェント</th>
+                <th className="py-2 pr-3">結果</th>
+                <th className="py-2 pr-3 text-right">時間</th>
+                <th className="py-2">ユーザー発話</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recent.map((s) => (
+                <tr
+                  key={s.geek_conversationsummaryid}
+                  className="border-b last:border-0 cursor-pointer hover:bg-muted/50 transition-colors"
+                  onClick={() => onSelect(s)}
+                >
+                  <td className="py-2 pr-3 whitespace-nowrap text-muted-foreground">
+                    {s.geek_starttime?.slice(0, 16).replace("T", " ")}
+                  </td>
+                  <td className="py-2 pr-3 max-w-[150px] truncate" title={s.geek_botname}>{s.geek_botname}</td>
+                  <td className="py-2 pr-3">
+                    <Badge
+                      variant={s.geek_outcome === 100000000 ? "default" : s.geek_outcome === 100000001 ? "destructive" : "secondary"}
+                      className="text-xs"
+                    >
+                      {OUTCOME_LABELS[s.geek_outcome] ?? s.geek_outcome}
+                    </Badge>
+                  </td>
+                  <td className="py-2 pr-3 text-right whitespace-nowrap">{s.geek_durationsec?.toFixed(0)}秒</td>
+                  <td className="py-2 max-w-[300px] truncate text-muted-foreground" title={s.geek_firstusertext}>
+                    {s.geek_firstusertext?.slice(0, 80)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── メインダッシュボード ──
+export default function CopilotDashboard() {
+  const { data: summaries, isLoading } = useConversationSummaries();
+  const { data: bots } = useBots();
+  const [selected, setSelected] = useState<ConversationSummary | null>(null);
+  const refresh = useRefreshSummaries();
+
+  const handleSync = () => {
+    refresh.mutate(undefined, {
+      onSuccess: (res) => {
+        toast.success(res.message || "同期を開始しました", {
+          description: "処理完了まで数分かかる場合があります。自動でデータが更新されます。",
+        });
+      },
+      onError: () => {
+        toast.error("同期の開始に失敗しました", {
+          description: "Power Automate フロー「サマリー同期」がデプロイ済みか確認してください。",
+        });
+      },
+    });
+  };
+
+  if (isLoading || !summaries) return <LoadingSkeletonCard count={4} />;
+
+  const totalConvos = summaries.length;
+  const resolved = summaries.filter((s) => s.geek_outcome === 100000000).length;
+  const abandoned = summaries.filter((s) => s.geek_outcome === 100000001).length;
+  const escalated = summaries.filter((s) => s.geek_outcome === 100000002).length;
+  const resolveRate = totalConvos > 0 ? ((resolved / totalConvos) * 100).toFixed(0) : "0";
+  const abandonRate = totalConvos > 0 ? ((abandoned / totalConvos) * 100).toFixed(0) : "0";
+  const escalateRate = totalConvos > 0 ? ((escalated / totalConvos) * 100).toFixed(0) : "0";
+  const avgDur = totalConvos > 0 ? (summaries.reduce((a, s) => a + (s.geek_durationsec ?? 0), 0) / totalConvos).toFixed(1) : "0";
+  const avgTurns = totalConvos > 0 ? (summaries.reduce((a, s) => a + (s.geek_usermsgcount ?? 0), 0) / totalConvos).toFixed(1) : "0";
+  const toolConvos = summaries.filter((s) => (s.geek_tooleventcount ?? 0) > 0).length;
+  const toolRate = totalConvos > 0 ? ((toolConvos / totalConvos) * 100).toFixed(0) : "0";
+  const fcrCount = summaries.filter((s) => s.geek_outcome === 100000000 && s.geek_usermsgcount <= 2).length;
+  const fcrRate = resolved > 0 ? ((fcrCount / resolved) * 100).toFixed(0) : "0";
+  const totalBots = bots?.length ?? 0;
+  const activeBots = new Set(summaries.map((s) => s.geek_botid)).size;
+
+  // 週次比較
+  const weekAgo = useMemo(() => {
+    const now = new Date();
+    const thisWeekStart = new Date(now);
+    thisWeekStart.setDate(now.getDate() - 7);
+    const lastWeekStart = new Date(thisWeekStart);
+    lastWeekStart.setDate(thisWeekStart.getDate() - 7);
+
+    const thisWeek = summaries.filter((s) => new Date(s.geek_starttime) >= thisWeekStart);
+    const lastWeek = summaries.filter((s) => {
+      const d = new Date(s.geek_starttime);
+      return d >= lastWeekStart && d < thisWeekStart;
+    });
+
+    const twCount = thisWeek.length;
+    const lwCount = lastWeek.length;
+    const twResolved = thisWeek.filter((s) => s.geek_outcome === 100000000).length;
+    const lwResolved = lastWeek.filter((s) => s.geek_outcome === 100000000).length;
+    const twRate = twCount > 0 ? (twResolved / twCount) * 100 : 0;
+    const lwRate = lwCount > 0 ? (lwResolved / lwCount) * 100 : 0;
+
+    return {
+      convoDelta: twCount - lwCount,
+      rateDelta: twRate - lwRate,
+    };
+  }, [summaries]);
+
+  const outcomeCounts: Record<number, number> = {};
+  for (const s of summaries) {
+    outcomeCounts[s.geek_outcome] = (outcomeCounts[s.geek_outcome] ?? 0) + 1;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Copilot Studio AI CoE ダッシュボード</h1>
+          <p className="text-muted-foreground">エージェントの利用状況・パフォーマンス・改善ポイントを一元管理</p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleSync}
+          disabled={refresh.isPending}
+        >
+          {refresh.isPending
+            ? <><Loader2 className="size-4 animate-spin" /> 同期中…</>
+            : <><RefreshCw className="size-4" /> データ同期</>
+          }
+        </Button>
+      </div>
+
+      {/* KPI カード — 1段目 */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <KpiCard title="総会話数" value={totalConvos} delta={{ value: weekAgo.convoDelta, label: "件 vs先週" }} />
+        <KpiCard title="解決率" value={`${resolveRate}%`} color={Number(resolveRate) >= 80 ? "hsl(142,76%,36%)" : "hsl(0,84%,60%)"} delta={{ value: Math.round(weekAgo.rateDelta), label: "pt" }} />
+        <KpiCard title="放棄率" value={`${abandonRate}%`} color={Number(abandonRate) > 20 ? "hsl(0,84%,60%)" : undefined} sub={`${abandoned}件`} />
+        <KpiCard title="エスカレーション率" value={`${escalateRate}%`} color={Number(escalateRate) > 15 ? "hsl(38,92%,50%)" : undefined} sub={`${escalated}件`} />
+      </div>
+
+      {/* KPI カード — 2段目 */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <KpiCard title="平均ターン数" value={avgTurns} sub="ユーザー発話数" />
+        <KpiCard title="平均応答時間" value={`${avgDur}秒`} />
+        <KpiCard title="ツール利用率" value={`${toolRate}%`} sub={`${toolConvos}件がツール呼出`} />
+        <KpiCard title="FCR (初回解決)" value={`${fcrRate}%`} sub={`≤2ターンで解決: ${fcrCount}件`} color={Number(fcrRate) >= 50 ? "hsl(142,76%,36%)" : undefined} />
+      </div>
+
+      {/* エージェント概況 */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <KpiCard title="エージェント" value={`${activeBots} / ${totalBots}`} sub="利用中 / 総数" />
+      </div>
+
+      {/* 成果分布 */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm">セッション成果分布</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <OutcomeBar data={outcomeCounts} />
+          <div className="flex gap-4 mt-2 text-xs text-muted-foreground">
+            {Object.entries(outcomeCounts).map(([k, v]) => (
+              <span key={k} className="flex items-center gap-1">
+                <span className="w-2 h-2 rounded-full" style={{ backgroundColor: OUTCOME_COLORS[Number(k)] }} />
+                {OUTCOME_LABELS[Number(k)]}: {v}件
+              </span>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* メイングリッド */}
+      <div className="grid md:grid-cols-2 gap-4">
+        <AgentTable summaries={summaries} />
+        <div className="space-y-4">
+          <DailyTrend summaries={summaries} />
+          <ChannelDistribution summaries={summaries} />
+        </div>
+      </div>
+
+      {/* 時間帯ヒートマップ + ツールランキング */}
+      <div className="grid md:grid-cols-2 gap-4">
+        <HourlyHeatmap summaries={summaries} />
+        <ToolServerRanking summaries={summaries} />
+      </div>
+
+      {/* 改善提案 */}
+      <ImprovementSuggestions summaries={summaries} />
+
+      {/* 最近の会話 */}
+      <RecentConversations summaries={summaries} onSelect={setSelected} />
+
+      {/* 会話チャットビュー */}
+      <ConversationChatDialog
+        summary={selected}
+        open={!!selected}
+        onOpenChange={(o) => !o && setSelected(null)}
+      />
+    </div>
+  );
+}

--- a/src/services/copilot-analytics-service.ts
+++ b/src/services/copilot-analytics-service.ts
@@ -1,0 +1,78 @@
+import { getClient } from "@microsoft/power-apps/data";
+import { dataSourcesInfo } from "@/lib/dataSourcesInfo";
+import type { ConversationSummary, BotInfo } from "@/types/copilot-analytics";
+
+function client() {
+  return getClient(dataSourcesInfo);
+}
+
+export async function getConversationSummaries(): Promise<ConversationSummary[]> {
+  const result = await client().retrieveMultipleRecordsAsync<ConversationSummary>(
+    "geek_conversationsummaries",
+    {
+      select: [
+        "geek_conversationsummaryid",
+        "geek_name",
+        "geek_transcriptid",
+        "geek_botname",
+        "geek_botid",
+        "geek_starttime",
+        "geek_outcome",
+        "geek_channel",
+        "geek_usermsgcount",
+        "geek_botmsgcount",
+        "geek_tooleventcount",
+        "geek_durationsec",
+        "geek_toolservers",
+        "geek_firstusertext",
+        "createdon",
+      ],
+      orderBy: ["geek_starttime desc"],
+    },
+  );
+  if (!result.success) throw result.error;
+  return result.data ?? [];
+}
+
+export async function getBots(): Promise<BotInfo[]> {
+  const result = await client().retrieveMultipleRecordsAsync<BotInfo>(
+    "bots",
+    {
+      select: ["botid", "name", "schemaname", "statecode", "publishedon", "createdon", "modifiedon"],
+      orderBy: ["modifiedon desc"],
+    },
+  );
+  if (!result.success) throw result.error;
+  return result.data ?? [];
+}
+
+export async function triggerSummaryRefresh(): Promise<{ status: string; message: string }> {
+  const result = await client().executeAsync<
+    Record<string, never>,
+    { status?: string; message?: string }
+  >({
+    connectorOperation: {
+      tableName: "RefreshSummaries",
+      operationName: "Run",
+      parameters: {},
+    },
+  });
+  if (!result.success) throw result.error;
+  return {
+    status: result.data?.status ?? "unknown",
+    message: result.data?.message ?? "同期リクエストを送信しました",
+  };
+}
+
+export async function getTranscriptContent(transcriptId: string): Promise<string> {
+  const result = await client().retrieveMultipleRecordsAsync<{ content: string }>(
+    "conversationtranscripts",
+    {
+      select: ["content"],
+      filter: `conversationtranscriptid eq '${transcriptId}'`,
+      top: 1,
+    },
+  );
+  if (!result.success) throw result.error;
+  return result.data?.[0]?.content ?? "";
+}

--- a/src/types/copilot-analytics.ts
+++ b/src/types/copilot-analytics.ts
@@ -1,0 +1,94 @@
+/** Copilot Studio 会話サマリーの型定義 */
+
+export interface ConversationSummary {
+  geek_conversationsummaryid: string;
+  geek_name: string;
+  geek_transcriptid: string;
+  geek_botname: string;
+  geek_botid: string;
+  geek_starttime: string;
+  geek_outcome: number; // 100000000=Resolved, 100000001=Abandoned, 100000002=Escalated, 100000003=None
+  geek_channel: string;
+  geek_usermsgcount: number;
+  geek_botmsgcount: number;
+  geek_tooleventcount: number;
+  geek_durationsec: number;
+  geek_toolservers: string;
+  geek_firstusertext: string;
+  createdon: string;
+}
+
+export interface BotInfo {
+  botid: string;
+  name: string;
+  schemaname: string;
+  statecode: number;
+  publishedon: string | null;
+  createdon: string;
+  modifiedon: string;
+}
+
+export const OUTCOME_LABELS: Record<number, string> = {
+  100000000: "解決",
+  100000001: "放棄",
+  100000002: "エスカレーション",
+  100000003: "なし",
+};
+
+export const OUTCOME_COLORS: Record<number, string> = {
+  100000000: "hsl(142, 76%, 36%)",   // green
+  100000001: "hsl(0, 84%, 60%)",     // red
+  100000002: "hsl(38, 92%, 50%)",    // amber
+  100000003: "hsl(220, 14%, 60%)",   // gray
+};
+
+/** チャット表示用に正規化した1アクティビティ */
+export interface ChatActivity {
+  id: string;
+  kind: "message" | "event";
+  role: "user" | "bot" | "tool";
+  text: string;
+  timestamp: number | null;
+  toolName?: string;
+}
+
+/** transcript.content(JSON文字列)をチャット表示用の配列に変換 */
+export function parseTranscriptActivities(contentJson: string): ChatActivity[] {
+  let content: { activities?: unknown[] } = {};
+  try {
+    content = JSON.parse(contentJson || "{}");
+  } catch {
+    return [];
+  }
+  const acts = Array.isArray(content.activities) ? content.activities : [];
+  const out: ChatActivity[] = [];
+
+  acts.forEach((raw, i) => {
+    const a = raw as Record<string, unknown>;
+    const tms = typeof a.timestampMs === "number" ? a.timestampMs : null;
+    const type = a.type;
+
+    if (type === "message") {
+      const text = typeof a.text === "string" ? a.text : "";
+      if (!text.trim()) return;
+      const from = a.from as { role?: number } | undefined;
+      const role: ChatActivity["role"] = from?.role === 1 ? "user" : "bot";
+      out.push({ id: String(a.id ?? `m${i}`), kind: "message", role, text, timestamp: tms });
+    } else if (type === "event") {
+      const name = typeof a.name === "string" ? a.name : "event";
+      const val = (a.value as Record<string, unknown>) ?? {};
+      const init = val.initializationResult as { serverInfo?: { name?: string } } | undefined;
+      const srv = init?.serverInfo?.name;
+      out.push({
+        id: String(a.id ?? `e${i}`),
+        kind: "event",
+        role: "tool",
+        text: srv ? `${name} · ${srv}` : name,
+        timestamp: tms,
+        toolName: srv ?? name,
+      });
+    }
+  });
+
+  return out;
+}


### PR DESCRIPTION
## 変更内容

### auth_helper.py — 新規ヘルパー追加
- \powerapps_api_call()\ — PowerApps API 呼び出し（接続検索等）
- \esolve_environment_id()\ — DATAVERSE_URL から環境 ID を逆引き
- \ind_connection()\ — 環境内の Connected な接続 ID を検索（リトライ付き）

### deploy_flow_backfill.py — auth_helper ユーティリティに統一
- 直接 \equests.get\ + \get_token\ で Flow/PowerApps API を叩いていたコードを排除
- \low_api_call\, \esolve_environment_id\, \ind_connection\ を使用

### GeekPowerCode エージェント — 認証ルール明文化
- Python デプロイスクリプトでは **必ず auth_helper.py の公開 API を使う** ルールを追加
- 正しいパターン / 禁止パターンをコード例付きで記載

### Copilot ダッシュボード — データ同期 & KPI 拡張
- 「データ同期」ボタン追加（非同期 Power Automate フロー呼出）
- 会話チャット UI（トランスクリプトをバブル表示）
- KPI 追加: 放棄率、エスカレーション率、平均ターン数、ツール利用率、FCR
- 時間帯ヒートマップ、チャネル分布、改善提案強化

### データソース登録
- \ots\, \conversationtranscripts\, \RefreshSummaries\ を dataSourcesInfo に追加
