### PR TITLE
skill(copilot-studio-v2): アイコン/MCP/公開フローを追加

### DIFF
--- a/.github/skills/copilot-studio-v2/SKILL.md
+++ b/.github/skills/copilot-studio-v2/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: copilot-studio-v2
-description: "Copilot Studio の「全く新しいアーキテクチャ」（cliagent テンプレート）エージェントを Dataverse Web API だけで完全自動構築する。UI 手動作成不要。Bot 作成・Instructions/モデル/メモリ設定・フラット Python スキル添付までスクリプトで完結。"
+description: "Copilot Studio の「全く新しいアーキテクチャ」（cliagent テンプレート）エージェントを Dataverse Web API だけで完全自動構築する。UI 手動作成不要。Bot 作成・Instructions/モデル/メモリ設定・フラット Python スキル添付・アイコン登録・MCP サーバー追加（Dataverse / Work IQ）・公開までスクリプトで完結。"
 category: automation
 triggers:
   - "Copilot Studio v2"
@@ -20,6 +20,12 @@ triggers:
   - "enableMemory"
   - "Sonnet46"
   - "エージェント v2"
+  - "エージェント アイコン"
+  - "MCP サーバー 追加"
+  - "Dataverse MCP"
+  - "Work IQ"
+  - "PvaPublish"
+  - "エージェント 公開"
 ---
 
 # Copilot Studio v2（新アーキテクチャ）エージェント構築スキル
@@ -58,13 +64,28 @@ Copilot Studio の **「全く新しいアーキテクチャ」（`cliagent` テ
 
 ```
 1. .env 準備（DATAVERSE_URL / TENANT_ID / 任意で SOLUTION_NAME・PUBLISHER_PREFIX）
-2. 設計提示 → ユーザー承認（名前・Instructions・モデル・スキル構成）
+2. 設計提示 → ユーザー承認（名前・Instructions・モデル・スキル・アイコン・MCP 構成）
 3. scripts/create_agent.py     … cliagent Bot を API 作成 + プロビジョニング待ち
-4. scripts/attach_skill.py     … フラット Python スキルを添付（type=9 + type=14）
-5. scripts/verify_agent.py     … 構造検証（filedata 実体ダウンロード確認）
-6. pac copilot list            … Provisioned / Active を確認
-7. Preview で動作テスト（ユーザー）
+4. scripts/set_icon.py         … アイコン登録（240 / Teams color 192 / outline 32）
+5. scripts/attach_skill.py     … フラット Python スキルを添付（type=9 + type=14）
+6. scripts/add_mcp_server.py   … MCP サーバー追加（Dataverse / Work IQ 等・接続参照込み）
+7. scripts/publish_agent.py    … PvaPublish で公開
+8. scripts/verify_agent.py     … 構造検証（filedata 実体ダウンロード確認）
+9. pac copilot list            … Published / Active / Provisioned を確認
+10. UI で MCP サーバーを「確認(Confirm)」… ★MCP 含む場合の正常系（後述）
+11. Preview で動作テスト（ユーザー）
 ```
+
+> **一括実行**: 上記 3〜7 は [scripts/deploy_agent.py](scripts/deploy_agent.py) で
+> ワンショット実行できる（`.env` の構成に従い作成→アイコン→スキル→MCP→公開を連結）。
+
+### MCP を含む場合の「確認(Confirm)」は正常系（重要）
+
+MCP サーバーを API で追加し公開しても、**初回は Copilot Studio UI で MCP サーバーの
+「確認(Confirm)」が一度必要**になることがある。これは Dataverse レコードを変更せず
+（Confirm 前後で差分なし）、セッション側で接続を再バインドする動作。**再公開だけでは
+エラーが消えないことがある**ため、自動デプロイの最後に「UI で一度 Confirm する」手順を
+**正常系として組み込む**。詳細は [MCP サーバーの追加](references/mcp-servers.md) を参照。
 
 ## 必須要件・落とし穴（実機検証済み）
 
@@ -124,6 +145,22 @@ Copilot Studio の **「全く新しいアーキテクチャ」（`cliagent` テ
 
 詳細は [スキルバンドル構造](references/skill-bundle-structure.md) を参照。
 
+### アイコン・MCP・公開（実機検証済み）
+
+```
+✅ アイコンは bots.iconbase64(240) ＋ teams.colorIcon(192)/outlineIcon(32) の 3 か所へ登録
+   ⚠ bots を PATCH する際は name 列を必ず同送（無いと 0x80040265 エラー）
+✅ MCP は botcomponent type=9 / data の kind:McpTool（connector/operationId/接続参照）
+   ⚠ 接続参照の論理名はコネクタ名を「フル」で：{botschema}.cr.{connector}.{接続GUID}
+     切詰めると公開時に「1 missing connection reference」で失敗する
+   ⚠ 対象コネクタの Connected な接続が環境に必要（接続自体は API 作成不可）
+✅ 公開は PvaPublish。状態確認は pac copilot list（publishedon は None のことがある）
+⚠ MCP 含む場合は公開後に UI で MCP サーバーの「確認(Confirm)」が一度必要（正常系）
+```
+
+詳細は [MCP サーバーの追加](references/mcp-servers.md) と
+[アイコン登録と公開](references/icon-and-publish.md) を参照。
+
 ### よくあるエラー
 
 | 症状 | 原因 | 対処 |
@@ -131,6 +168,9 @@ Copilot Studio の **「全く新しいアーキテクチャ」（`cliagent` テ
 | `0x8004023b "Connection State is closed"` | Bot プロビジョニング直後で認可セッション未確立 | 数秒待って **リトライ**（一時エラー） |
 | `undeclared property 'parentbotcomponentid'` | 親ナビ名が誤り | `ParentBotComponentId`（Pascalケース）を使う |
 | `bot $select` で 400 | 新アーキに存在しない列を指定 | 全列取得してから必要列をフィルタ |
