### PR TITLE
code-apps: SDK 1.2.x データ層 API とデータソース命名の教訓を反映

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -81,6 +81,11 @@ Code Apps 開発は **設計 → 初回デプロイ → データソース接続
 
 > 章構成: §1 概要（本章・設計フェーズ）→ §2 初回デプロイ → §3 データソース接続 → §4 改善デプロイ → §5 リファレンス索引。
 
+> [!TIP]
+> **`pac code add-data-source`（⑦）は `pac code init`（④）直後に実行してよい**（push 不要 / 検証済 2026-07-01）。
+> 全テーブルを先に追加してから初回 `pac code push`（⑥）すれば「空スケルトンを push → data source 追加 → 再 push」の二度手間を避けられる。
+> 生成される `dataSourcesInfo` のキーは **EntitySetName（複数形）**（`-t {prefix}_factory` → キー `{prefix}_factories`）。詳細は [ビルドリファレンス Step 4/6](references/build-reference.md)。
+
 > [!NOTE]
 > 本スキル内のコード例は `{prefix}_tablename` 等のプレースホルダーで汎用化されています。
 > 実際のテーブル名・型名は、あなたのプロジェクトのエンティティに読み替えてください。

--- a/.github/skills/code-apps/references/build-reference.md
+++ b/.github/skills/code-apps/references/build-reference.md
@@ -192,6 +192,26 @@ python scripts/toggle_table_lang.py jp
 > **重要**: テーブル論理名に `geek_xxx` のような literal を書かない。
 > publisher prefix は環境ごとに異なるため、必ず `.env` の `PUBLISHER_PREFIX` を変数展開して使う。
 
+> **`add-data-source` は初回デプロイ前に実行してよい（push 不要）**（検証済 2026-07-01 / PAC 2.8.1）。
+> `pac code add-data-source` は `power.config.json` があれば動作し、**デプロイ済みアプリを必要としない**。
+> `pac code init` 直後に全テーブルを追加してから初回 `pac code push` すれば、
+> 「空スケルトンを push → data source 追加 → 再 push」の二度手間を避けられる。
+
+> **⚠ 生成されるデータソースのキー名は EntitySetName（複数形）である**（検証済 2026-07-01）。
+> `pac code add-data-source -t {prefix}_factory`（**単数**の論理名）を実行すると、
+> `.power/schemas/appschemas/dataSourcesInfo.ts` に生成されるキーは **`{prefix}_factories`（複数形）** になる。
+> `retrieveMultipleRecordsAsync(dataSourceName)` に渡す `dataSourceName` は
+> **必ずこの複数形キー**を使う（単数の論理名では 404 / 空データになる）。
+>
+> | `add-data-source -t`（単数・論理名） | 生成キー / `DATA_SOURCE`（複数形・EntitySetName） |
+> |---|---|
+> | `{prefix}_factory` | `{prefix}_factories` |
+> | `{prefix}_capacity` | `{prefix}_capacities` |
+> | `{prefix}_replenishmentrequest` | `{prefix}_replenishmentrequests` |
+> | `systemuser` | `systemusers` |
+>
+> 実際のキーは生成後の `.power/schemas/appschemas/dataSourcesInfo.ts` で必ず確認する。
+
 ### Step 5: 技術スタック導入
 
 ```bash
@@ -230,6 +250,18 @@ export const router = createHashRouter([
 ```
 
 ### Step 6: DataverseService パターンで CRUD 実装
