### PR TITLE
fix: クイックスタートで .gitignore が欠落しコミット対象が増える問題を修正

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -177,6 +177,7 @@ Code Apps 開発は **設計 → 初回デプロイ → データソース接続
 
 ```bash
 # Step 0: テンプレート scaffold（標準では @GeekPowerCode が scaffold）
+cp -n .github/skills/standard/references/gitignore-template .gitignore   # .gitignore がなければコピー
 npm install
 
 # Step 1: 初期化 — power.config.json を生成（PAC CLI 認証でテナント不一致なし）

--- a/.github/skills/code-apps/references/build-reference.md
+++ b/.github/skills/code-apps/references/build-reference.md
@@ -17,6 +17,9 @@
 ### Step 1: テンプレート scaffold + プロジェクト初期化
 
 ```bash
+# ⓪ .gitignore が存在しなければテンプレートからコピー（node_modules/ 等の除外に必須）
+cp -n .github/skills/standard/references/gitignore-template .gitignore
+
 # ① テンプレート scaffold（vite.config.ts / plugins/plugin-power-apps.ts / styles/ / src/ 一式）
 #    標準では @GeekPowerCode が scaffold する。手動で行う場合:
 #    npx degit github:microsoft/PowerAppsCodeApps/templates/vite .

--- a/.github/skills/code-apps/references/new-theme-checklist.md
+++ b/.github/skills/code-apps/references/new-theme-checklist.md
@@ -12,11 +12,18 @@
 
 ```bash
 mkdir <your-theme-name> && cd <your-theme-name>
-npx degit geekfujiwara/CodeAppsDevelopmentStandard .github
+npx degit geekfujiwara/CodeAppsDevelopmentStandard/.github .github
+cp .github/skills/standard/references/gitignore-template .gitignore
 # 取得後、@GeekPowerCode に「新規テーマ: [テーマ名]を作成してください」と依頼
 ```
 
 ## チェックリスト（実装開始前）
+
+### 0. `.gitignore` が存在すること
+
+- [ ] ルートに `.gitignore` がある — なければ `cp .github/skills/standard/references/gitignore-template .gitignore` でコピー
+
+> `.gitignore` がないと `node_modules/`・`dist/`・`.power/`・`.env`・`src/generated/` 等がすべてコミット対象になる。
 
 ### 1. SDK 生成物が存在しないこと（あれば前テーマの残骸）
 

--- a/.github/skills/standard/references/gitignore-template
+++ b/.github/skills/standard/references/gitignore-template
@@ -1,0 +1,80 @@
+# Dependencies
+node_modules/
+package-lock.json
+
+# Copilot memories (session/user notes)
+memories/
+
+# spec-to-markdown default workspace
+work/input/*
+!work/input/.gitkeep
+work/staging/
+work/docs/
+work/conversion-checklist.json
+
+# Build output
+dist/
+
+# Editor
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+
+# IDE
+.idea/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Authentication cache (auth_helper.py)
+.auth_record.json
+
+# Power Platform
+.power/
+.auth_record.json
+*.log
+
+# SDK generated (npx power-apps add-data-source で再生成)
+src/generated/
+power.config.json
+
+# App-specific code (テンプレートには含めない)
+src/pages/incident-*.tsx
+src/pages/incidents.tsx
+src/hooks/use-incidents.ts
+src/services/incident-service.ts
+src/lib/incident-types.ts
+
+# Python
+__pycache__/
+
+# Generated images (preview/test)
+*_preview.png
+*_icon.png
+*.pyc
+.venv/
+
+# Debug artifacts
+scripts/*_debug.json
+deploy_log*.txt
+dump_*.txt
+cs_data.txt
+gpt_data.txt
+check_log.txt
+icon_*.png
+icon_*.txt
+icon_preview.svg
+
+# Build info
+tsconfig.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -141,11 +141,15 @@ Windows 端末の開発環境準備（開発ツールの導入と動作確認ま
 
 ### 手順
 
-テーマ用ワークスペースフォルダを開いた状態で、以下のコマンドを実行してエージェント・スキルを取得します。
+テーマ用ワークスペースフォルダを開いた状態で、以下のコマンドを実行してエージェント・スキルと `.gitignore` を取得します。
 
 ```bash
 npx degit geekfujiwara/CodeAppsDevelopmentStandard/.github .github
+cp .github/skills/standard/references/gitignore-template .gitignore
 ```
+
+> [!NOTE]
+> `.gitignore` がないと `node_modules/`・`dist/`・`.power/`・`.env` 等がコミット対象になります。必ずコピーしてください。
 
 取得後、**@GeekPowerCode** に新規テーマ開発を依頼します。`spec/input/` フォルダにドキュメントや画像を配置して **/spec-to-markdown** で依頼することもできます。
 
@@ -165,7 +169,10 @@ gh repo create <your-account>/<your-theme-repo> --private --clone && cd <your-th
 # 2. エージェント・スキルを取得
 npx degit geekfujiwara/CodeAppsDevelopmentStandard/.github .github
 
-# 3. @GeekPowerCode にプロジェクト scaffold を依頼
+# 3. .gitignore をコピー（node_modules/ 等の除外に必須）
+cp .github/skills/standard/references/gitignore-template .gitignore
+
+# 4. @GeekPowerCode にプロジェクト scaffold を依頼
 ```
 
 > [!TIP]


### PR DESCRIPTION
degit は .github/ のみコピーするためルートの .gitignore が新規プロジェクトに
含まれず、node_modules/ や .env 等が git add 対象になっていた。
テンプレートを .github/skills/standard/references/ に配置し、
README・SKILL.md・build-reference・new-theme-checklist の各手順にコピーステップを追加。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Eni8YXUxLegAQuNEtvUdLR