### PR TITLE
feat: template: true フラグでデモメニュー残骸のデプロイを自動ブロック

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -190,6 +190,18 @@ PUBLISHER_PREFIX={prefix}          ← ソリューション発行者の prefix
 テンプレートにはサンプルの営業管理ページ（顧客・商談・テリトリー等）が含まれるが、
 これらは **テーマ開発の参考実装** であり、そのままデプロイしてはならない。
 
+テンプレートのデモメニューには `template: true` フラグが付いている。
+このフラグが残ったまま `npm run predeploy` を実行するとエラーになるため、削除忘れを防げる。
+
+```typescript
+// テンプレートの config.ts（初期状態）— template: true 付き
+{ label: "顧客", path: "customers", iconKey: "customers", template: true },
+// ↑ template: true が付いた行はデプロイ前に削除 or テーマ用に書き換え
+
+// テーマ固有のメニュー（template フラグなし）
+{ label: "AI CoE ダッシュボード", path: "copilot-dashboard", iconKey: "copilot" },
+```
+
 ```
 テンプレート構成:
   src/config.ts         → デフォルトはダッシュボード1画面のみ。テーマに合わせて変更する

--- a/.github/skills/code-apps/references/pre-deploy-review.md
+++ b/.github/skills/code-apps/references/pre-deploy-review.md
@@ -202,10 +202,15 @@ Select-String -Path "src/pages/_layout.tsx" -Pattern 'ml-64|ml-16'
   │     → Sidebar が fixed + 固定幅（w-64）であることを確認
   │     → メインコンテンツに md:ml-64 のオフセットがあることを確認
   │
-  ├─ ⑦ npm run build
+  ├─ ⑦ ナビ ↔ ルーター整合性チェック（自動: npm run predeploy）
+  │     → config.ts に template: true が残っていないか → エラー
+  │     → config.ts のナビにルーターが無いパスが無いか → エラー
+  │     → ルーターにナビが無いパスが無いか → 警告
+  │
+  ├─ ⑧ npm run build
   │     → TypeScript エラーがあれば修正
   │
-  └─ ⑧ npx power-apps push / pac code push
+  └─ ⑨ npx power-apps push / pac code push
         → デプロイ完了
 ```
 

--- a/scripts/pre-deploy-check.mjs
+++ b/scripts/pre-deploy-check.mjs
@@ -52,6 +52,45 @@ if (fs.existsSync(configTs)) {
   }
 }
 