+| `0x80040265`（bots 更新不可） | PATCH に `name` 列を含めていない | アイコン等の PATCH でも `name` を同送 |
+| 公開時 `1 missing connection reference` | 接続参照の論理名でコネクタ名を切詰めた | コネクタ名は**フル**で論理名を生成 |
+| 公開後も MCP がエラー | UI の「確認(Confirm)」未実施 | UI で MCP サーバーを **Confirm**（再公開だけでは消えないことがある） |
 | 日本語出力で `UnicodeEncodeError`（cp932） | Windows コンソール既定 | `sys.stdout.reconfigure(encoding="utf-8")` |
 
 ## スクリプト一覧
@@ -138,7 +178,11 @@ Copilot Studio の **「全く新しいアーキテクチャ」（`cliagent` テ
 | スクリプト | 用途 |
 |---|---|
 | [scripts/create_agent.py](scripts/create_agent.py) | cliagent Bot を API 作成 + プロビジョニング待ち |
+| [scripts/set_icon.py](scripts/set_icon.py) | アイコン登録（iconbase64 / Teams color / outline） |
 | [scripts/attach_skill.py](scripts/attach_skill.py) | フラット Python スキルを添付（type=9 + type=14） |
+| [scripts/add_mcp_server.py](scripts/add_mcp_server.py) | MCP サーバー追加（接続参照 + McpTool。Dataverse / Work IQ） |
+| [scripts/publish_agent.py](scripts/publish_agent.py) | PvaPublish で公開（リトライ付き） |
+| [scripts/deploy_agent.py](scripts/deploy_agent.py) | 一括: 作成→アイコン→スキル→MCP→公開 を連結 |
 | [scripts/verify_agent.py](scripts/verify_agent.py) | 構造検証（filedata 実体ダウンロード確認） |
 | [scripts/analyze_agent.py](scripts/analyze_agent.py) | 既存エージェントの構成・コンポーネントをダンプ |
 
@@ -151,6 +195,8 @@ Copilot Studio の **「全く新しいアーキテクチャ」（`cliagent` テ
 | [新アーキテクチャ構造](references/new-architecture.md) | cliagent の BotConfiguration / botcomponents 全体像と v1 との対比 |
 | [フラット Python スキルの書き方](references/flat-python-skill.md) | JS 不使用・Base64 画像・フラット構成の実装テンプレート |
 | [スキルバンドル構造](references/skill-bundle-structure.md) | type=9/14・親バインド・filedata アップロードの詳細 |
+| [MCP サーバーの追加](references/mcp-servers.md) | 接続参照規約・operationId・公開後の Confirm（正常系） |
+| [アイコン登録と公開](references/icon-and-publish.md) | iconbase64/Teams アイコン・PvaPublish・name 同送の注意 |
 
 ## .env 必須項目
 
@@ -166,4 +212,10 @@ PUBLISHER_PREFIX=geek
 AGENT_NAME=my-new-agent
 AGENT_SCHEMA=geek_mynewagent
 AGENT_MODEL_SERIES=Sonnet46