+
+> **⚠ `samples/` 配下のサンプルアプリのデータ層はコピー禁止（SDK 旧 API）**（検証済 2026-07-01 / `@microsoft/power-apps` 1.2.5）。
+> 一部サンプルの `src/services/dataverse-service.ts` は
+> `import { getClient } from "@microsoft/power-apps"`（ルートインポート）と
+> `client().getRecords(...)` / `createRecord(...)` を使っているが、**現行 SDK には存在しない**:
+> - **ルートエクスポート（`"."`）は無い** → `@microsoft/power-apps/data` のサブパス必須。
+> - `getRecords` / `createRecord` / `updateRecord` / `deleteRecord` は**廃止**。
+>   現行の `DataClient` メソッドは
+>   `retrieveMultipleRecordsAsync` / `retrieveRecordAsync` / `createRecordAsync` /
+>   `updateRecordAsync` / `deleteRecordAsync` で、いずれも `IOperationResult<T>`（`{ success, data, error }`）を返す。
+>
+> データ層は**必ず下記の `DataverseService` パターン**で新規に書くこと（サンプルの `dataverse-service.ts` / `lib/dataSourcesInfo.ts` は流用しない）。
 
 #### `getClient(dataSourcesInfo)` — dataSourcesInfo は必須引数
 
@@ -292,7 +324,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { DataverseService } from "@/lib/dataverse-service";
 import type { Product } from "@/types";
 