+// 4. ナビ ↔ ルーター整合性チェック（テンプレート残骸防止）
+const routerPath = path.join(root, "src", "router.tsx");
+if (fs.existsSync(configTs) && fs.existsSync(routerPath)) {
+  const configContent = fs.readFileSync(configTs, "utf-8");
+  const routerContent = fs.readFileSync(routerPath, "utf-8");
+
+  // 4a. template: true が残っていないか
+  const templateMatches = configContent.match(/template:\s*true/g);
+  if (templateMatches) {
+    errors.push(
+      `config.ts に template: true のデモメニューが ${templateMatches.length} 件残っています。\n` +
+      `     → テーマに無関係なナビは削除するか、template フラグを外してください。`
+    );
+  }
+
+  // 4b. config.ts からナビパスを抽出: path: "xxx"
+  const navPaths = [...configContent.matchAll(/path:\s*["']([^"']+)["']/g)].map(m => m[1]);
+
+  // router.tsx からルートパスを抽出: path: "xxx"（コメント行を除外）
+  const routerLines = routerContent.split("\n").filter(l => !l.trim().startsWith("//"));
+  const routePaths = [...routerLines.join("\n").matchAll(/path:\s*["']([^"']+)["']/g)].map(m => m[1]);
+
+  // ナビにあるがルーターに無いパス → 孤立メニュー
+  const orphanedNav = navPaths.filter(p => !routePaths.includes(p));
+  if (orphanedNav.length > 0) {
+    errors.push(
+      `ナビゲーション (config.ts) にルートが存在しないパスがあります: ${orphanedNav.join(", ")}\n` +
+      `     → router.tsx にルートを追加するか、config.ts からナビを削除してください。`
+    );
+  }
+
+  // ルーターにあるがナビに無いパス → 隠しページ（warning のみ）
+  const hiddenRoutes = routePaths.filter(p => !navPaths.includes(p) && p !== "*" && p !== "/");
+  if (hiddenRoutes.length > 0) {
+    console.warn(`⚠ ルーター (router.tsx) にナビから到達できないページがあります: ${hiddenRoutes.join(", ")}`);
+    console.warn(`  → 意図的な隠しページでなければ config.ts にナビを追加してください。`);
+  }
+}
+
 // 結果出力
 if (errors.length > 0) {
   console.error("\n❌ デプロイ前チェック失敗:\n");

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,8 @@ export type CodeAppsNavItemConfig = {
   label: string
   path: string
   iconKey?: string
+  /** テンプレートのデモ用メニュー。true のままデプロイすると pre-deploy チェックが失敗する */
+  template?: boolean
 }
 
 export type CodeAppsNavSectionConfig = {
@@ -13,25 +15,25 @@ const defaultNavSections: CodeAppsNavSectionConfig[] = [
   {
     category: "概況",
     items: [
-      { label: "ダッシュボード", path: "dashboard", iconKey: "dashboard" },
-      { label: "テリトリー", path: "territory", iconKey: "territory" },
+      { label: "ダッシュボード", path: "dashboard", iconKey: "dashboard", template: true },
+      { label: "テリトリー", path: "territory", iconKey: "territory", template: true },
     ],
   },
   {
     category: "顧客・商談",
     items: [
-      { label: "顧客", path: "customers", iconKey: "customers" },
-      { label: "商談", path: "opportunities", iconKey: "opportunities" },
-      { label: "パイプライン", path: "pipeline", iconKey: "pipeline" },
+      { label: "顧客", path: "customers", iconKey: "customers", template: true },
+      { label: "商談", path: "opportunities", iconKey: "opportunities", template: true },
+      { label: "パイプライン", path: "pipeline", iconKey: "pipeline", template: true },
     ],
   },
   {
     category: "活動",
-    items: [{ label: "活動履歴", path: "activities", iconKey: "activities" }],
+    items: [{ label: "活動履歴", path: "activities", iconKey: "activities", template: true }],
   },
   {
     category: "インシデント",
-    items: [{ label: "インシデント", path: "incidents", iconKey: "incidents" }],
+    items: [{ label: "インシデント", path: "incidents", iconKey: "incidents", template: true }],
   },
 ]
 


### PR DESCRIPTION
## 概要
テンプレートのデモメニュー（顧客・商談・テリトリー等）にtemplate: trueフラグを付与し、テーマ開発時に削除し忘れたままデプロイすることを自動ブロックする仕組みを追加。

## 課題
テンプレートからテーマ開発を始めた際、CRMデモ用のナビゲーションメニューが残ったままデプロイされることがあった。
手動でのクリーンアップに依存しており、見落としが発生しやすい。

## 変更内容

### 1. template フラグ（src/config.ts）
- CodeAppsNavItemConfig型にtemplate?: booleanを追加
- テンプレートのデモメニュー全7項目にtemplate: trueを付与

### 2. pre-deployチェック（scripts/pre-deploy-check.mjs）
- チェック4a: template: trueが残っていればデプロイをブロック（エラー）
- チェック4b: ナビ↔ルーター整合性チェック（孤立メニュー→エラー、隠しページ→警告）
- コメント行のルートパスを誤検出しないよう除外処理追加

### 3. スキルドキュメント更新
- SKILL.md: テンプレートフラグの説明と使い方を追加
- pre-deploy-review.md: チェック⑦（ナビ↔ルーター整合性）を追加

## 動作確認

```n# テンプレートのまま（template: true 残存）→ ブロック
$ node scripts/pre-deploy-check.mjs
❌ デプロイ前チェック失敗:
  • config.ts に template: true のデモメニューが 7 件残っています。

# テーマ用にメニューを書き換え後 → 通過
$ node scripts/pre-deploy-check.mjs
✅ デプロイ前チェック OK
``` 