### PR TITLE
feat(spec-to-markdown): 開発利用ドキュメントを強化 — テスト要件・インデックス・MoSCoW・タスク分解を追加

### DIFF
--- a/.github/skills/spec-to-markdown/SKILL.md
+++ b/.github/skills/spec-to-markdown/SKILL.md
@@ -28,7 +28,12 @@ spec/                          ← スキル専用ディレクトリ
 ├── input/                     # ここに変換したいファイルを置く（ユーザーが操作）
 ├── output/                    # 全出力はここに入る（ユーザーが参照）
 │   ├── staging/               # ファイル単位の中間 markdown
-│   └── docs/                  # 統合要件定義書 3 点
+│   └── docs/                  # 統合要件定義書 5 点
+│       ├── index.md           # ドキュメント一覧・開発利用フロー
+│       ├── business-requirements.md
+│       ├── functional-requirements.md
+│       ├── design-requirements.md
+│       └── test-requirements.md
 └── .cache/                    # システム内部用（ユーザーは触らない）
     ├── conversion-checklist.json
     ├── pending_ocr.json
@@ -61,9 +66,11 @@ spec/                          ← スキル専用ディレクトリ
                                                  (Claude が統合)
                                                           │
                                               [spec/output/docs/]
+                                         ├── index.md
                                          ├── business-requirements.md
                                          ├── functional-requirements.md