+# set_icon.py 用（任意）
+ICON_TEXT=A
+ICON_BG_COLOR=#2563EB
+ICON_ACCENT_COLOR=#22C55E
+# deploy_agent.py の MCP 一括追加（"connector|表示名" をカンマ区切り）
+MCP_CONNECTORS=shared_commondataserviceforapps|Microsoft Dataverse MCP サーバー
 ```

--- a/.github/skills/copilot-studio-v2/references/.env.example
+++ b/.github/skills/copilot-studio-v2/references/.env.example
@@ -15,9 +15,25 @@ AGENT_SCHEMA=geek_mynewagent
 AGENT_MODEL_SERIES=Sonnet46
 AGENT_INSTRUCTIONS=ここにエージェントの指示文を記載します。
 
-# attach_skill.py / verify_agent.py / analyze_agent.py 用
+# attach_skill.py / set_icon.py / publish_agent.py / verify_agent.py / analyze_agent.py 用
 # 未指定なら create_agent.py が出力する agent_botid.txt を読む
 AGENT_BOTID=<bot-guid>
 SKILL_DIR=skill
 SKILL_NAME=geek-pptx-py
 SKILL_DESCRIPTION=フラット Python スキルの説明（Use when: ... を含める）
+
+# set_icon.py 用（任意。汎用アイコン: 角丸背景＋頭文字＋アクセントバッジ）
+# 取得元: 任意。ICON_TEXT 未指定ならエージェント名の先頭1文字を使用
+ICON_TEXT=A
+ICON_BG_COLOR=#2563EB
+ICON_ACCENT_COLOR=#22C55E
+
+# add_mcp_server.py 用（既定は Dataverse MCP）
+MCP_CONNECTOR=shared_commondataserviceforapps
+MCP_DISPLAY=Microsoft Dataverse MCP サーバー
+# add_mcp_server.py の operationId は Swagger 自動検出。明示する場合のみ設定
+# MCP_OPERATION=InvokeMCP
+
+# deploy_agent.py の MCP 一括追加（"connector|表示名" をカンマ区切り）
+# 例: shared_commondataserviceforapps|Microsoft Dataverse MCP サーバー,shared_workiqonedrive|Work IQ OneDrive (Preview)
+MCP_CONNECTORS=shared_commondataserviceforapps|Microsoft Dataverse MCP サーバー

--- a/.github/skills/copilot-studio-v2/references/icon-and-publish.md
+++ b/.github/skills/copilot-studio-v2/references/icon-and-publish.md
@@ -1,0 +1,58 @@
+# アイコン登録と公開（API）
+
+cliagent エージェントにアイコンを登録し、公開（PvaPublish）するまでの実機検証済みリファレンス。
+スクリプトは [scripts/set_icon.py](../scripts/set_icon.py) と
+[scripts/publish_agent.py](../scripts/publish_agent.py)。
+
+## アイコン登録（3 か所）
+
+Pillow で PNG を生成し、以下の 3 か所へ登録する。
+
+| 用途 | 格納先 | サイズ | 備考 |
+|---|---|---|---|
+| エージェント本体 | `bots.iconbase64` | 240x240 | **生 base64**（`data:` 接頭辞なし） |
+| Teams カラー | `applicationmanifestinformation.teams.colorIcon` | 192x192 | JSON 内に base64 |
+| Teams アウトライン | `applicationmanifestinformation.teams.outlineIcon` | 32x32 | 白・透明背景 |
+
+### ★ハマりどころ: PATCH に name を必ず含める
+
+`bots` を PATCH するとき **`name` 列を必ず同送**する。含めないと
+`0x80040265`（更新不可）エラーになる。
+
+```python
+sess.patch(f"{API}/bots({bot_id})", json={"name": name, "iconbase64": icon_b64})
+```
+
+`applicationmanifestinformation` は GET → JSON パース → `teams.colorIcon/outlineIcon` を
+セット → PATCH（こちらも `name` 同送）。`teams.accentColor` に背景色 HEX を入れておくとよい。
+
+## アイコン意匠
+
+`scripts/set_icon.py` の `draw_icon()` は **汎用意匠**（角丸の単色背景＋中央頭文字＋任意の
+アクセントバッジ）。色・頭文字は `.env`（`ICON_BG_COLOR` / `ICON_TEXT` / `ICON_ACCENT_COLOR`）で
+差し替える。独自意匠（人物シルエット等）にしたい場合は `draw_icon()` をプロジェクト側で
+上書きする。例（人物＋承認チェック）:
+
+```python
+# 頭（楕円）＋肩（pieslice）＋右下に緑の承認チェックバッジ
+d.ellipse([...], fill=WHITE)
+d.pieslice([...], start=180, end=360, fill=WHITE)
+d.ellipse([...], fill=GREEN); d.line(check_points, fill=WHITE, width=w, joint="curve")
+```
+
+## 公開（PvaPublish）
+
+```python
+sess.post(f"{API}/bots({bot_id})/Microsoft.Dynamics.CRM.PvaPublish", json={})
+```
+
+- プロビジョニング直後は一時失敗することがあるため数回リトライする。
+- **公開状態の確認は `pac copilot list`（Published / Active / Provisioned）が正**。
+  cliagent では `bots.publishedon` が None のままになることがあるため、これで判断しない。
+
+## MCP を含むエージェントは公開後に「確認(Confirm)」
+
+MCP サーバーを含む場合、公開後に Copilot Studio UI で MCP サーバーの
+**「確認(Confirm)」が一度必要**になることがある（再公開だけでは解消しないことがある）。
+これを **正常系の最終ステップ**として組み込む。詳細は
+[mcp-servers.md](mcp-servers.md) を参照。

--- a/.github/skills/copilot-studio-v2/references/mcp-servers.md
+++ b/.github/skills/copilot-studio-v2/references/mcp-servers.md
@@ -1,0 +1,87 @@
+# MCP サーバーを API で追加する（接続参照・operationId・公開後の確認）
+
+cliagent エージェントに MCP サーバー（Dataverse MCP / Work IQ など）を **Dataverse Web API だけ**で
+追加するための実機検証済みリファレンス。スクリプトは
+[scripts/add_mcp_server.py](../scripts/add_mcp_server.py)。
+
+> 実機での確証: 手動 UI で MCP サーバーを追加したエージェントと、API で追加したエージェントの
+> Dataverse レコードを比較したところ **差分が無かった**。つまり下記の API 手順が
+> 「Dataverse 側の完全な必要要件」である。
+
+## MCP ツールの実体（botcomponent type=9）
+
+`data` 列に以下のプレーンテキスト（CRLF 区切り）を格納する。
+
+```
+kind: McpTool
+connectorId: /providers/Microsoft.PowerApps/apis/{connector}
+authMode: Invoker
+connectionReference: {接続参照の論理名}
+operationId: {MCP operation}
+```
+
+- `name` ＝ `"{表示名} — {表示名}"`（UI 形式）
+- `schemaname` ＝ `"{botschema}.tool.{Ascii表示名}-{Ascii表示名}_{乱数3}"`
+- 親バインド ＝ `parentbotid@odata.bind` → `/bots({botid})`
+
+## 既知コネクタと operationId
+
+`operationId` はコネクタ Swagger の `x-ms-agentic-protocol: mcp-streamable-1.0` を持つ POST 操作。
+`scripts/add_mcp_server.py` は Swagger から自動検出し、取得不可時は下表へフォールバックする。
+
+| MCP サーバー | connector | operationId | 表示名（例） |
+|---|---|---|---|
+| Microsoft Dataverse MCP | `shared_commondataserviceforapps` | `InvokeMCP` | Microsoft Dataverse MCP サーバー |
+| Work IQ OneDrive (Preview) | `shared_workiqonedrive` | `mcp_OneDriveRemoteServer` | Work IQ OneDrive (Preview) |
+
+> 別 MCP コネクタを足す場合は `--operation` で明示するか、Swagger 自動検出に任せる。
+
+## 接続参照（connectionReference）の論理名規約 ★最重要
+
+```
+{botschema}.cr.{connector}.{接続GUID}
+```
+
+- **コネクタ名は「フル」**（`shared_commondataserviceforapps` をそのまま）。
+  20 文字などに切詰めると、公開時の検証がフル名で接続参照を探すため
+  **「1 missing connection reference」で公開失敗**する。
+- **接続 GUID** は接続名末尾の GUID。ハイフン有無は接続名に合わせる
+  （UI 作成の接続はハイフン無し GUID のことがある。例: Work IQ）。
+- 100 文字を超える場合のみコネクタ名末尾を切詰める（UI 互換フォールバック）。
+- `connectionreferences.connectionid` には **接続のフル名**（`shared-...-{guid}`）を入れる。
+
+## 接続の事前承認（API 不可）
+
+接続（connection）自体は API で作成できない。対象コネクタの **Connected な接続が環境に
+存在している必要がある**。無ければ make.powerautomate.com で一度作成・承認する。
+`scripts/add_mcp_server.py` は環境内の Connected 接続を自動検出し、無ければ中断する。
+
+## 公開後の「確認(Confirm)」は正常系の一部 ★
+
+API で MCP ツール＋接続参照を作成し公開しても、初回は Copilot Studio UI 上で
+**MCP サーバーの「確認(Confirm)」操作が一度必要**になる場合がある。
+
+- これは Dataverse レコードを変更しない（Confirm 前後でレコード差分なし）。
+  オーサリング/ランタイム **セッション側で接続を再バインドする**動作。
+- **再公開だけではエラーが消えないことがある**。その場合は UI で
+  「設定 > ツール（または MCP サーバー）> 対象サーバー > 確認(Confirm)」を実行する。
+- したがって、自動デプロイの最後に「UI で一度 Confirm する」手順を**正常系として組み込む**。
+
+### 手順（UI・最終確認）
+
+1. Copilot Studio でエージェントを開く。
+2. ツール / MCP サーバー一覧で対象サーバーを開く。
+3. 接続が選択されていることを確認し、**確認(Confirm)** を押す。
+4. 必要なら再公開する（`scripts/publish_agent.py` または UI の「公開」）。
+
+> 自動化メモ: この UI 操作は Playwright MCP（`browser_navigate` / `browser_click`）で
+> 自動化できる。対象は対象サーバー詳細パネルの「確認 / Confirm」ボタン。
+
+## 既知エラーと対処
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| 公開時 `1 missing connection reference` | 接続参照の論理名でコネクタ名を切詰めた | コネクタ名は**フル**で `{botschema}.cr.{connector}.{guid}` |
+| 実行時に MCP が反応しない / 認可エラー | 公開後の Confirm 未実施、または接続未承認 | UI で **Confirm** ＋ 接続の承認を確認 |
+| `Connected な接続がありません` | 環境に該当コネクタの接続が無い | make.powerautomate.com で接続を作成/承認 |
+| `operationId を検出できません` | Swagger 取得不可かつ既知表に無い | `--operation` で明示指定 |

--- a/.github/skills/copilot-studio-v2/scripts/add_mcp_server.py
+++ b/.github/skills/copilot-studio-v2/scripts/add_mcp_server.py
@@ -1,0 +1,259 @@
+"""
+MCP Server を Copilot Studio v2 (cliagent) エージェントに API だけで追加する【正準スクリプト】
+================================================================================
+実機検証済み。手動 UI 接続の前後で Dataverse レコードに差分が無かったことから、
+以下の API 手順が「Dataverse 側の完全な必要要件」であることを確認済み。
+
+要点（ハマりどころ）:
+  1) McpTool は botcomponent type=9 / data に kind:McpTool
+     （connectorId / authMode / connectionReference / operationId）
+  2) operationId は コネクタ Swagger の x-ms-agentic-protocol=mcp-streamable-1.0 の POST 操作
+       例) Dataverse = InvokeMCP, Work IQ OneDrive = mcp_OneDriveRemoteServer
+  3) ★接続参照(connectionReference)の論理名は厳密な規約に従う:
+       {botschema}.cr.{connector}.{接続GUID}
+       - コネクタ名は「フル」（shared_commondataserviceforapps をそのまま）。
+         切詰め名だと公開時に「1 missing connection reference」で失敗する。
+       - 接続名末尾の GUID（ハイフン有無は接続名に合わせる）
+       - 100 文字を超える場合のみコネクタ名末尾を切詰（UI 互換フォールバック）
+  4) ツール name/schemaname は UI 形式に合わせる:
+       name="<表示名> — <表示名>"
+       schemaname="{botschema}.tool.{Ascii表示名}-{Ascii表示名}_{乱数3}"
+  5) ★接続の事前承認: 対象コネクタの Connected な接続が環境に存在している必要がある
+       （接続自体は API 作成不可。未承認なら make.powerautomate.com で一度作成/承認）
+  6) ★公開後に UI で MCP サーバーの「確認(Confirm)」が一度必要（正常系の一部）。
+       references/mcp-servers.md を参照。
+
+使い方:
+  python add_mcp_server.py --connector shared_commondataserviceforapps \
+      --display "Microsoft Dataverse MCP サーバー"
+  python add_mcp_server.py --connector shared_workiqonedrive \
+      --display "Work IQ OneDrive (Preview)"
+  ※ --bot 省略時は .env の AGENT_SCHEMA / AGENT_BOTID から解決
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import uuid
+from pathlib import Path
+
+import requests
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+_STD = Path(__file__).resolve().parents[2] / "standard" / "scripts"
+sys.path.insert(0, str(_STD))
+from auth_helper import (  # noqa: E402
+    api_get, api_post, api_patch, get_session, get_token, DATAVERSE_URL,
+)
+
+API = f"{DATAVERSE_URL}/api/data/v9.2"
+PREFIX = os.getenv("PUBLISHER_PREFIX", "geek").strip()
+SOLUTION_NAME = os.getenv("SOLUTION_NAME", "").strip()
+AGENT_SCHEMA_DEFAULT = os.getenv("AGENT_SCHEMA", "").strip()
+AGENT_BOTID_DEFAULT = os.getenv("AGENT_BOTID", "").strip()
+
+# 既知 MCP コネクタの operationId フォールバック（Swagger 取得不可時）
+KNOWN_MCP_OPS = {
+    "shared_commondataserviceforapps": "InvokeMCP",          # Dataverse MCP
+    "shared_workiqonedrive": "mcp_OneDriveRemoteServer",     # Work IQ OneDrive (Preview)
+}
+
+
+def resolve_env_id() -> str:
+    tok = get_token(scope="https://service.flow.microsoft.com/.default")
+    r = requests.get(
+        "https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01",
+        headers={"Authorization": f"Bearer {tok}"}, timeout=60)
+    r.raise_for_status()
+    dv = DATAVERSE_URL.rstrip("/")
+    return next(e["name"] for e in r.json()["value"]
+                if (e["properties"].get("linkedEnvironmentMetadata", {}).get("instanceUrl", "") or "").rstrip("/") == dv)
+
+
+def resolve_bot(bot_arg: str | None) -> tuple[str, str]:
+    """戻り値: (botid, schemaname)"""
+    bot_arg = bot_arg or AGENT_BOTID_DEFAULT or AGENT_SCHEMA_DEFAULT
+    if bot_arg and re.fullmatch(r"[0-9a-fA-F-]{36}", bot_arg):
+        b = api_get(f"bots({bot_arg})?$select=botid,schemaname")
+        return b["botid"], b["schemaname"]
+    if not bot_arg:
+        bf = Path("agent_botid.txt")
+        if bf.exists():
+            bot_arg = bf.read_text(encoding="utf-8").strip()
+            b = api_get(f"bots({bot_arg})?$select=botid,schemaname")
+            return b["botid"], b["schemaname"]
+    res = api_get(f"bots?$select=botid,schemaname&$filter=schemaname eq '{bot_arg}'")
+    if not res.get("value"):
+        print(f"  ❌ エージェントが見つかりません (schema={bot_arg})", file=sys.stderr)
+        sys.exit(1)
+    b = res["value"][0]
+    return b["botid"], b["schemaname"]
+
+
+def find_connection(env_id: str, connector: str) -> str:
+    """Connected な接続の name を返す。"""
+    tok = get_token(scope="https://service.powerapps.com/.default")
+    r = requests.get(
+        f"https://api.powerapps.com/providers/Microsoft.PowerApps/apis/{connector}/connections",
+        headers={"Authorization": f"Bearer {tok}"},
+        params={"api-version": "2016-11-01", "$filter": f"environment eq '{env_id}'"}, timeout=120)
+    r.raise_for_status()
+    for conn in r.json().get("value", []):
+        if any(s.get("status") == "Connected" for s in conn.get("properties", {}).get("statuses", [])):
+            return conn["name"]
+    print(f"  ❌ Connected な {connector} 接続がありません。"
+          f"make.powerautomate.com で接続を作成/承認してください。", file=sys.stderr)
+    sys.exit(1)
+
+
+def _fetch_swagger(env_id: str, connector: str):
+    tok = get_token(scope="https://service.powerapps.com/.default")
+    for params in (
+        {"api-version": "2016-11-01", "$filter": f"environment eq '{env_id}'", "$expand": "properties/apiDefinitions"},
+        {"api-version": "2016-11-01", "$filter": f"environment eq '{env_id}'", "$expand": "apiDefinitions"},
+    ):
+        r = requests.get(f"https://api.powerapps.com/providers/Microsoft.PowerApps/apis/{connector}",
+                         headers={"Authorization": f"Bearer {tok}"}, params=params, timeout=120)
+        if r.status_code != 200:
+            continue
+        props = r.json().get("properties", {})
+        swurl = (props.get("apiDefinitions", {}) or {}).get("originalSwaggerUrl") or props.get("swagger")
+        if isinstance(swurl, dict):
+            return swurl
+        if isinstance(swurl, str) and swurl.startswith("http"):
+            s = requests.get(swurl, timeout=120)
+            if s.status_code == 200:
+                return s.json()
+    return None
+
+
+def discover_operation_id(env_id: str, connector: str) -> str:
+    """Swagger から x-ms-agentic-protocol=mcp-streamable-1.0 の POST operationId を取得。"""
+    sw = _fetch_swagger(env_id, connector)
+    if sw:
+        for _path, methods in sw.get("paths", {}).items():
+            for m, op in methods.items():
+                if isinstance(op, dict) and m.lower() == "post" \
+                        and op.get("x-ms-agentic-protocol") == "mcp-streamable-1.0":
+                    return op.get("operationId")
+    if connector in KNOWN_MCP_OPS:
+        print(f"  ⚠ Swagger 取得不可 → 既知フォールバック使用: {KNOWN_MCP_OPS[connector]}")
+        return KNOWN_MCP_OPS[connector]
+    print("  ❌ operationId を検出できません。--operation で明示指定してください。", file=sys.stderr)
+    sys.exit(1)
+
+
+def build_connref_logical(bot_schema: str, connector: str, connection_name: str) -> str:
+    """UI と同一規約: {botschema}.cr.{connector}.{接続GUID}。
+    100 文字超のときのみコネクタ名末尾を切詰める（UI 互換フォールバック）。"""
+    m = re.search(r"[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}",
+                  connection_name)
+    guid = m.group(0) if m else connection_name
+    name = f"{bot_schema}.cr.{connector}.{guid}"
+    if len(name) > 100:
+        overflow = len(name) - 100
+        name = f"{bot_schema}.cr.{connector[:max(0, len(connector) - overflow)]}.{guid}"
+    return name
+
+
+def ensure_connref(logical: str, connector: str, connection_name: str, display: str):
+    existing = api_get("connectionreferences?$select=connectionreferenceid,connectionid"
+                       f"&$filter=connectionreferencelogicalname eq '{logical}'")
+    if existing.get("value"):
+        ref = existing["value"][0]
+        if ref.get("connectionid") != connection_name:
+            api_patch(f"connectionreferences({ref['connectionreferenceid']})", {"connectionid": connection_name})
+        print(f"  接続参照 既存: {logical}")
+        return
+    api_post("connectionreferences", {
+        "connectionreferencelogicalname": logical,
+        "connectionreferencedisplayname": display,
+        "connectorid": f"/providers/Microsoft.PowerApps/apis/{connector}",
+        "connectionid": connection_name,
+    }, solution=SOLUTION_NAME or None)
+    print(f"  ✅ 接続参照 作成: {logical} (len={len(logical)})")
+
+
+def create_mcp_tool(sess, bot_id: str, bot_schema: str, connector: str,
+                    operation_id: str, connref_logical: str, display: str) -> str:
+    ascii_name = re.sub(r"[^A-Za-z0-9]+", "", display) or "McpServer"
+    schema = f"{bot_schema}.tool.{ascii_name}-{ascii_name}_{uuid.uuid4().hex[:3].upper()}"
+
+    # 冪等化: 同コネクタの McpTool を削除
+    res = api_get(f"botcomponents?$select=botcomponentid,data"
+                  f"&$filter=_parentbotid_value eq {bot_id} and componenttype eq 9")
+    for c in res.get("value", []):
+        d = c.get("data") or ""
+        if "McpTool" in d and connector in d:
+            sess.delete(f"{API}/botcomponents({c['botcomponentid']})")
+            print(f"  🧹 既存 MCP ツール削除: {c['botcomponentid']}")
+
+    data = (
+        "kind: McpTool\r\n"
+        f"connectorId: /providers/Microsoft.PowerApps/apis/{connector}\r\n"
+        "authMode: Invoker\r\n"
+        f"connectionReference: {connref_logical}\r\n"
+        f"operationId: {operation_id}"
+    )
+    body = {
+        "name": f"{display} — {display}",
+        "schemaname": schema,
+        "componenttype": 9,
+        "description": display,
+        "data": data,
+        "parentbotid@odata.bind": f"/bots({bot_id})",
+    }
+    headers = {"Prefer": "return=representation"}
+    if SOLUTION_NAME:
+        headers["MSCRM.SolutionName"] = SOLUTION_NAME
+    r = sess.post(f"{API}/botcomponents", json=body, headers=headers)
+    if r.status_code not in (200, 201):
+        print("  ❌ ツール作成失敗:", r.status_code, r.text[:600], file=sys.stderr)
+        sys.exit(1)
+    cid = r.json()["botcomponentid"]
+    print(f"  ✅ MCP ツール作成: {cid}\n     schemaname: {schema}")
+    return cid
+
+
+def add_mcp_server(sess, bot_id: str, bot_schema: str, connector: str,
+                   display: str, operation: str | None = None) -> str:
+    """MCP 追加のオーケストレーション。deploy_agent.py からも import して再利用する。"""
+    env_id = resolve_env_id()
+    conn_name = find_connection(env_id, connector)
+    print(f"  接続: {conn_name}")
+    op_id = operation or discover_operation_id(env_id, connector)
+    print(f"  operationId: {op_id}")
+    connref = build_connref_logical(bot_schema, connector, conn_name)
+    print(f"  接続参照 規約名: {connref}")
+    ensure_connref(connref, connector, conn_name, f"{display} (MCP)")
+    return create_mcp_tool(sess, bot_id, bot_schema, connector, op_id, connref, display)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Copilot Studio v2 エージェントに MCP Server を追加")
+    ap.add_argument("--connector", default="shared_commondataserviceforapps",
+                    help="MCP コネクタ名（既定: Dataverse）")
+    ap.add_argument("--display", default="Microsoft Dataverse MCP サーバー", help="ツール表示名")
+    ap.add_argument("--bot", default=None, help="botid または schemaname（既定: .env / agent_botid.txt）")
+    ap.add_argument("--operation", default=None, help="operationId（省略時は Swagger から自動検出）")
+    args = ap.parse_args()
+
+    print("=" * 60)
+    print(f"  MCP Server 追加: {args.display} ({args.connector})")
+    print("=" * 60)
+    bot_id, bot_schema = resolve_bot(args.bot)
+    print(f"  エージェント: {bot_schema} ({bot_id})")
+
+    sess = get_session()
+    add_mcp_server(sess, bot_id, bot_schema, args.connector, args.display, args.operation)
+
+    print("\n✅ 完了。Copilot Studio でエージェントを公開してください。")
+    print("   ※ 公開後、UI で MCP サーバーの「確認(Confirm)」が一度必要な場合があります"
+          "（references/mcp-servers.md）。")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/copilot-studio-v2/scripts/deploy_agent.py
+++ b/.github/skills/copilot-studio-v2/scripts/deploy_agent.py
@@ -1,0 +1,72 @@
+"""
+Copilot Studio v2 (cliagent) エージェントを API だけでフル自動デプロイするオーケストレーター。
+================================================================================
+以下を順に実行する（各ステップは個別スクリプトとしても実行可能）:
+  1) create_agent.py   … cliagent Bot を API 作成 + プロビジョニング待ち（agent_botid.txt を出力）
+  2) set_icon.py       … アイコン登録（240 / Teams color 192 / outline 32）
+  3) attach_skill.py   … フラット Python スキルを添付（type=9 + type=14）
+  4) add_mcp_server.py … MCP サーバーを追加（MCP_CONNECTORS の各コネクタ）
+  5) publish_agent.py  … PvaPublish で公開
+
+各ステップは agent_botid.txt（cwd）でエージェントを受け渡すため、同一作業ディレクトリで実行する。
+
+.env パラメータ（詳細は references/.env.example）:
+  AGENT_NAME / AGENT_SCHEMA / AGENT_MODEL_SERIES / AGENT_INSTRUCTIONS
+  SKILL_DIR / SKILL_NAME / SKILL_DESCRIPTION
+  ICON_TEXT / ICON_BG_COLOR / ICON_ACCENT_COLOR
+  MCP_CONNECTORS   追加する MCP を "connector|表示名" 形式でカンマ区切り。例:
+                   shared_commondataserviceforapps|Microsoft Dataverse MCP サーバー,
+                   shared_workiqonedrive|Work IQ OneDrive (Preview)
+                   （空なら MCP 追加をスキップ）
+
+実行: python deploy_agent.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+HERE = Path(__file__).resolve().parent
+PY = sys.executable
+
+
+def run(script: str, *args: str) -> None:
+    cmd = [PY, str(HERE / script), *args]
+    print(f"\n{'=' * 64}\n▶ {script} {' '.join(args)}\n{'=' * 64}")
+    r = subprocess.run(cmd, env=os.environ.copy())
+    if r.returncode != 0:
+        print(f"❌ {script} が失敗しました（exit={r.returncode}）", file=sys.stderr)
+        sys.exit(r.returncode)
+
+
+def main() -> None:
+    run("create_agent.py")
+    run("set_icon.py")
+
+    skill_dir = os.getenv("SKILL_DIR", "skill")
+    if (Path.cwd() / skill_dir).is_dir():
+        run("attach_skill.py")
+    else:
+        print(f"\n⏭ スキルディレクトリ '{skill_dir}' が無いため attach_skill をスキップ")
+
+    mcp_spec = os.getenv("MCP_CONNECTORS", "").strip()
+    for entry in [e for e in mcp_spec.split(",") if e.strip()]:
+        parts = entry.split("|", 1)
+        connector = parts[0].strip()
+        display = parts[1].strip() if len(parts) > 1 else connector
+        run("add_mcp_server.py", "--connector", connector, "--display", display)
+
+    run("publish_agent.py")
+
+    print("\n" + "=" * 64)
+    print("✅ デプロイ完了。確認: pac copilot list（Published / Active / Provisioned）")
+    print("   ※ MCP を含む場合は、Copilot Studio UI で MCP サーバーの「確認(Confirm)」を")
+    print("     一度実施してから利用してください（references/mcp-servers.md）。")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/copilot-studio-v2/scripts/publish_agent.py
+++ b/.github/skills/copilot-studio-v2/scripts/publish_agent.py
@@ -1,0 +1,74 @@
+"""
+Copilot Studio v2 (cliagent) エージェントを API で公開する。
+================================================================================
+PvaPublish アクションを呼ぶ。プロビジョニング直後は一時的に失敗することがあるため
+数回リトライする。
+
+★公開状態の確認は `pac copilot list`（Published / Active / Provisioned）が正。
+  cliagent では bots.publishedon が None のままになることがある。
+
+★MCP サーバーを含むエージェントは、公開後に Copilot Studio UI で MCP サーバーの
+  「確認(Confirm)」が一度必要（正常系の一部）。再公開だけではエラーが消えないことがある。
+  詳細は references/mcp-servers.md を参照。
+
+.env パラメータ:
+  AGENT_BOTID / AGENT_SCHEMA   対象エージェント（未指定なら agent_botid.txt）
+
+実行: python publish_agent.py
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+_STD = Path(__file__).resolve().parents[2] / "standard" / "scripts"
+sys.path.insert(0, str(_STD))
+from auth_helper import api_get, get_session, DATAVERSE_URL  # noqa: E402
+
+API = f"{DATAVERSE_URL}/api/data/v9.2"
+
+
+def resolve_bot() -> str:
+    bot = os.getenv("AGENT_BOTID", "").strip()
+    if bot and re.fullmatch(r"[0-9a-fA-F-]{36}", bot):
+        return bot
+    schema = os.getenv("AGENT_SCHEMA", "").strip()
+    if schema:
+        res = api_get(f"bots?$select=botid&$filter=schemaname eq '{schema}'").get("value")
+        if res:
+            return res[0]["botid"]
+    bf = Path("agent_botid.txt")
+    if bf.exists():
+        return bf.read_text(encoding="utf-8").strip()
+    print("Error: AGENT_BOTID / AGENT_SCHEMA / agent_botid.txt のいずれかが必要です。", file=sys.stderr)
+    sys.exit(1)
+
+
+def publish(sess, bot_id: str, retries: int = 3) -> bool:
+    for attempt in range(retries):
+        r = sess.post(f"{API}/bots({bot_id})/Microsoft.Dynamics.CRM.PvaPublish", json={})
+        if r.status_code in (200, 204):
+            print(f"  ✅ 公開成功 (status={r.status_code})")
+            return True
+        print(f"  ⚠️ 公開リトライ {attempt + 1}/{retries}: {r.status_code} {r.text[:300]}")
+        time.sleep(10)
+    print("  ❌ 公開に失敗しました。Copilot Studio UI で公開してください。", file=sys.stderr)
+    return False
+
+
+def main() -> None:
+    bot_id = resolve_bot()
+    sess = get_session()
+    print(f"公開: bot={bot_id}")
+    publish(sess, bot_id)
+    print("確認: pac copilot list（Published / Active / Provisioned）")
+    print("※ MCP を含む場合は UI で MCP サーバーの「確認(Confirm)」が一度必要なことがあります。")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/copilot-studio-v2/scripts/set_icon.py
+++ b/.github/skills/copilot-studio-v2/scripts/set_icon.py
@@ -1,0 +1,154 @@
+"""
+Copilot Studio v2 (cliagent) エージェントにアイコンを API で登録する。
+================================================================================
+Pillow でアイコン PNG を生成し、3 か所へ登録する:
+  - bots.iconbase64                         … 240x240（生 base64。data: 接頭辞なし）
+  - applicationmanifestinformation.teams.colorIcon   … 192x192
+  - applicationmanifestinformation.teams.outlineIcon … 32x32（白・透明背景）
+
+★ハマりどころ: bots を PATCH する際は name 列を必ず含める（無いと 0x80040265 エラー）。
+
+アイコン意匠（汎用）: 角丸の単色背景＋中央に頭文字（ICON_TEXT）。任意で右下にアクセントの
+丸バッジを描く。色・頭文字は .env で差し替え可能。独自意匠にしたい場合は draw_icon() を
+プロジェクト側で上書きする（references/icon-and-publish.md 参照）。
+
+.env パラメータ:
+  AGENT_BOTID / AGENT_SCHEMA   対象エージェント（未指定なら agent_botid.txt）
+  ICON_TEXT                    頭文字（既定: エージェント名の先頭1文字）
+  ICON_BG_COLOR                背景色 HEX（既定: #2563EB）
+  ICON_ACCENT_COLOR            アクセント色 HEX（既定: 空＝バッジ無し）
+
+実行: python set_icon.py
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+_STD = Path(__file__).resolve().parents[2] / "standard" / "scripts"
+sys.path.insert(0, str(_STD))
+from auth_helper import api_get, get_session, DATAVERSE_URL  # noqa: E402
+
+API = f"{DATAVERSE_URL}/api/data/v9.2"
+
+ICON_TEXT = os.getenv("ICON_TEXT", "").strip()
+BG_HEX = os.getenv("ICON_BG_COLOR", "#2563EB").strip()
+ACCENT_HEX = os.getenv("ICON_ACCENT_COLOR", "").strip()
+WHITE = (255, 255, 255, 255)
+
+
+def _hex_rgba(h: str, default=(37, 99, 235)) -> tuple:
+    h = (h or "").lstrip("#")
+    if len(h) == 6:
+        return (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16), 255)
+    return (*default, 255)
+
+
+def _font(size: int):
+    try:
+        return ImageFont.load_default(size=size)  # Pillow >= 10
+    except TypeError:
+        return ImageFont.load_default()
+
+
+def draw_icon(size: int, text: str, *, transparent_bg: bool = False, outline_only: bool = False) -> Image.Image:
+    """角丸背景＋中央頭文字＋任意のアクセントバッジ。"""
+    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    d = ImageDraw.Draw(img)
+    s = size
+    bg = _hex_rgba(BG_HEX)
+    accent = _hex_rgba(ACCENT_HEX, default=(34, 197, 94)) if ACCENT_HEX else None
+    fg = WHITE
+
+    if not (transparent_bg or outline_only):
+        d.rounded_rectangle([0, 0, s - 1, s - 1], radius=int(s * 0.22), fill=bg)
+
+    # 中央の頭文字
+    glyph = (text or "A")[:2]
+    font = _font(int(s * (0.5 if len(glyph) == 1 else 0.38)))
+    try:
+        bbox = d.textbbox((0, 0), glyph, font=font)
+        tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+        tx = (s - tw) / 2 - bbox[0]
+        ty = (s - th) / 2 - bbox[1] - s * 0.02
+    except Exception:
+        tw = th = s * 0.4
+        tx, ty = (s - tw) / 2, (s - th) / 2
+    if outline_only:
+        d.text((tx, ty), glyph, font=font, fill=fg, stroke_width=max(1, int(s * 0.03)), stroke_fill=fg)
+    else:
+        d.text((tx, ty), glyph, font=font, fill=fg)
+
+    # 右下アクセントバッジ
+    if accent and not outline_only:
+        r = s * 0.20
+        bx, by = s * 0.76, s * 0.76
+        d.ellipse([bx - r, by - r, bx + r, by + r], fill=accent, outline=WHITE, width=max(1, int(s * 0.02)))
+        chk = [(bx - r * 0.45, by + r * 0.02), (bx - r * 0.08, by + r * 0.38), (bx + r * 0.50, by - r * 0.40)]
+        d.line(chk, fill=fg, width=max(2, int(s * 0.05)), joint="curve")
+
+    return img
+
+
+def to_b64(img: Image.Image) -> str:
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def resolve_bot() -> str:
+    bot = os.getenv("AGENT_BOTID", "").strip()
+    if bot and re.fullmatch(r"[0-9a-fA-F-]{36}", bot):
+        return bot
+    schema = os.getenv("AGENT_SCHEMA", "").strip()
+    if schema:
+        res = api_get(f"bots?$select=botid&$filter=schemaname eq '{schema}'").get("value")
+        if res:
+            return res[0]["botid"]
+    bf = Path("agent_botid.txt")
+    if bf.exists():
+        return bf.read_text(encoding="utf-8").strip()
+    print("Error: AGENT_BOTID / AGENT_SCHEMA / agent_botid.txt のいずれかが必要です。", file=sys.stderr)
+    sys.exit(1)
+
+
+def set_icon(sess, bot_id: str, text: str | None = None) -> None:
+    name = api_get(f"bots({bot_id})?$select=name")["name"]
+    text = (text or ICON_TEXT or name[:1]).upper()
+    icon_main = to_b64(draw_icon(240, text))
+    icon_color = to_b64(draw_icon(192, text))
+    icon_outline = to_b64(draw_icon(32, text, transparent_bg=True, outline_only=True))
+
+    r = sess.patch(f"{API}/bots({bot_id})", json={"name": name, "iconbase64": icon_main})
+    print(f"  iconbase64(240): {r.status_code}")
+
+    bd = api_get(f"bots({bot_id})?$select=name,applicationmanifestinformation")
+    ami = json.loads(bd.get("applicationmanifestinformation") or "{}")
+    teams = ami.setdefault("teams", {})
+    teams["colorIcon"] = icon_color
+    teams["outlineIcon"] = icon_outline
+    teams.setdefault("accentColor", BG_HEX)
+    r = sess.patch(f"{API}/bots({bot_id})",
+                   json={"name": name, "applicationmanifestinformation": json.dumps(ami)})
+    print(f"  Teams colorIcon/outlineIcon: {r.status_code}")
+
+
+def main() -> None:
+    bot_id = resolve_bot()
+    sess = get_session()
+    print(f"アイコン登録: bot={bot_id}")
+    set_icon(sess, bot_id)
+    print("✅ 完了")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Copilot Studio v2(cliagent) スキルに、アイコン登録・MCP サーバー追加(Dataverse / Work IQ)・公開(PvaPublish)・公開後の手動Confirm(正常系)を反映。新規スクリプト set_icon.py / add_mcp_server.py / publish_agent.py / deploy_agent.py と references/mcp-servers.md / icon-and-publish.md を追加。validate_skill.py PASS。