### PR TITLE
docs: システムテーブル SDK登録ルール + React フック規則を追記

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -228,12 +228,18 @@ PUBLISHER_PREFIX={prefix}          ← ソリューション発行者の prefix
 
 ❌ src/lib/dataSourcesInfo.ts にカスタムテーブル定義を手動追記
    → SDK 自動生成と重複し、将来の add-data-source 実行時に不整合が起きる
+   → 手動追記だけでは Power Apps プラットフォームがテーブルへのアクセスを許可しない
 
 ✅ pac code add-data-source -a dataverse -t {table} で各テーブルを追加
    → .power/schemas/appschemas/dataSourcesInfo.ts が自動更新される
    → その後 npm run build が成功する
    → 日本語表示名エラー時は toggle_table_lang.py で英語に切り替えてから実行
+   → システムテーブル（bot, botcomponent, conversationtranscript 等）も登録可能
 ```
+
+> **注意**: `systemuser` テーブルは `pac code add-data-source` で追加できない場合がある。
+> その場合のみ `src/lib/dataSourcesInfo.ts` に手動追記する。
+> それ以外のテーブルは必ず SDK コマンドで追加すること。
 
 ### 標準ワークフロー（この順序で進める）
 

--- a/.github/skills/code-apps/references/pre-deploy-review.md
+++ b/.github/skills/code-apps/references/pre-deploy-review.md
@@ -149,6 +149,28 @@ import { createHashRouter, Navigate } from "react-router-dom";
 export const router = createHashRouter([...]);
 ```
 
+### 5a. React フック規則チェック
+
+React のフック規則違反（条件付きフック呼び出し）は本番でのみクラッシュすることがある（React error #310）。
+**早期 return の前にすべてのフック（useState, useMemo, useQuery 等）を配置すること。**
+
+```typescript
+// ❌ 早期 return の後に useMemo → ロード完了時にフック数が変わりクラッシュ
+export default function Page() {
+  const { data, isLoading } = useQuery(...);
+  if (isLoading) return <Loading />;
+  const computed = useMemo(() => ..., [data]); // ← ここでクラッシュ
+}
+
+// ✅ すべてのフックを早期 return の前に配置
+export default function Page() {
+  const { data, isLoading } = useQuery(...);
+  const computed = useMemo(() => data ? ... : fallback, [data]);
+  if (isLoading) return <Loading />;
+  // computed を安全に使用
+}
+```
+
 ### 6. サイドバー fixed レイアウトチェック
 
 サイドバーが flex レイアウト内に固定幅なしで配置されていると、ページ遷移時に幅が崩れる。


### PR DESCRIPTION
## 概要
開発中に判明した2つの教訓をスキルドキュメントに追記。

## 変更内容

### 1. システムテーブルも pac code add-data-source で登録可能（SKILL.md）
- bot, botcomponent, conversationtranscript 等のシステムテーブルも SDK コマンドで登録できることを明記
- 手動で dataSourcesInfo.ts に追記するだけでは Power Apps プラットフォームがテーブルへのアクセスを許可しない
- systemuser のみ pac code add-data-source で追加できない場合があり、手動追記の例外として注記

### 2. React フック規則チェック追加（pre-deploy-review.md チェック5a）
- 早期 return の後に useMemo/useState 等を配置すると React error #310 が発生する
- 正しいパターン（全フックを早期 return の前に配置）と違反パターンをコード例付きで追加

## 背景
- bot テーブルを dataSourcesInfo.ts に手動追記したがデータが取得できず、pac code add-data-source で正式登録して解決
- copilot-dashboard.tsx で useMemo が早期 return の後にあり、ロード完了時にクラッシュ（開発時は再現せず本番のみ発生）