-                                         └── design-requirements.md
+                                         ├── design-requirements.md
+                                         └── test-requirements.md
 ```
 
 ## 基本フロー
@@ -73,14 +80,30 @@ spec/                          ← スキル専用ディレクトリ
    - ファイル名は `元のファイル名.元の拡張子.MD`（例: `要件定義.docx.MD`）
 3. 画像ファイルは `spec/.cache/pending_ocr.json` に記録し、agent-ocr で後続処理する
 4. 画像以外の文書は `spec/.cache/pending_skills.json` に記録し、anthropics/skills で後続処理する
-5. `spec/output/docs/` に以下 3 つを作成する
+5. `spec/output/docs/` に以下 5 つを作成する
+   - `index.md`（ドキュメント一覧・開発利用フロー）
    - `business-requirements.md`
    - `functional-requirements.md`
    - `design-requirements.md`
+   - `test-requirements.md`
 6. `spec/.cache/conversion-checklist.json` を更新する
    - 新規ファイルはチェックリストへ追加
    - `is_completed=false` または更新差分ありのファイルのみ再処理
    - 全件完了時は既存 `spec/output/docs/` を参照して開発を継続
+
+## staging → docs 統合フロー
+
+staging の変換完了後、以下の手順で docs を更新する。
+
+1. `spec/.cache/conversion-checklist.json` を読み、`is_completed=false` のファイルがないか確認する
+2. `is_completed=false` が残っていれば、対象の staging ファイルを読んで内容を補完する
+3. 全 staging ファイルを横断し、各 docs の `要確認` を実際の要件に書き換える：
+   - `business-requirements.md` → ステークホルダー・ユーザーストーリー・業務フロー
+   - `functional-requirements.md` → 機能一覧(MoSCoW)・データモデル・非機能要件
+   - `design-requirements.md` → 全体構成・コンポーネント・リスク・実装タスク分解
+   - `test-requirements.md` → テストシナリオ・受け入れ条件（functional の機能一覧 # と対応）
+4. `index.md` の処理状況テーブルも合わせて更新する
+5. 推測で埋めず、情報不足は `要確認` として残す
 
 ## agent-ocr 更新方針
 
@@ -98,34 +121,51 @@ spec/                          ← スキル専用ディレクトリ
 画像以外の文書は `pending_skills.json` を使って処理する。
 
 - `source_path` の元ファイルを anthropics/skills で読み取り
+- `context_hint` を参照してどの観点で内容を抽出するかを確認する
 - 抽出 markdown を `staging_markdown_path` に反映
-- 処理済み後、`docs` の 3 文書を更新
+- 処理済み後、`docs` の 5 文書を更新
 
 補足: anthropics/skills（Claude）は画像読解も可能だが、このスキルでは OCR の責務を agent-ocr に固定する。
 
 ## `spec/output/docs/` で整理する観点
 
+### index.md
+- ドキュメント一覧（各 docs へのリンクと役割）
+- 処理状況テーブル
+- 開発利用フロー（番号付き手順）
+
 ### business-requirements.md
-- 対象業務 / 目的
-- 利用者 / ロール
+- 概要（対象業務・プロジェクト背景・スコープ）
+- ステークホルダー / ロール（ロール・担当業務・関心事の表）
+- ユーザーストーリー（As a…I want…so that…形式）
 - 業務フロー
-- 未確定事項 / 要確認事項
+- 未確定事項 / 要確認事項（項目・確認先・期限・ステータスの表）
 - 要件変更履歴（変更理由を必ず併記）
 
 ### functional-requirements.md
-- Dataverse テーブル候補
-- 主要列 / マスタ / リレーション候補
+- 機能一覧（MoSCoW 優先度・受け入れ条件の表）
+- Dataverse テーブル候補（テーブル名・主な列・リレーション）
 - Code Apps / Model-Driven Apps の UI 要件
 - Power Automate の自動化要件
 - Copilot Studio / AI Builder の利用余地
 - 外部連携
+- 非機能要件（パフォーマンス・セキュリティ・可用性・スケーラビリティ）
 - 要件変更履歴（変更理由を必ず併記）
 
 ### design-requirements.md
 - Power Platform 全体構成案
-- セキュリティ / 権限 / 監査の論点
-- 設計上のリスク
+- コンポーネント設計（種別・役割・依存の表）
+- セキュリティ / 権限 / 監査（区分・内容・対応方針の表）
+- 設計上のリスク（リスク・影響度・発生確率・対応方針の表）
 - Phase 0 で確認が必要な論点
+- 実装タスク分解（タスク・依存・優先度・見積の表）
+- 要件変更履歴（変更理由を必ず併記）
+
+### test-requirements.md
+- テスト戦略（テスト方針・環境・自動化範囲）
+- テストシナリオ（シナリオ名・前提条件・操作手順・期待結果・優先度の表）
+- 受け入れ条件（functional-requirements の機能 # と対応させた表）
+- 非機能テスト（区分・テスト内容・合格基準の表）
 - 要件変更履歴（変更理由を必ず併記）
 
 ## 実行例

--- a/.github/skills/spec-to-markdown/references/conversion-guide.md
+++ b/.github/skills/spec-to-markdown/references/conversion-guide.md
@@ -9,7 +9,12 @@ spec/
 ├── input/                     # 変換元ドキュメントを置く
 ├── output/
 │   ├── staging/               # ファイル単位 markdown
-│   └── docs/                  # 業務要件 / 機能要件 / 設計要件
+│   └── docs/                  # 業務要件 / 機能要件 / 設計要件 / テスト要件 + インデックス
+│       ├── index.md
+│       ├── business-requirements.md
+│       ├── functional-requirements.md
+│       ├── design-requirements.md
+│       └── test-requirements.md
 └── .cache/                    # システム内部用
     ├── conversion-checklist.json
     ├── pending_ocr.json
@@ -92,30 +97,44 @@ python convert_documents.py \
 - `staging_markdown_path`
 - `sha256`
 - `processor` (`anthropics/skills`)
+- `context_hint`（抽出時の観点ヒント — どの要件観点で読み取るかを明示）
 
 ## 6. docs の構成
 
+### index.md
+- ドキュメント一覧（各 docs へのリンク・役割・主な利用者）
+- 処理状況テーブル
+- 開発利用フロー（番号付き手順）
+
 ### business-requirements.md
-- 対象業務 / 目的
-- 利用者 / ロール
+- 概要（対象業務・プロジェクト背景・スコープ）
+- ステークホルダー / ロール（表）
+- ユーザーストーリー（As a…I want…so that…形式）
 - 業務フロー
-- 未確定事項 / 要確認事項
+- 未確定事項 / 要確認事項（表）
 - 要件変更履歴（理由を併記）
 
 ### functional-requirements.md
-- Dataverse テーブル候補
-- 主要列 / マスタ / リレーション候補
-- Code Apps / Model-Driven Apps の UI 要件
-- Power Automate の自動化要件
-- Copilot Studio / AI Builder の利用余地
-- 外部連携
+- 機能一覧（MoSCoW 優先度・受け入れ条件の表）
+- Dataverse テーブル候補（表）
+- UI 要件 / 自動化要件 / AI 連携要件
+- 非機能要件（パフォーマンス・セキュリティ・可用性・スケーラビリティの表）
 - 要件変更履歴（理由を併記）
 
 ### design-requirements.md
 - Power Platform 全体構成案
-- セキュリティ / 権限 / 監査の論点
-- 設計上のリスク
-- Phase 0 で確認が必要な論点
+- コンポーネント設計（表）
+- セキュリティ / 権限 / 監査（表）
+- 設計上のリスク（影響度・発生確率・対応方針の表）
+- Phase 0 確認事項
+- 実装タスク分解（タスク・依存・優先度・見積の表）
+- 要件変更履歴（理由を併記）
+
+### test-requirements.md
+- テスト戦略
+- テストシナリオ（前提条件・操作手順・期待結果・優先度の表）
+- 受け入れ条件（functional の機能 # と対応させた表）
+- 非機能テスト（合格基準の表）
 - 要件変更履歴（理由を併記）
 
 ## 7. conversion-checklist の運用
@@ -128,13 +147,24 @@ python convert_documents.py \
 ## 8. 処理ルール
 
 - 画像は必ず agent-ocr
-- 画像以外は anthropics/skills
+- 画像以外は anthropics/skills（`context_hint` を参照して抽出観点を確認）
 - 推測で埋めず、情報不足は `要確認`
 - OCR 抽出では表を markdown table 化し、判読不能箇所は `[判読不可]` とする
 
 補足: anthropics/skills（Claude）も画像読解は可能だが、この運用では OCR を agent-ocr に固定する。
 
-## 9. 備考
+## 9. staging → docs 統合後の開発フロー
+
+staging が全件完了したら、以下の流れで開発に入る。
+
+1. **要件合意**: `business-requirements.md` の未確定事項を PO / BA と確認し、`要確認` を解消する
+2. **優先度合意**: `functional-requirements.md` の MoSCoW 優先度を PO と合意する
+3. **設計確定**: `design-requirements.md` の実装タスク分解を確定させる
+4. **テスト設計**: `test-requirements.md` の受け入れ条件を `functional-requirements.md` の機能 # と紐付ける
+5. **開発着手**: `design-requirements.md` の実装タスク表を元にタスクを割り当てる
+6. **変更管理**: 仕様変更時は各 docs の「要件変更履歴」に変更内容と理由を記録する
+
+## 10. 備考
 
 `convert_documents.py` は `spec/output/staging/`・`spec/output/docs/` の土台作成と  
 `spec/.cache/` への pending manifest 生成を担当する。  

--- a/.github/skills/spec-to-markdown/scripts/convert_documents.py
+++ b/.github/skills/spec-to-markdown/scripts/convert_documents.py
@@ -41,6 +41,11 @@ OCR_PROMPT_HINT = (
     "画像内テキストを漏れなく markdown 化し、表は markdown table を使う。"
     " 判読不能箇所は [判読不可] と明記する。"
 )
+SKILLS_CONTEXT_HINT = (
+    "ドキュメント全体を markdown 化する。表は markdown table、見出しは # を使う。"
+    " 業務要件・機能要件・設計要件として整理できる情報を漏れなく抽出する。"
+    " 判読不能箇所は [判読不可] と明記する。"
+)
 
 
 @dataclass
@@ -240,49 +245,286 @@ agent-ocr での抽出待ちです。
 
 
 
-def build_requirements_doc(
-    title: str,
-    batch_started_at: str,
-    results: list[ConversionResult],
-    focus_items: list[str],
-) -> str:
-    lines = [
-        f"# {title}",
-        "",
-        "## 1. 変換対象ファイル",
-        "",
-        f"- Batch converted at: `{batch_started_at}`",
-        f"- Files: {len(results)}",
-        "",
-        "| Source | Staging markdown | Status | Note |",
-        "| --- | --- | --- | --- |",
-    ]
-
+def _build_file_table_rows(results: list[ConversionResult]) -> str:
+    rows = []
     for item in results:
         note = item.message.replace("\n", " ")
-        lines.append(
+        rows.append(
             f"| `{item.relative_path.as_posix()}` | `{item.staging_path.name}` | `{item.status}` | {note} |"
         )
+    return "\n".join(rows)
 
-    lines.extend([
-        "",
-        "## 2. 要件整理",
-        "",
-    ])
-    for focus in focus_items:
-        lines.extend([f"### {focus}", "- 要確認", ""])
 
-    lines.extend([
-        "## 3. 備考",
-        "- `spec/output/staging/` の markdown を根拠に整理すること",
-        "- 情報不足は推測せず `要確認` として残すこと",
-        "",
-        "## 4. 要件変更履歴",
-        "- 記載ルール: 変更内容と理由を必ず併記する（例: `2026-06-04: xxx を変更（理由: xxx）`）",
-        "",
-    ])
-    return "\n".join(lines)
+def _file_table_header(batch_started_at: str, results: list[ConversionResult]) -> str:
+    return (
+        f"- Batch converted at: `{batch_started_at}`\n"
+        f"- Files: {len(results)}\n"
+        "\n"
+        "| Source | Staging markdown | Status | Note |\n"
+        "| --- | --- | --- | --- |\n"
+        f"{_build_file_table_rows(results)}"
+    )
 
+
+def build_business_requirements_doc(batch_started_at: str, results: list[ConversionResult]) -> str:
+    date_prefix = batch_started_at[:10]
+    return f"""# 業務要件
+
+## 1. 変換対象ファイル
+
+{_file_table_header(batch_started_at, results)}
+
+## 2. 概要
+
+- **対象業務 / 目的**: 要確認
+- **プロジェクト背景**: 要確認
+- **スコープ**: 要確認
+
+## 3. ステークホルダー / ロール
+
+| ロール | 担当業務 | 主な関心事 |
+| --- | --- | --- |
+| 要確認 | 要確認 | 要確認 |
+
+## 4. ユーザーストーリー
+
+<!-- staging の内容を根拠に As a [ロール], I want [機能], so that [価値]. 形式で記載 -->
+
+- As a 要確認, I want 要確認, so that 要確認.
+
+## 5. 業務フロー
+
+<!-- staging の業務フロー図・手順を転記・整理する -->
+
+要確認
+
+## 6. 未確定事項 / 要確認事項
+
+| # | 項目 | 確認先 | 期限 | ステータス |
+| --- | --- | --- | --- | --- |
+| 1 | 要確認 | 要確認 | 要確認 | open |
+
+## 7. 備考
+
+- `spec/output/staging/` の markdown を根拠に整理すること
+- 情報不足は推測せず `要確認` として残すこと
+
+## 8. 要件変更履歴
+
+- 記載ルール: 変更内容と理由を必ず併記する（例: `{date_prefix}: xxx を変更（理由: xxx）`）
+"""
+
+
+def build_functional_requirements_doc(batch_started_at: str, results: list[ConversionResult]) -> str:
+    date_prefix = batch_started_at[:10]
+    return f"""# 機能要件
+
+## 1. 変換対象ファイル
+
+{_file_table_header(batch_started_at, results)}
+
+## 2. 機能一覧
+
+<!-- Must / Should / Could / Won't で優先度を記載 (MoSCoW) -->
+
+| # | 機能名 | 優先度 (MoSCoW) | 概要 | 受け入れ条件 |
+| --- | --- | --- | --- | --- |
+| 1 | 要確認 | Must | 要確認 | 要確認 |
+
+## 3. データモデル候補
+
+### Dataverse テーブル候補
+
+| テーブル名 | 主な列 | マスタ / リレーション | 備考 |
+| --- | --- | --- | --- |
+| 要確認 | 要確認 | 要確認 | 要確認 |
+
+## 4. UI 要件
+
+### Code Apps / Model-Driven Apps
+
+- 要確認
+
+## 5. 自動化要件
+
+### Power Automate フロー候補
+
+- 要確認
+
+## 6. AI / 連携要件
+
+### Copilot Studio / AI Builder
+
+- 要確認
+
+### 外部連携
+
+- 要確認
+
+## 7. 非機能要件
+
+| 区分 | 内容 | 指標 |
+| --- | --- | --- |
+| パフォーマンス | 要確認 | 要確認 |
+| セキュリティ | 要確認 | 要確認 |
+| 可用性 | 要確認 | 要確認 |
+| スケーラビリティ | 要確認 | 要確認 |
+
+## 8. 備考
+
+- `spec/output/staging/` の markdown を根拠に整理すること
+- 情報不足は推測せず `要確認` として残すこと
+
+## 9. 要件変更履歴
+
+- 記載ルール: 変更内容と理由を必ず併記する（例: `{date_prefix}: xxx を変更（理由: xxx）`）
+"""
+
+
+def build_design_requirements_doc(batch_started_at: str, results: list[ConversionResult]) -> str:
+    date_prefix = batch_started_at[:10]
+    return f"""# 設計要件
+
+## 1. 変換対象ファイル
+
+{_file_table_header(batch_started_at, results)}
+
+## 2. Power Platform 全体構成案
+
+<!-- アーキテクチャ図（mermaid / テキスト）や構成の説明を記載 -->
+
+要確認
+
+## 3. コンポーネント設計
+
+| コンポーネント | 種別 | 役割 | 依存 | 備考 |
+| --- | --- | --- | --- | --- |
+| 要確認 | 要確認 | 要確認 | 要確認 | 要確認 |
+
+## 4. セキュリティ / 権限 / 監査
+
+| 区分 | 内容 | 対応方針 |
+| --- | --- | --- |
+| 認証 / 認可 | 要確認 | 要確認 |
+| データアクセス制御 | 要確認 | 要確認 |
+| 監査ログ | 要確認 | 要確認 |
+
+## 5. 設計上のリスク
+
+| # | リスク | 影響度 | 発生確率 | 対応方針 |
+| --- | --- | --- | --- | --- |
+| 1 | 要確認 | 高/中/低 | 高/中/低 | 要確認 |
+
+## 6. Phase 0 確認事項
+
+- 要確認
+
+## 7. 実装タスク分解
+
+<!-- 開発着手前に確認・合意する粒度で記載 -->
+
+| # | タスク | 依存タスク | 優先度 | 見積 (h) | 担当 |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 要確認 | なし | 高 | 要確認 | 要確認 |
+
+## 8. 備考
+
+- `spec/output/staging/` の markdown を根拠に整理すること
+- 情報不足は推測せず `要確認` として残すこと
+
+## 9. 要件変更履歴
+
+- 記載ルール: 変更内容と理由を必ず併記する（例: `{date_prefix}: xxx を変更（理由: xxx）`）
+"""
+
+
+def build_test_requirements_doc(batch_started_at: str, results: list[ConversionResult]) -> str:
+    date_prefix = batch_started_at[:10]
+    return f"""# テスト要件
+
+## 1. 変換対象ファイル
+
+{_file_table_header(batch_started_at, results)}
+
+## 2. テスト戦略
+
+- **テスト方針**: 要確認
+- **テスト環境**: 要確認
+- **自動化範囲**: 要確認
+
+## 3. テストシナリオ
+
+<!-- functional-requirements.md の機能一覧と対応させて記載 -->
+
+| # | シナリオ名 | 前提条件 | 操作手順 | 期待結果 | 優先度 |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 要確認 | 要確認 | 要確認 | 要確認 | 高/中/低 |
+
+## 4. 受け入れ条件
+
+<!-- functional-requirements.md の機能一覧 #N に対応させて記載 -->
+
+| # | 機能名 | 受け入れ条件 | 確認方法 |
+| --- | --- | --- | --- |
+| 1 | 要確認 | 要確認 | 要確認 |
+
+## 5. 非機能テスト
+
+| 区分 | テスト内容 | 合格基準 |
+| --- | --- | --- |
+| パフォーマンス | 要確認 | 要確認 |
+| セキュリティ | 要確認 | 要確認 |
+| ユーザビリティ | 要確認 | 要確認 |
+| 可用性 | 要確認 | 要確認 |
+
+## 6. 備考
+
+- `spec/output/staging/` の markdown を根拠に整理すること
+- 情報不足は推測せず `要確認` として残すこと
+
+## 7. 要件変更履歴
+
+- 記載ルール: 変更内容と理由を必ず併記する（例: `{date_prefix}: xxx を変更（理由: xxx）`）
+"""
+
+
+def build_index_doc(batch_started_at: str, results: list[ConversionResult]) -> str:
+    completed = sum(1 for r in results if r.status == "already-completed")
+    pending = len(results) - completed
+    date_prefix = batch_started_at[:10]
+    return f"""# 要件定義書 インデックス
+
+- Batch converted at: `{batch_started_at}`
+- 変換ファイル数: {len(results)} ({completed} 完了 / {pending} 処理待ち)
+
+## ドキュメント一覧
+
+| ドキュメント | 説明 | 主な利用者 |
+| --- | --- | --- |
+| [業務要件](business-requirements.md) | 対象業務・ステークホルダー・ユーザーストーリー・業務フロー | PO / BA / 開発者 |
+| [機能要件](functional-requirements.md) | 機能一覧(MoSCoW)・データモデル・非機能要件 | 開発者 / アーキテクト |
+| [設計要件](design-requirements.md) | 全体構成・コンポーネント・リスク・実装タスク分解 | アーキテクト / 開発者 |
+| [テスト要件](test-requirements.md) | テストシナリオ・受け入れ条件・非機能テスト | QA / 開発者 |
+
+## 処理状況
+
+{_file_table_header(batch_started_at, results)}
+
+## 開発利用フロー
+
+1. `spec/output/staging/` の変換完了を確認する（`conversion-checklist.json` で `is_completed=true`）
+2. staging の内容を元に各 docs の `要確認` を実際の要件に更新する
+3. 機能要件の MoSCoW 優先度を PO と合意する
+4. 設計要件の実装タスク分解を確定させ、開発に着手する
+5. テスト要件の受け入れ条件を機能要件と紐付ける
+6. 変更が発生した場合は各 docs の **要件変更履歴** に記録する
+
+## 備考
+
+- 情報不足は推測せず `要確認` として残すこと
+- `要確認` が残っているセクションは必ず PO / BA と確認すること
+- {date_prefix} 現在の情報が反映されています
+"""
 
 
 def write_pending_json(path: Path, payload: list[dict[str, str]]) -> None:
@@ -424,6 +666,7 @@ def main() -> int:
                     "staging_markdown_path": str(staging_path),
                     "sha256": sha256,
                     "processor": "anthropics/skills",
+                    "context_hint": SKILLS_CONTEXT_HINT,
                 })
                 processor = "anthropics/skills"
                 status = "pending-skills"
@@ -438,6 +681,7 @@ def main() -> int:
                 "staging_markdown_path": str(staging_path),
                 "sha256": sha256,
                 "processor": "anthropics/skills",
+                "context_hint": SKILLS_CONTEXT_HINT,
             })
             processor = "anthropics/skills"
             status = "pending-skills"
@@ -498,56 +742,24 @@ def main() -> int:
     business_doc = docs_dir / "business-requirements.md"
     functional_doc = docs_dir / "functional-requirements.md"
     design_doc = docs_dir / "design-requirements.md"
+    test_doc = docs_dir / "test-requirements.md"
+    index_doc = docs_dir / "index.md"
 
-    if processed_count > 0 or not (business_doc.exists() and functional_doc.exists() and design_doc.exists()):
-        write_text(
-            business_doc,
-            build_requirements_doc(
-                title="業務要件",
-                batch_started_at=batch_started_at,
-                results=results,
-                focus_items=[
-                    "対象業務 / 目的",
-                    "利用者 / ロール",
-                    "業務フロー",
-                    "未確定事項 / 要確認事項",
-                ],
-            ),
-        )
-        write_text(
-            functional_doc,
-            build_requirements_doc(
-                title="機能要件",
-                batch_started_at=batch_started_at,
-                results=results,
-                focus_items=[
-                    "Dataverse テーブル候補",
-                    "主要列 / マスタ / リレーション候補",
-                    "Code Apps / Model-Driven Apps の UI 要件",
-                    "Power Automate の自動化要件",
-                    "Copilot Studio / AI Builder の利用余地",
-                    "外部連携",
-                ],
-            ),
-        )
-        write_text(
-            design_doc,
-            build_requirements_doc(
-                title="設計要件",
-                batch_started_at=batch_started_at,
-                results=results,
-                focus_items=[
-                    "Power Platform 全体構成案",
-                    "セキュリティ / 権限 / 監査の論点",
-                    "設計上のリスク",
-                    "Phase 0 で確認が必要な論点",
-                ],
-            ),
-        )
+    all_docs_exist = all(
+        p.exists() for p in [business_doc, functional_doc, design_doc, test_doc, index_doc]
+    )
+    if processed_count > 0 or not all_docs_exist:
+        write_text(business_doc, build_business_requirements_doc(batch_started_at, results))
+        write_text(functional_doc, build_functional_requirements_doc(batch_started_at, results))
+        write_text(design_doc, build_design_requirements_doc(batch_started_at, results))
+        write_text(test_doc, build_test_requirements_doc(batch_started_at, results))
+        write_text(index_doc, build_index_doc(batch_started_at, results))
 
         print(f"📝 wrote: {business_doc}")
         print(f"📝 wrote: {functional_doc}")
         print(f"📝 wrote: {design_doc}")
+        print(f"📝 wrote: {test_doc}")
+        print(f"📝 wrote: {index_doc}")
     else:
         print(f"✅ 未完了変換はありません。既存の `{docs_dir}` を参照して開発を進めてください。")
 


### PR DESCRIPTION
## Summary

- **`test-requirements.md` を新規追加**: テストシナリオ・受け入れ条件・非機能テスト表を含む4つ目の要件ドキュメントを生成するようにした
- **`index.md` を新規追加**: ドキュメント一覧（役割・主な利用者付き）と開発利用フロー手順を含むナビゲーション用ファイルを生成
- **各 docs テンプレートを特化型に分割**: 共通の `build_requirements_doc` を4種の専用関数に分割し、ドキュメントごとに実用的な表構造を追加
  - 業務要件: ステークホルダー表・ユーザーストーリー（As a…形式）・未確定事項管理表
  - 機能要件: MoSCoW 優先度付き機能一覧・データモデル表・非機能要件表
  - 設計要件: コンポーネント設計表・リスク管理表（影響度×発生確率）・実装タスク分解表
  - テスト要件: テストシナリオ表・受け入れ条件表（機能要件 # との対応）・非機能テスト合格基準表
- **`pending_skills.json` に `context_hint` フィールドを追加**: anthropics/skills が文書を読み取る際の抽出観点を manifest に明示
- **SKILL.md・conversion-guide.md を更新**: staging→docs 統合フローを具体的な手順に明文化、新ドキュメントの説明を追加

## Test plan

- [ ] `convert_documents.py` を実行し、`spec/output/docs/` に `index.md` と `test-requirements.md` が生成されることを確認
- [ ] 生成された各 docs に MoSCoW 表・タスク分解表などのテンプレートが含まれることを確認
- [ ] `pending_skills.json` に `context_hint` フィールドが含まれることを確認
- [ ] 既存の `already-completed` ファイルが再処理されないことを確認（`is_completed=true` のまま）
- [ ] `--input` / `--staging` / `--docs` オプションが引き続き動作することを確認

https://claude.ai/code/session_01LACppAqeTwgyEFwUnJyJ8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01LACppAqeTwgyEFwUnJyJ8s)_