### PR TITLE
code-apps: 一覧の検索・フィルター・所有者列とステージ矢羽パターンを追加

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -268,8 +268,21 @@ SDK の `getContext().app.queryParams` で親ウィンドウの URL パラメー
 SDK 生成サービスは Lookup 名フィールド（`createdbyname` 等）を返さない。
 `_xxx_value`（GUID）+ `useMemo` マップで名前解決する。
 データソース未登録テーブルの場合は OData FormattedValue アノテーションを使う。
+**所有者（「誰のレコードか」）の表示は `_owninguser_value` + `systemusers` Map で解決する**（取得 hook の `$select` に `_owninguser_value` を含めること）。
 
 → 詳細: **[Lookup 名前解決リファレンス](references/lookup-resolution.md)**
+
+### 一覧の検索・フィルター・重要列（所有者・金額）
+
+営業系の一覧は名称検索だけで終わらせず、**所有者列・金額列などの重要項目を表示し、ステータス／所有者で絞り込み・横断検索できる**構成を標準とする。所有者フィルターは実データに存在する所有者のみを列挙し、絞り込み結果の件数・合計をツールバーに表示する。
+
+→ 詳細: **[CRUD UI 標準パターン](references/crud-ui-pattern.md)** の「一覧の検索・フィルター・重要列」
+
+### ステージ矢羽（Stage Path）— OptionSet の進捗を可視化＆クリックで変更
+
+商談ステージ・リードステータス等、順序を持つ OptionSet を Salesforce 風の矢羽（シェブロン）で表示する。`onSelect` でその場ステージ変更（patch）も可能。失注・不認定など否定的終端は `negativeValue` で赤表示。
+
+→ 詳細: **[ステージ矢羽パターン](references/stage-path-pattern.md)**
 
 ### scaffold 時に含めないファイル
 
@@ -318,9 +331,10 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 | [デザインテンプレート集](references/design-templates.md) | 設計時に選択する配色テンプレート 6 種（プレビュー HTML・CSS Variables 一式・light/dark 対応） |
 | [デザインシステム](references/design-system.md) | shadcn/ui + Tailwind CSS v4 のコンポーネント選定・画面設計パターン |
 | [コンポーネントカタログ](references/component-catalog.md) | 全コンポーネントの詳細仕様・使用例 |
+| [ステージ矢羽パターン](references/stage-path-pattern.md) | OptionSet（ステージ／ステータス）を Salesforce 風の矢羽で可視化・クリックで変更 |
 | [構築リファレンス](references/build-reference.md) | ビルド・デプロイの詳細手順・vite.config.ts 必須設定・TypeScript エラー対処 |
 | [データソースパターン](references/data-source-patterns.md) | SDK 生成サービス・dataSourcesInfo・getClient(dataSourcesInfo)・TanStack React Query |
-| [Lookup 名前解決](references/lookup-resolution.md) | クライアントサイド名前解決・OData FormattedValue パターン |
+| [Lookup 名前解決](references/lookup-resolution.md) | クライアントサイド名前解決・OData FormattedValue パターン・所有者（Owner）列の表示 |
 | [日本語サニタイズ](references/japanese-sanitize.md) | 日本語 DisplayName エラーの回避（toggle_table_lang.py / patch-nameutils.cjs） |
 | [CSP 構成](references/csp.md) | iframe 埋め込み・外部 API 接続時の CSP 設定・CSP 安全な SDK メソッド一覧 |
 | [ユーザー識別](references/user-identity.md) | ログインユーザーの systemuserid 取得パターン（CSP 安全） |

--- a/.github/skills/code-apps/references/component-catalog.md
+++ b/.github/skills/code-apps/references/component-catalog.md
@@ -17,6 +17,7 @@
 |--------------|-----------|------|-----------|
 | `ListTable` | `@/components/list-table` | 検索・ソート・ページネーション付きテーブル | `data: T[]`, `columns: TableColumn<T>[]`, `filters?: FilterConfig<T>[]`, `searchKeys?: string[]` |
 | `InlineEditTable` | `@/components/inline-edit-table` | インライン編集テーブル（text/textarea/lookup/select）、行追加・削除、CSV インポート対応 | `data: T[]`, `columns: EditableColumn<T>[]`, `onUpdate`, `onAdd`, `onDelete` |
