### PR TITLE
docs(code-apps): サンプル流用時の欠落ファイル・dataSourcesInfo型・systemuser追加・表示名退避の知見を追記

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -240,8 +240,9 @@ PUBLISHER_PREFIX={prefix}          ← ソリューション発行者の prefix
    → システムテーブル（bot, botcomponent, conversationtranscript 等）も登録可能
 ```
 
-> **注意**: `systemuser` テーブルは `pac code add-data-source` で追加できない場合がある。
-> その場合のみ `src/lib/dataSourcesInfo.ts` に手動追記する。
+> **注意**: `systemuser` テーブルも通常は `pac code add-data-source -a dataverse -t systemuser` で追加できる（検証済 2026-06-15）。
+> 追加できれば `src/lib/dataSourcesInfo.ts` は生成ファイルを re-export するだけでよい。
+> 環境によって追加できない場合のみ `src/lib/dataSourcesInfo.ts` に手動追記する。
 > それ以外のテーブルは必ず SDK コマンドで追加すること。
 
 ### 標準ワークフロー（この順序で進める）
@@ -381,8 +382,8 @@ pac code push -env {ENVIRONMENT_ID} -s {SOLUTION_NAME}
 
 **手動で `dataSourcesInfo.ts` にカスタムテーブル定義を追記してはならない。**
 SDK が `.power/schemas/appschemas/dataSourcesInfo.ts` を自動生成する。
-`src/lib/dataSourcesInfo.ts` には、SDK で追加できないシステムテーブル
-（`systemuser`, `bot`, `conversationtranscript` 等）とコネクタのみ手動追記する。
+`src/lib/dataSourcesInfo.ts` は基本的にこの生成ファイルを re-export するだけにする。
+SDK の add-data-source で追加**できなかった**システムテーブル（`bot`, `conversationtranscript` 等）やコネクタのみ手動追記する。
 
 ### 日本語 DisplayName サニタイズエラーの回避
 

--- a/.github/skills/code-apps/references/data-source-patterns.md
+++ b/.github/skills/code-apps/references/data-source-patterns.md
@@ -4,7 +4,9 @@
 
 1. **カスタムテーブルは `pac code add-data-source` で追加** → `.power/schemas/appschemas/dataSourcesInfo.ts` が自動更新
 2. **手動で `dataSourcesInfo.ts` にカスタムテーブル定義を追記してはならない**
-3. **`src/lib/dataSourcesInfo.ts`** にはシステムテーブル（systemuser, bot 等）とコネクタのみ手動追記
+3. **`systemuser` も `pac code add-data-source -t systemuser` で追加できる**（検証済 2026-06-15）。
+   追加できれば `src/lib/dataSourcesInfo.ts` は生成ファイルを re-export するだけでよく、手動定義は不要
+4. **`src/lib/dataSourcesInfo.ts`** への手動追記は、SDK の add-data-source で追加**できなかった**システムテーブルやコネクタに限る（最後の手段）
 
 ## SDK 生成コードの構成
 
@@ -83,14 +85,31 @@ export const DataverseService = {
 `getClient(dataSourcesInfo)` はシングルトン。最初の呼び出しで渡した `dataSourcesInfo` にフロー/コネクタが含まれないと
 `Data source not found` エラーになる。
 
+### 基本: 生成ファイルをそのまま re-export（systemuser も add-data-source 済みの場合）
+
+`systemuser` を含む全テーブルを `pac code add-data-source` で追加できていれば、
+`src/lib/dataSourcesInfo.ts` は生成ファイルを再エクスポートするだけでよい（手書き定義・型注釈は不要）。
+
+```typescript
+// src/lib/dataSourcesInfo.ts
+import { dataSourcesInfo } from "../../.power/schemas/appschemas/dataSourcesInfo";
+
+export default dataSourcesInfo;
+```
+
+> `pac code add-data-source -a dataverse -t systemuser` で `systemusers` が生成 `dataSourcesInfo` に含まれる（検証済 2026-06-15）。
+> `DataSourcesInfo` 型は SDK が公開エクスポートしていないため、手書きの型注釈を付けようとすると import エラーになる。
+> → [トラブルシューティング #26](troubleshooting.md)
+
+### 応用: SDK で追加できなかったテーブル/コネクタを足す場合のみ spread
+
 ```typescript
 // src/lib/dataSourcesInfo.ts
 import { dataSourcesInfo as powerInfo } from "../../.power/schemas/appschemas/dataSourcesInfo";
 
