### PR TITLE
refactor: root scripts フォルダをスキル配下に統合

### DIFF
--- a/.github/skills/code-apps/scripts/pre-deploy-check.mjs
+++ b/.github/skills/code-apps/scripts/pre-deploy-check.mjs
@@ -4,15 +4,15 @@
  * pac code push / npx power-apps push の前に実行し、
  * テーマ固有のカスタマイズが行われていることを確認する。
  *
- * Usage: node scripts/pre-deploy-check.mjs
- * npm script: "predeploy": "node scripts/pre-deploy-check.mjs"
+ * Usage: node .github/skills/code-apps/scripts/pre-deploy-check.mjs
+ * npm script: "predeploy": "node .github/skills/code-apps/scripts/pre-deploy-check.mjs"
  */
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
-const root = path.resolve(path.dirname(__filename), "..");
+const root = path.resolve(path.dirname(__filename), "../../../..");
 
 const errors = [];
 

--- a/.github/skills/standard/scripts/bootstrap.mjs
+++ b/.github/skills/standard/scripts/bootstrap.mjs
@@ -5,7 +5,7 @@ import { spawnSync } from "node:child_process";
 
 // ── 定数 ──────────────────────────────────────────────
 const __filename = fileURLToPath(import.meta.url);
-const repoRoot = path.resolve(path.dirname(__filename), "..");
+const repoRoot = path.resolve(path.dirname(__filename), "../../../..");
 const projectName = path.basename(repoRoot);
 const isWindows = process.platform === "win32";
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npm run setup
 > 最初からチーム用の private リポジトリを作りたい場合は、`gh repo create <your-account>/<your-theme-repo> --template geekfujiwara/CodeAppsStarter --private --clone` でテンプレートから生成して `cd` 後に `npm install && npm run setup` を実行します。
 
 `npm run setup` が本リポジトリ（CodeAppsDevelopmentStandard）から `.github/`（エージェント・スキル。
-認証ヘルパー・日本語パッチ・地図 SVG 等のスキル所有アセットを含む）と `scripts/`（共通ツール）・`.env.example` を同期します。
+認証ヘルパー・日本語パッチ・地図 SVG 等のスキル所有アセットを含む）と `.env.example` を同期します。
 
 これで **@GeekPowerCode** のエージェントをローカルで実行でき、スムーズに新規テーマ開発を始めることができます。
 
@@ -215,7 +215,6 @@ npm run setup
 │       └── */samples/                                   # リファレンス実装（同期対象外）
 ├── .claude/
 │   └── agents/                      # Claude Code カスタムエージェント定義
-├── scripts/                         # bootstrap.mjs / pre-deploy-check.mjs（プロジェクト共通ツール）
 ├── .env.example                     # 環境変数テンプレート
 ├── .gitignore
 ├── package.json
@@ -223,9 +222,9 @@ npm run setup
 └── README.md
 ```
 
-> **root には慣習的なリポ直下ファイル（README / .env.example / .gitignore / package.json / LICENSE）と
-> プロジェクト共通ツール（`scripts/`）だけを置く。** 認証ヘルパー・日本語パッチ・地図 SVG など
-> 「特定スキルが所有するアセット」はそのスキル配下に置き、`.github/` 同期でテーマに配布する。
+> **root には慣習的なリポ直下ファイル（README / .env.example / .gitignore / package.json / LICENSE）だけを置く。**
+> 認証ヘルパー・日本語パッチ・地図 SVG など「特定スキルが所有するアセット」はそのスキル配下に置き、`.github/` 同期でテーマに配布する。
+> 環境セットアップ（bootstrap.mjs）は `standard/scripts/`、デプロイ前チェック（pre-deploy-check.mjs）は `code-apps/scripts/` に配置。
 > アプリの実装（`src/` / `vite.config.ts` 等）は本リポジトリには置かない（雛形は
 > [CodeAppsStarter](https://github.com/geekfujiwara/CodeAppsStarter)、リファレンス実装は各スキルの `samples/`）。
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Power Platform コードファースト開発標準（スキル・エージェント・リファレンス）",
   "type": "module",
   "scripts": {
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "check:env": "node .github/skills/standard/scripts/bootstrap.mjs --check",
+    "setup": "node .github/skills/standard/scripts/bootstrap.mjs --setup"
   }
 }


### PR DESCRIPTION
- scripts/bootstrap.mjs → .github/skills/standard/scripts/bootstrap.mjs
- scripts/pre-deploy-check.mjs → .github/skills/code-apps/scripts/pre-deploy-check.mjs
- package.json の npm script パスを更新
- README.md のディレクトリツリー・説明文を更新

scripts/ フォルダを廃止し、各スクリプトを役割に対応するスキルに同梱。
bootstrap は「全スキル共通の基盤」である standard に、
pre-deploy-check は Code Apps 固有チェックを行う code-apps に配置。

https://claude.ai/code/session_01UWujzzoRtA3hp9VHuPgFPh