### PR TITLE
fix(dataverse): Lookup 既存衝突を事前チェックで回避し CreateOneToMany に統一

### DIFF
--- a/.github/skills/dataverse/SKILL.md
+++ b/.github/skills/dataverse/SKILL.md
@@ -199,11 +199,14 @@ existing_tables = api_get(f"EntityDefinitions?$filter=startswith(SchemaName,'{PR
 
 | ルール | 理由 |
 |--------|------|
+| **`CreateOneToMany` アクションで Lookup 作成** | `RelationshipDefinitions` POST は既存 Lookup との衝突時にエラーメッセージが不安定。`CreateOneToMany` の方が信頼性が高い |
+| **Lookup 作成前に属性存在チェック必須** | `api_get("EntityDefinitions(LogicalName='{from}')/Attributes(LogicalName='{col}')")` で存在確認。存在すればスキップ。`retry_metadata` の "already exists" 検出だけに頼らない |
+| **LOOKUPS 形式: `from_table`, `column_logical`, `display`, `to_table`** | シンプルな 4 キー構造。`SchemaName` は `{from_table}_{column_logical}` で自動生成 |
 | **`@odata.bind` にはナビゲーションプロパティ名（NavProp名）を使う** | 列の論理名ではない。大文字/小文字が区別される |
 | **NavProp 名は `ManyToOneRelationships` で動的取得** | `ReferencingEntityNavigationPropertyName` を確認する |
 | **NavProp 名を推測しない** | `get_navprop(from_logical, to_logical)` ヘルパーで取得 |
 | **Lookup は `NavProp@odata.bind` で設定** | `/{EntitySetName}({id})` の形式 |
-| **Lookup リレーション作成はべき等チェック** | `RelationshipDefinitions` POST が 400 で失敗しても、再実行時に「既存。スキップ」で通過。既存チェックロジック必須 |
+| **Lookup リレーション作成はべき等設計** | 属性存在チェック → 存在すればスキップ → 未存在なら `CreateOneToMany` → `retry_metadata` で二重保護 |
 
 ### ローカライズ
 

--- a/.github/skills/dataverse/scripts/setup_dataverse.py
+++ b/.github/skills/dataverse/scripts/setup_dataverse.py
@@ -136,18 +136,12 @@ TABLES = [
 
 LOOKUPS = [
     # 通常の Lookup:
-    # {"schema": f"{PREFIX}_samplemain_{PREFIX}_samplemaster",
-    #  "referencing": f"{PREFIX}_samplemain",
-    #  "referenced": f"{PREFIX}_samplemaster",
-    #  "lookup_attr": f"{PREFIX}_samplemasterid",
-    #  "lookup_display": "Sample Master"},
+    # {"from_table": f"{PREFIX}_samplemain", "column_logical": f"{PREFIX}_samplemasterid",
+    #  "display": "Sample Master", "to_table": f"{PREFIX}_samplemaster"},
 
     # SystemUser への Lookup（担当者等）:
-    # {"schema": f"{PREFIX}_samplemain_systemuser_assignee",
-    #  "referencing": f"{PREFIX}_samplemain",
-    #  "referenced": "systemuser",
-    #  "lookup_attr": f"{PREFIX}_assigneeid",
-    #  "lookup_display": "Assigned To"},
+    # {"from_table": f"{PREFIX}_samplemain", "column_logical": f"{PREFIX}_assigneeid",
+    #  "display": "Assigned To", "to_table": "systemuser"},
 ]
 
 # ── ローカライズ定義 ─────────────────────────────────────
@@ -382,22 +376,39 @@ def create_lookups():
     print("\n=== Step 3: Lookup リレーションシップ作成 ===")
 
     for lk in LOOKUPS:
+        col_logical = lk["column_logical"]
+        from_table = lk["from_table"]
+        to_table = lk["to_table"]
+
+        # 既存 Lookup 属性チェック（べき等: 存在すればスキップ）
+        try:
+            api_get(f"EntityDefinitions(LogicalName='{from_table}')/Attributes(LogicalName='{col_logical}')?$select=LogicalName")
+            print(f"  Lookup '{col_logical}' は既存。スキップ。")
+            continue
+        except Exception:
+            pass
+
         def _create(l=lk):
             body = {
-                "@odata.type": "#Microsoft.Dynamics.CRM.OneToManyRelationshipMetadata",
-                "SchemaName": l["schema"],
-                "ReferencedEntity": l["referenced"],
-                "ReferencingEntity": l["referencing"],
+                "@odata.type": "#Microsoft.Dynamics.CRM.CreateOneToManyRequest",
+                "OneToManyRelationship": {
+                    "@odata.type": "#Microsoft.Dynamics.CRM.OneToManyRelationshipMetadata",
+                    "ReferencedEntity": l["to_table"],
+                    "ReferencingEntity": l["from_table"],
+                    "SchemaName": f"{l['from_table']}_{l['column_logical']}",
+                    "ReferencingAttribute": l["column_logical"],
+                },
                 "Lookup": {
-                    "SchemaName": l["lookup_attr"],
-                    "DisplayName": label_jp(l["lookup_display"]),
+                    "@odata.type": "#Microsoft.Dynamics.CRM.LookupAttributeMetadata",
+                    "SchemaName": l["column_logical"],
+                    "DisplayName": label_jp(l["display"]),
                     "RequiredLevel": {"Value": "None"},
                 },
             }
-            api_post("RelationshipDefinitions", body, solution=SOLUTION_NAME)
-            print(f"  Lookup '{l['schema']}' 作成完了")
+            api_post("CreateOneToMany", body, solution=SOLUTION_NAME)
+            print(f"  Lookup '{col_logical}' 作成完了")
 
-        retry_metadata(_create, f"Lookup {lk['schema']}")
+        retry_metadata(_create, f"Lookup {col_logical}")
         time.sleep(5)
 
 


### PR DESCRIPTION
## 概要

Lookup リレーション作成時、既に存在する Lookup に対して再実行すると 400 エラーが発生する問題を修正。

## 変更内容

### setup_dataverse.py（テンプレート）
- create_lookups() に属性存在チェックを追加（api_get で既存確認 → スキップ）
- RelationshipDefinitions POST → CreateOneToMany アクションに変更
- LOOKUPS 定義形式を簡素化: from_table, column_logical, display, to_table の 4 キー構造

### SKILL.md
- Lookup ルール表を更新（CreateOneToMany 使用・事前チェック必須・新形式を明記）

## マージ順

単独 PR。他のオープン PR（#207, #208）とは無関係。