-export const dataSourcesInfo = {
+export default {
   ...powerInfo,
-  // SDK で追加できないシステムテーブル
-  systemusers: { tableId: "systemuser", version: "", primaryKey: "systemuserid", dataSourceType: "Dataverse", apis: {} },
+  // SDK の add-data-source で追加できなかったシステムテーブル/コネクタのみここに足す
   bots: { tableId: "bot", version: "", primaryKey: "botid", dataSourceType: "Dataverse", apis: {} },
   // コネクタは npx power-apps add-flow で追加後にここにマージ
 };

--- a/.github/skills/code-apps/references/japanese-sanitize.md
+++ b/.github/skills/code-apps/references/japanese-sanitize.md
@@ -98,6 +98,91 @@ node .github/skills/code-apps/references/patch-nameutils.cjs
 > `npm install` 後に毎回 `node .github/skills/code-apps/references/patch-nameutils.cjs` を実行する必要がある
 > （`node_modules` が再生成されパッチが消えるため）。スクリプト実体はこのスキルに同梱され、`.github/` 同期でテーマに配布される。
 
+## より堅牢な方法: 表示名を退避＆復元する（推奨・検証済 2026-06-15）
+
+上記テンプレートは TABLES に**日本語表示名をハードコード**する必要があり、テーブルが増えるたびに保守が必要。
+また「日本語に復元」する際、現在の表示名を `UserLocalizedLabel` から読むと、
+**英語に切替済みの状態では英語ラベルを拾ってしまい**、元の日本語名が失われる事故が起きる。
+
+これを避けるには、英語化の直前に**現在の表示名をファイルに退避**し、復元時はそのバックアップから書き戻す。
+言語コードは `UserLocalizedLabel` ではなく `LocalizedLabels` の **1041（日本語）を明示的に**読む。
+
+```python
+"""テーブル表示名を英語化／日本語復元する（退避＆復元方式）。
+
+usage:
+  python toggle_lang.py en   # 現在の日本語名を .lang_backup.json に退避し英語化
+  python toggle_lang.py jp   # .lang_backup.json から日本語名を復元
+"""
+import json, os, sys
+from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv()
+# auth_helper.py のあるパスを通す（プロジェクト構成に合わせて調整）
+sys.path.insert(0, os.path.join(".github", "skills", "standard", "scripts"))
+from auth_helper import api_get, api_request
+
+PREFIX = os.environ["PUBLISHER_PREFIX"].strip()
+# ── プロジェクト固有: (論理名サフィックス, 英語DisplayName, 英語Plural) のみ定義 ──
+# 日本語名はハードコードしない（退避ファイルから復元するため）
+EN = {
+    "customer": ("Customer", "Customers"),
+    # "engineer": ("Engineer", "Engineers"), ...
+}
+BACKUP = Path(".lang_backup.json")
+
+
+def label(text, code):
+    return {"LocalizedLabels": [{"Label": text, "LanguageCode": code}]}
+
+
+def get_meta(logical):
+    return api_get(
+        f"EntityDefinitions(LogicalName='{logical}')"
+        "?$select=MetadataId,DisplayName,DisplayCollectionName"
+    )
+
+
+def put_names(mid, disp, coll, code):
+    api_request(f"EntityDefinitions({mid})", {
+        "@odata.type": "#Microsoft.Dynamics.CRM.EntityMetadata",
+        "MetadataId": mid,
+        "DisplayName": label(disp, code),
+        "DisplayCollectionName": label(coll, code),
+    }, method="PUT")
+
+
+def to_english():
+    backup = {}
+    for suffix, (en_d, en_p) in EN.items():
+        logical = f"{PREFIX}_{suffix}"
+        m = get_meta(logical)
+        # ✅ 1041（日本語）を明示的に拾う。UserLocalizedLabel は UI 言語に依存し不確実
+        jp = next((l for l in m["DisplayName"]["LocalizedLabels"] if l["LanguageCode"] == 1041), None)
+        jpc = next((l for l in m["DisplayCollectionName"]["LocalizedLabels"] if l["LanguageCode"] == 1041), None)
+        if jp:
+            backup[logical] = {"disp": jp["Label"], "coll": jpc["Label"]}
+        put_names(m["MetadataId"], en_d, en_p, 1033)
+        print(f"  {logical} → {en_d}")
+    BACKUP.write_text(json.dumps(backup, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def to_japanese():
+    backup = json.loads(BACKUP.read_text(encoding="utf-8"))
+    for logical, v in backup.items():
+        put_names(get_meta(logical)["MetadataId"], v["disp"], v["coll"], 1041)
+        print(f"  {logical} → {v['disp']}")
+
+
+if __name__ == "__main__":
+    mode = sys.argv[1] if len(sys.argv) > 1 else "en"
+    (to_english if mode == "en" else to_japanese)()
+```
+
+> **メリット**: 日本語名を二重管理しない／復元漏れが起きない。
+> 英語化は 1033、復元は退避済みの 1041 ラベルを書き戻すため、UI 言語設定に左右されない。
+
 ## スキーマ名は英語のみ
 
 ```

--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -1260,3 +1260,98 @@ WOFF2 バイナリファイルを配信する際に、Content-Encoding やバイ
 - `@fontsource/geist` 等の npm フォントパッケージ
 - `public/` や `assets/` に配置した `.woff2` / `.woff` ファイル
 - `.ttf` / `.otf` でも同様の問題が発生する可能性がある
+
+---
+
+## 25. サンプルを流用すると `styles/index.pcss` / `plugins/plugin-power-apps.ts` が欠落しビルド失敗（検証済 2026-06-15）
+
+### 症状
+
+`pac code init` を使わずサンプル（`samples/geek-*`）の `src/` だけを別プロジェクトにコピーして開発を始めると、
+`npm run build` が以下のいずれかで失敗する:
+
+```
+[@tailwindcss/vite:generate:build] Can't resolve '../styles/index.pcss' in '.../src'
+```
+
+```
+error TS2307: Cannot find module './plugins/plugin-power-apps' or its corresponding type declarations.
+```
+
+### 原因
+
+`pac code init` がスキャフォールドするファイルのうち、**`src/` の外にあるファイルがコピー漏れする**。
+
+| ファイル | 参照元 | 役割 |
+|---|---|---|
+| `styles/index.pcss` | `src/index.css` の `@import "../styles/index.pcss"` | Tailwind v4 テーマ（CSS Variables 一式） |
+| `plugins/plugin-power-apps.ts` | `vite.config.ts` の `import { powerApps, POWER_APPS_CORS_ORIGINS } from "./plugins/plugin-power-apps"` | Vite 開発サーバー用プラグイン（**`apply: "serve"` の dev 専用**） |
+
+`plugin-power-apps.ts` は `apply: "serve"` のため**本番ビルドの実行には不要**だが、
+`vite.config.ts` の `import` 文がトップレベルにあるため、ファイルが存在しないとビルドが起動しない。
+
+### 対処
+
+1. **正攻法**: `pac code init` を空フォルダで実行し、生成された `styles/` と `plugins/` を残したまま `src/` を実装する
+   （サンプルをそのまま出発点にしない → [新規テーマ開始チェックリスト](new-theme-checklist.md)）。
+2. **既にサンプルを流用してしまった場合**: 不足ファイルをサンプルから補完する。
+   - `styles/index.pcss` … 任意のサンプル（`samples/geek-*/styles/index.pcss`）からコピーし、配色を調整
+   - `plugins/plugin-power-apps.ts` … 任意のサンプル（`samples/geek-*/plugins/plugin-power-apps.ts`）からコピー（中身は全テーマ共通）
+
+### 予防
+
+`pac code init` がスキャフォールドするインフラは `src/` だけではない。
+プロジェクト直下の **`styles/` `plugins/` `vite.config.ts` `index.html` `components.json`** も含めて一式で扱う。
+
+---
+
+## 26. `DataSourcesInfo` 型は `@microsoft/power-apps` からエクスポートされない（検証済 2026-06-15）
+
+### 症状
+
+`src/lib/dataSourcesInfo.ts` を手書きする際に型注釈を付けようとすると、import がすべて失敗する:
+
+```
+error TS2307: Cannot find module '@microsoft/power-apps' ...          // ルート import
+error TS2305: Module '"@microsoft/power-apps/data"' has no exported member 'DataSourcesInfo'.
+```
+
+### 原因
+
+`@microsoft/power-apps`（v1.2.2）は **`DataSourcesInfo` という型を公開エクスポートしていない**。
+`/data` サブパスが公開するのは `getClient` / `IOperationOptions` / `IOperationResult` / `DataClient` のみ。
+内部型（`IDataSourceInfo` 等）は `internal/...` にあり、公開 API として import すべきではない。
+
+### 対処（推奨）: 生成ファイルをそのまま re-export する
+
+`src/lib/dataSourcesInfo.ts` で型を手書きせず、SDK が生成した `dataSourcesInfo` を再エクスポートする。
+型は生成オブジェクトから推論されるため、手書きの型注釈は不要。
+
+```typescript
+// src/lib/dataSourcesInfo.ts
+import { dataSourcesInfo } from "../../.power/schemas/appschemas/dataSourcesInfo";
+
+export default dataSourcesInfo;
+```
+
+フロー/コネクタや SDK で追加できないテーブルを足す場合のみ spread する:
+
+```typescript
+import { dataSourcesInfo as powerInfo } from "../../.power/schemas/appschemas/dataSourcesInfo";
+
+export default {
+  ...powerInfo,
+  // SDK の add-data-source で追加できなかったテーブル/コネクタのみここに足す
+};
+```
+
+### どうしても型注釈が必要な場合
+
+`getClient` の引数型から導出する（公開 API の範囲で完結する）:
+
+```typescript
+import { type getClient } from "@microsoft/power-apps/data";
+type DataSourcesInfo = Parameters<typeof getClient>[0];
+```
+
+→ 関連: [データソースパターン](data-source-patterns.md)


### PR DESCRIPTION
## 概要

テーマを Code Apps で実装する中で得た、再発防止に有効な汎用的な知見を標準スキルに反映します。トラブルシューティングだけでなく、原則・パターン・回避スクリプトにも反映しています。

## 背景となった実体験

`pac code init` を使わずサンプルを流用して開発を開始したところ、以下に連続して遭遇しました。すべて「次回スムーズに進めるための知見」として一般化できます。

1. `styles/index.pcss` 欠落で Tailwind ビルド失敗（`Can't resolve '../styles/index.pcss'`）
2. `plugins/plugin-power-apps.ts` 欠落で vite ビルド失敗（dev 専用プラグインだが import 解決は必須）
3. `DataSourcesInfo` 型を `@microsoft/power-apps` から import しようとして TS2307 / TS2305
4. `systemuser` が実際には `pac code add-data-source -t systemuser` で追加できた（既存スキルは「追加できない場合がある」と記載）
5. 表示名の英語⇔日本語切替で、`UserLocalizedLabel` を読むと英語化後に日本語名を取りこぼす

## 変更内容

### `references/troubleshooting.md`
- **#25** サンプル流用時の `styles/index.pcss` / `plugins/plugin-power-apps.ts` 欠落でビルド失敗（症状・原因・補完手順・予防）
- **#26** `DataSourcesInfo` 型は SDK が公開エクスポートしていない（生成ファイル re-export 推奨／どうしても型が必要なら `Parameters<typeof getClient>[0]`）

### `references/data-source-patterns.md`
- 原則を更新: `systemuser` も `pac code add-data-source -t systemuser` で追加可能（検証済 2026-06-15）。追加できれば `src/lib/dataSourcesInfo.ts` は生成ファイルの re-export だけでよい
- 統合 dataSourcesInfo の節を「基本（re-export のみ）」と「応用（spread）」に整理

### `references/japanese-sanitize.md`
- 表示名の **退避＆復元方式** を追記。日本語名をハードコードせず、英語化直前に現在の表示名を `.lang_backup.json` に退避し、復元時に書き戻す。言語コードは `UserLocalizedLabel` ではなく **1041 を明示的に**読むことで UI 言語に依存しない

### `SKILL.md`
- `systemuser` の注記と dataSourcesInfo 手動追記の原則を、上記の検証結果に合わせて更新

## 影響範囲

ドキュメント（スキル）のみ。コード・スクリプトの実体変更はありません。既存手順を否定せず、より確実な選択肢を追加する方向の更新です。