+| `StagePath` | `@/components/stage-path` | OptionSet（ステージ/ステータス）を Salesforce 風の矢羽で表示・クリックで変更。詳細は [ステージ矢羽パターン](stage-path-pattern.md) | `stages: StagePathItem[]`, `current?: number`, `negativeValue?: number`, `onSelect?` |
 
 #### ListTable の列定義
 

--- a/.github/skills/code-apps/references/crud-ui-pattern.md
+++ b/.github/skills/code-apps/references/crud-ui-pattern.md
@@ -220,6 +220,97 @@ return editing ? (
 
 ---
 
+## 一覧の検索・フィルター・重要列（標準）
+
+一覧は単なる名称検索で終わらせず、**「誰のレコードか（所有者）」「金額などの重要数値」を列として表示し、それらで絞り込み・検索できる**ようにする。営業系（リード・商談・活動・キャンペーン等）の一覧はこの構成を標準とする。
+
+### 構成要素
+
+| 要素 | 内容 |
+|---|---|
+| 検索ボックス | 名称＋関連名（取引先名・会社名・メール等）を横断検索 |
+| フィルター（ステータス/ステージ） | OptionSet ラベルから `Select` を生成。`"all"` で全件 |
+| フィルター（所有者） | **実データに存在する所有者のみ**列挙（全ユーザーを出さない） |
+| 重要列（所有者） | `_owninguser_value` + systemusers Map で名前表示（→ [Lookup 名前解決](lookup-resolution.md)） |
+| 重要列（金額） | `formatCurrency`。絞り込み結果の**合計**もツールバーに表示 |
+| 件数・合計表示 | `{filtered.length} 件 / 合計 {formatCurrency(total)}` |
+
+### 実装パターン
+
+```tsx
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+const { data: rows = [] } = useOpportunities()
+const { data: users = [] } = useSystemUsers()
+
+const [search, setSearch] = useState("")
+const [stageFilter, setStageFilter] = useState("all")
+const [ownerFilter, setOwnerFilter] = useState("all")
+
+// 所有者名の Map（→ lookup-resolution.md）
+const userMap = useMemo(() => {
+  const m = new Map<string, string>()
+  users.forEach((u) => m.set(u.systemuserid, u.fullname ?? ""))
+  return m
+}, [users])
+
+// フィルターの所有者候補は「実データに存在する所有者」だけ
+const ownerOptions = useMemo(() => {
+  const ids = new Set<string>()
+  rows.forEach((r) => { if (r._owninguser_value) ids.add(r._owninguser_value) })
+  return Array.from(ids).map((id) => ({ id, name: userMap.get(id) ?? id }))
+}, [rows, userMap])
+
+// 検索 + フィルターを一度に適用
+const filtered = useMemo(() => {
+  const s = search.toLowerCase()
+  return rows.filter((r) => {
+    if (s) {
+      const acc = r._{prefix}_accountid_value ? (accountMap.get(r._{prefix}_accountid_value) ?? "").toLowerCase() : ""
+      if (!r.{prefix}_name?.toLowerCase().includes(s) && !acc.includes(s)) return false
+    }
+    if (stageFilter !== "all" && String(r.{prefix}_stage) !== stageFilter) return false
+    if (ownerFilter !== "all" && r._owninguser_value !== ownerFilter) return false
+    return true
+  })
+}, [rows, search, stageFilter, ownerFilter, accountMap])
+
+const totalAmount = useMemo(() => filtered.reduce((sum, r) => sum + (r.{prefix}_amount ?? 0), 0), [filtered])
+```
+
+ツールバー（検索 + 2 フィルター + 件数/合計）:
+
+```tsx
+<div className="flex flex-wrap items-center gap-2">
+  <div className="relative w-full max-w-xs">
+    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+    <Input placeholder="商談名・取引先で検索..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+  </div>
+  <Select value={stageFilter} onValueChange={setStageFilter}>
+    <SelectTrigger className="w-36"><SelectValue placeholder="ステージ" /></SelectTrigger>
+    <SelectContent>
+      <SelectItem value="all">全ステージ</SelectItem>
+      {Object.entries(opportunityStageLabels).map(([k, v]) => <SelectItem key={k} value={k}>{v}</SelectItem>)}
+    </SelectContent>
+  </Select>
+  <Select value={ownerFilter} onValueChange={setOwnerFilter}>
+    <SelectTrigger className="w-44"><SelectValue placeholder="所有者" /></SelectTrigger>
+    <SelectContent>
+      <SelectItem value="all">全所有者</SelectItem>
+      {ownerOptions.map((o) => <SelectItem key={o.id} value={o.id}>{o.name}</SelectItem>)}
+    </SelectContent>
+  </Select>
+  <div className="ml-auto text-sm text-muted-foreground">
+    {filtered.length} 件 / 合計 <span className="font-semibold text-foreground">{formatCurrency(totalAmount)}</span>
+  </div>
+</div>
+```
+
+> **所有者列を表示するには `$select` に `_owninguser_value` を含めること**（Dataverse のデータ取得 hook 側）。値の解決は [Lookup 名前解決リファレンス](lookup-resolution.md) の「所有者（Owner）列」を参照。
+> レスポンシブで列を出し分ける場合は `hidden md:table-cell` / `hidden lg:table-cell` / `hidden xl:table-cell` を使い、重要列（所有者・金額）は早い段階（`md`/`lg`）で表示する。
+
+---
+
 ## チェックリスト（CRUD 画面実装時）
 
 - [ ] 一覧の行／カード全体がクリックで詳細を開く（`cursor-pointer` + ホバー）
@@ -230,3 +321,7 @@ return editing ? (
 - [ ] 詳細は ID 保持＋クエリ導出で最新値を反映
 - [ ] 対象切替時に編集モードをリセット（`useEffect`）
 - [ ] 削除確認は `useConfirm()` モーダル（ブラウザ `confirm()` を使わない）
+- [ ] 一覧に所有者列・重要数値列（金額等）を表示している
+- [ ] ステータス/ステージと所有者で絞り込め、名称＋関連名で検索できる
+- [ ] 所有者フィルターは実データに存在する所有者のみ列挙している
+- [ ] 所有者表示用に `$select` へ `_owninguser_value` を含めている

--- a/.github/skills/code-apps/references/lookup-resolution.md
+++ b/.github/skills/code-apps/references/lookup-resolution.md
@@ -54,6 +54,53 @@ const columns = [
 ];
 ```
 
+## 所有者（Owner）列 — 「誰のレコードか」を表示
+
+「誰のレコードか」を一覧・詳細に表示するのは所有者 Lookup（`_owninguser_value`）の名前解決そのもの。`systemuser` テーブルをデータソースに追加し、`useMemo` Map で `systemuserid → fullname` を引く。
+
+### 1. `$select` に所有者列を含める（必須）
+
+SDK 生成サービスは指定した列しか返さない。**所有者を表示するテーブルの取得 hook の `$select` に `_owninguser_value` を必ず追加する。** これを忘れると `_owninguser_value` が `undefined` になり所有者が空欄になる。
+
+```typescript
+export function useOpportunities() {
+  return useQuery<Opportunity[]>({
+    queryKey: ["opportunities"],
+    queryFn: () => DataverseService.GetItems<Opportunity>("{prefix}_opportunities", {
+      select: ["{prefix}_opportunityid", "{prefix}_name", "{prefix}_amount", /* ... */, "_owninguser_value"],
+      orderBy: ["createdon desc"],
+    }),
+  })
+}
+```
+
+型にも追加する:
+
+```typescript
+export interface Opportunity {
+  // ...
+  _owninguser_value?: string
+}
+```
+
+### 2. systemusers の Map で名前解決
+
+```typescript
+const { data: users = [] } = useSystemUsers()
+const userMap = useMemo(() => {
+  const m = new Map<string, string>()
+  users.forEach((u) => m.set(u.systemuserid, u.fullname ?? ""))
+  return m
+}, [users])
+
+// 一覧の所有者セル
+<td>{row._owninguser_value ? userMap.get(row._owninguser_value) ?? "" : ""}</td>
+```
+
+> `useSystemUsers` は `systemusers` を `select: ["systemuserid", "fullname", "internalemailaddress"]`, `filter: "isdisabled eq false"` で取得する。`fullname` は省略可型のため Map 格納時は `?? ""` でフォールバックする（`Map<string, string>` の型エラー回避）。
+> 所有者でフィルター・検索する一覧 UI の組み込み方は [CRUD UI 標準パターン](crud-ui-pattern.md) の「一覧の検索・フィルター・重要列」を参照。
+> 所有者ベースのアクセス制御（自分のレコードのみ操作可など）は [owner-guard-pattern.md](owner-guard-pattern.md)。
+
 ## パターン 2: OData FormattedValue（データソース未登録テーブル向け）
 
 データソースに追加できないテーブルの Lookup 名は、

--- a/.github/skills/code-apps/references/stage-path-pattern.md
+++ b/.github/skills/code-apps/references/stage-path-pattern.md
@@ -1,0 +1,144 @@
+# ステージ矢羽（Stage Path / Chevron）パターン
+
+商談ステージ・リードステータス・案件進捗など、**順序を持つ選択肢（OptionSet）を Salesforce 風の矢羽（シェブロン）で表示し、クリックでステージを進められる**汎用コンポーネント。
+
+- 完了済みステージ＝塗りつぶし＋チェック、現在ステージ＝強調、未到達＝グレー
+- 「失注」「不認定」など否定的な終端ステージは赤系で表示（`negativeValue`）
+- `onSelect` を渡すとクリックで `value` を返す（詳細画面でその場ステージ変更 → patch）。省略すると読み取り専用表示
+
+> プレースホルダー `{prefix}` とテーブル名・OptionSet 値はプロジェクトに読み替える。コンポーネント本体はそのまま流用できる。
+
+---
+
+## コンポーネント本体
+
+`src/components/stage-path.tsx`:
+
+```tsx
+import { cn } from "@/lib/utils"
+
+export interface StagePathItem {
+  value: number
+  label: string
+}
+
+interface StagePathProps {
+  stages: StagePathItem[]
+  current?: number
+  /** 失注・不認定など否定的な終端ステージの値（赤系で表示） */
+  negativeValue?: number
+  onSelect?: (value: number) => void
+  className?: string
+}
+
+/**
+ * Salesforce 風のステージ矢羽（パス）表示。
+ * 完了済みステージは塗りつぶし、現在ステージは強調、未到達はグレー。
+ */
+export function StagePath({ stages, current, negativeValue, onSelect, className }: StagePathProps) {
+  const currentIndex = stages.findIndex((s) => s.value === current)
+  const isNegative = current !== undefined && current === negativeValue
+
+  return (
+    <div className={cn("flex w-full overflow-x-auto", className)}>
+      {stages.map((stage, idx) => {
+        const isCurrent = idx === currentIndex
+        const isCompleted = currentIndex >= 0 && idx < currentIndex
+        const isLastNegative = isNegative && stage.value === negativeValue
+
+        let toneClass: string
+        if (isLastNegative) {
+          toneClass = "bg-rose-600 text-white"
+        } else if (isCurrent) {
+          toneClass =
+            negativeValue !== undefined && idx === stages.length - 1
+              ? "bg-emerald-700 text-white"
+              : "bg-emerald-600 text-white"
+        } else if (isCompleted) {
+          toneClass = "bg-emerald-500/90 text-white"
+        } else {
+          toneClass = "bg-muted text-muted-foreground"
+        }
+
+        // 矢羽形状（先頭セルは左ノッチなし、それ以降は左右にノッチ）
+        const clip =
+          idx === 0
+            ? "polygon(0 0, calc(100% - 14px) 0, 100% 50%, calc(100% - 14px) 100%, 0 100%)"
+            : "polygon(0 0, calc(100% - 14px) 0, 100% 50%, calc(100% - 14px) 100%, 0 100%, 14px 50%)"
+
+        return (
+          <button
+            key={stage.value}
+            type="button"
+            disabled={!onSelect}
+            onClick={() => onSelect?.(stage.value)}
+            style={{ clipPath: clip, marginLeft: idx === 0 ? 0 : -10 }}
+            className={cn(
+              "relative flex h-9 min-w-[96px] flex-1 items-center justify-center px-4 text-xs font-medium whitespace-nowrap transition-colors",
+              toneClass,
+              onSelect && "cursor-pointer hover:brightness-110",
+              isCurrent && "font-semibold",
+            )}
+            title={stage.label}
+          >
+            <span className="flex items-center gap-1">
+              {(isCompleted || (isCurrent && !isLastNegative)) && (
+                <svg viewBox="0 0 16 16" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2.5">
+                  <path d="M3 8.5l3.5 3.5L13 4" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              )}
+              {stage.label}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+```
+
+---
+
+## 使い方（詳細画面でその場ステージ変更）
+
+`types` 側の OptionSet ラベル定義（プロジェクトの値に置き換え）:
+
+```typescript
+export enum OpportunityStage { Prospect = 100000000, Proposal = 100000001, Negotiation = 100000002, Won = 100000003, Lost = 100000004 }
+export const opportunityStageLabels: Record<OpportunityStage, string> = {
+  [OpportunityStage.Prospect]: "見込み", [OpportunityStage.Proposal]: "提案",
+  [OpportunityStage.Negotiation]: "交渉", [OpportunityStage.Won]: "受注", [OpportunityStage.Lost]: "失注",
+}
+```
+
+詳細画面:
+
+```tsx
+import { StagePath } from "@/components/stage-path"
+import { opportunityStageLabels } from "@/types"
+
+// ラベル定義から矢羽アイテムを生成
+const stagePathItems = Object.entries(opportunityStageLabels).map(([k, v]) => ({ value: Number(k), label: v }))
+
+const handleStageSelect = async (stage: number) => {
+  // OptionSet を直接 patch（楽観更新でもよい）
+  await updateOpportunity.mutateAsync({ id, body: { {prefix}_stage: stage } })
+  toast.success(`ステージを「${(opportunityStageLabels as Record<number, string>)[stage]}」に変更しました`)
+}
+
+<StagePath
+  stages={stagePathItems}
+  current={opportunity.{prefix}_stage}
+  negativeValue={100000004 /* 失注 */}
+  onSelect={handleStageSelect}
+/>
+```
+
+---
+
+## 設計上の注意
+
+- **TS7053（number index）対策**: `opportunityStageLabels[stage]` を number で引くと型エラーになる。`(opportunityStageLabels as Record<number, string>)[stage]` でキャストする。
+- **`negativeValue`**: 否定的終端（失注・不認定）を矢羽の最後に並べ、選択時のみ赤表示。完了チェックは付けない。
+- **読み取り専用**: `onSelect` を省略すると `disabled` ボタンとなり、一覧やカードのステータス可視化にも使える。
+- **クリックでステージ変更 → 通知フロー**: `onSelect` の patch を Power Automate（OptionSet 変更トリガー）と組み合わせると、ステージ変更時のメール通知などを自動化できる（[フロー連携](flow-integration.md)）。


### PR DESCRIPTION
## 概要

実プロジェクトで汎用化した 3 つの UI パターンを code-apps スキルに反映する。次回以降の Code Apps 開発で標準的に使えるようにする。

### 1. ステージ矢羽（Stage Path / Chevron）— 新規リファレンス
- `references/stage-path-pattern.md` を追加
- OptionSet（商談ステージ・リードステータス等）を Salesforce 風の矢羽で可視化
- 完了/現在/未到達を色分け、`negativeValue` で失注・不認定を赤表示
- `onSelect` でその場ステージ変更（patch）→ Power Automate 通知連携も可能
- TS7053（number index）対策・コンポーネント本体をそのまま流用可能な形で収録

### 2. 一覧の検索・フィルター・重要列 — crud-ui-pattern.md に追記
- 「誰のレコードか（所有者）」「金額などの重要数値」を列として表示する構成を標準化
- ステータス/ステージ + 所有者の 2 フィルター、名称＋関連名の横断検索
- 所有者フィルターは実データに存在する所有者のみ列挙
- 絞り込み結果の件数・合計をツールバーに表示
- 実装パターン（useMemo フィルター・ツールバー JSX）とチェックリスト項目を追加

### 3. 所有者（Owner）列の表示 — lookup-resolution.md に追記
- 「誰のレコードか」を `_owninguser_value` + `systemusers` Map で名前解決
- 取得 hook の `$select` に `_owninguser_value` を含める必須要件を明記
- `fullname` 省略可型に対する `?? ""` フォールバック（Map 型エラー回避）

### 索引・カタログ更新
- SKILL.md §4 に 2 セクション追加、§5 索引に stage-path-pattern を追加
- component-catalog.md に `StagePath` 行を追加

main ブランチへの新規 PR。既存のオープン PR（architecture 系）とは独立した内容のため別 PR としています。