-const DATA_SOURCE = "inv_products";  // dataSourcesInfo のキー名
+const DATA_SOURCE = "inv_products";  // dataSourcesInfo のキー名 = EntitySetName（複数形）。add-data-source -t inv_product（単数）で生成される
 
 export function useProducts() {
   return useQuery<Product[]>({

--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -1355,3 +1355,88 @@ type DataSourcesInfo = Parameters<typeof getClient>[0];
 ```
 
 → 関連: [データソースパターン](data-source-patterns.md)
+
+---
+
+## 27. サンプルの `dataverse-service.ts` を流用すると `getRecords is not a function`（検証済 2026-07-01 / SDK 1.2.5）
+
+### 症状
+
+`samples/geek-*` の `src/services/dataverse-service.ts` をコピーして使うと、
+ビルドは通っても実行時に以下で落ちる（またはビルド時に型エラー）:
+
+```
+TypeError: client(...).getRecords is not a function
+```
+
+```
+error TS2305: Module '"@microsoft/power-apps"' has no exported member 'getClient'.
+```
+
+### 原因
+
+一部サンプルのデータ層は **旧 SDK（ルートエクスポート + 簡易メソッド）前提**で書かれており、
+現行 `@microsoft/power-apps`（1.2.x）には存在しない:
+
+```typescript
+// ❌ サンプルの旧パターン（現行 SDK では動かない）
+import { getClient } from "@microsoft/power-apps"          // ルート import は無い
+function client() { return getClient(dataSourcesInfo) }
+client().getRecords(`${P}_products`)                        // getRecords は廃止
+client().createRecord(...)  // createRecord / updateRecord / deleteRecord も廃止
+```
+
+現行 `DataClient` のメソッド名と戻り値（`IOperationResult<T>` = `{ success, data, error }`）:
+
+| 旧（サンプル・廃止） | 現行 SDK 1.2.x |
+|---|---|
+| `getRecords(name)` | `retrieveMultipleRecordsAsync<T>(name, options?)` → `result.data` |
+| `getRecord(name, id)` | `retrieveRecordAsync<T>(name, id, options?)` |
+| `createRecord(name, body)` | `createRecordAsync<TIn, TOut>(name, body)` |
+| `updateRecord(name, id, body)` | `updateRecordAsync<TIn, TOut>(name, id, body)` |
+| `deleteRecord(name, id)` | `deleteRecordAsync(name, id)` |
+
+### 対処
+
+サンプルの `dataverse-service.ts` / `lib/dataSourcesInfo.ts` は**流用しない**。
+[ビルドリファレンス Step 6](build-reference.md) の `DataverseService` パターン
+（`@microsoft/power-apps/data` のサブパス import + `retrieveMultipleRecordsAsync` +
+`if (!result.success) throw result.error` + `return result.data`）で新規に書く。
+
+---
+
+## 28. データソース名に単数の論理名を渡すと 404 / 空データになる（検証済 2026-07-01）
+
+### 症状
+
+`pac code add-data-source -t {prefix}_factory` で追加したのに、
+`retrieveMultipleRecordsAsync("{prefix}_factory", ...)` が 404 相当で 0 件（またはエラー）を返す。
+
+### 原因
+
+`pac code add-data-source` は **単数の論理名**（`-t {prefix}_factory`）で追加するが、
+生成される `.power/schemas/appschemas/dataSourcesInfo.ts` の**キーは EntitySetName（複数形）**になる。
+
+```jsonc
+// add-data-source -t geek_factory / geek_capacity / systemuser で生成される
+export const dataSourcesInfo = {
+  "geek_factories":  { "primaryKey": "geek_factoryid",  ... },  // ← 複数形キー
+  "geek_capacities": { "primaryKey": "geek_capacityid", ... },
+  "systemusers":     { ... },
+}
+```
+
+`retrieveMultipleRecordsAsync` 等に渡す `dataSourceName` は、この**複数形キー**でなければならない。
+
+### 対処
+
+```typescript
+// ❌ 単数の論理名（404 / 空データ）
+const DATA_SOURCE = "geek_factory";
+
+// ✅ 生成された複数形キー（EntitySetName）
+const DATA_SOURCE = "geek_factories";
+```
+
+追加後は必ず `.power/schemas/appschemas/dataSourcesInfo.ts` を開き、実際のキー名を確認してから
+`DATA_SOURCE` 定数に転記する。不規則な複数形（`capacity → capacities`）に注意。

--- a/.github/skills/code-apps/scripts/toggle_table_lang.py
+++ b/.github/skills/code-apps/scripts/toggle_table_lang.py
@@ -8,7 +8,8 @@ pac code add-data-source の日本語サニタイズ問題の回避用。
   python scripts/toggle_table_lang.py jp   # 日本語に復元
 
 前提:
-  - auth_helper.py がプロジェクトルートに存在すること
+  - auth_helper.py が参照可能なこと（標準は .github/skills/standard/scripts/auth_helper.py。
+    プロジェクトルート直下に置いている場合も自動でフォールバック解決する）
   - .env に PUBLISHER_PREFIX, DATAVERSE_URL が設定されていること
 
 カスタマイズ:
@@ -17,13 +18,22 @@ pac code add-data-source の日本語サニタイズ問題の回避用。
 """
 import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# auth_helper.py を解決: 標準（standard スキル）→ プロジェクトルートの順に探す
+_ROOT = Path(__file__).resolve().parent.parent
+for _cand in (
+    _ROOT / ".github" / "skills" / "standard" / "scripts",
+    _ROOT,
+):
+    if (_cand / "auth_helper.py").exists():
+        sys.path.insert(0, str(_cand))
+        break
 
 from dotenv import load_dotenv
 from auth_helper import api_get, api_request
 
-load_dotenv()
+load_dotenv(_ROOT / ".env")
 
 PREFIX = os.environ.get("PUBLISHER_PREFIX", "").strip()
 if not PREFIX:


### PR DESCRIPTION
現行 SDK (`@microsoft/power-apps` 1.2.5) と PAC 2.8.1 で検証した教訓を反映。

## 変更点
- **build-reference.md**
  - `add-data-source` は `pac code init` 直後に実行可（push 不要）を明記。空スケルトンの二度手間 push を回避。
  - 生成される dataSourcesInfo のキーは **EntitySetName（複数形）**（`-t {prefix}_factory` → キー `{prefix}_factories`）を対応表付きで明記。
  - Step 6 冒頭に、サンプルのデータ層（ルート import + `getRecords` 等）は現行 SDK では動かないため流用禁止の警告を追加。
- **troubleshooting.md**
  - #27 サンプルの `dataverse-service.ts` 流用で `getRecords is not a function`（旧→現行メソッド対応表）。
  - #28 データソース名に単数論理名を渡すと 404 / 空データ（複数形キーを使う）。
- **SKILL.md**: ワークフロー概要に add-data-source の前倒し可・複数形キーの TIP を追加。
- **scripts/toggle_table_lang.py**: `auth_helper.py` を standard スキル配下 → プロジェクトルートの順で自動解決するよう修正（従来のルート直下前提を撤廃）。

検証: SDK 1.2.5 の型定義（`dist/data` / `internal/data/core/types`）と生成 `dataSourcesInfo.ts` の実キーで確認。