### PR TITLE
skill(cowork): Cowork アップロード/公開の実運用教訓を反映

### DIFF
--- a/.github/skills/cowork/SKILL.md
+++ b/.github/skills/cowork/SKILL.md
@@ -253,18 +253,23 @@ ZIP 検証: ルートに `manifest.json` / `dataverse-mcp-tools.json`、`skills/
 
 ### Step 8: アップロード（M365 管理センター → エージェント画面）
 
-> ⚠️ Cowork プラグインは**「統合アプリ」ではなく、新しい「エージェント」画面**からアップロードする（UI 変更済み）。
+> ⚠️ Cowork プラグインは**「統合アプリ（Integrated apps）」ではなく、新しい「エージェント」画面**
+> からアップロードする（UI 変更済み）。Integrated apps 画面は「Agents > All agents へ移動」の案内のみで
+> カスタムアプリのアップロード導線は**廃止**された。
 
 > **ブラウザ操作は AI 自動化を優先**: このアップロード〜Publish も **Playwright MCP** で自動化する
 > ことを第一候補とする（`browser_navigate` で `#/agents/all` へ→ファイル選択→ウィザードを
-> `browser_click` で進める）。検証エラーが出た場合は `browser_snapshot` で内容を読み取り
-> troubleshooting と突き合わせて修正→再アップロードする。Playwright MCP が使えない環境でのみ
-> 下記を人手で操作する。
+> `browser_click` で進める）。`Add agent` の **More actions（…）はページ中段の Registry ツールバー**
+> にあり、**画面が狭いと折り畳まれて見えない**ため viewport を広げる（例: 1600×900）。
+> ファイル選択は `<input type=file>` に `setInputFiles` で直接投入すると確実。検証エラーが出た場合は
+> `browser_snapshot` で内容を読み取り troubleshooting と突き合わせて修正→再アップロードする。
+> Playwright MCP が使えない環境でのみ下記を人手で操作する。
 
 1. [Microsoft 365 管理センター](https://admin.cloud.microsoft/) → 左ナビ **エージェント（Agents）** (`#/agents/all`)
-2. **Registry** タブ → ツールバー右の **More actions（…、Export の隣）** → **Add agent** → **Upload agent** ウィザード起動
+2. **Registry** タブ → グリッド中段ツールバーの **Export の右隣「…」(More actions)** → **Add agent** → **Upload agent** ウィザード起動
 3. **Upload**: `<name>.zip` を選択→manifest 検証が走る（エラーが出たら troubleshooting 参照）
-4. **Publish to users**: 公開対象（All users / 特定ユーザー）と Install（None 推奨）を選択
+4. **Publish to users**: 公開対象（All users / **Specific users/groups**）を選択。特定ユーザーは検索ボックスで
+   ユーザー/グループを追加する。**Install（None 推奨）は明示選択しないと Next が有効化されない**
 5. **Apply template**（Default で Next）→ **Accept permissions**（権限不要なら「No required permissions」）→ **Review & finish** → **Publish**
 6. 「You uploaded <name>」表示で完了 → **Close**。詳細パネルの Status が **Available** になる
 7. **Cowork → Sources & Skills** にスキル＋Dataverse MCP コネクタが表示されることを確認
@@ -310,7 +315,7 @@ ZIP 検証: ルートに `manifest.json` / `dataverse-mcp-tools.json`、`skills/
 - [ ] ZIP ルートに manifest.json / dataverse-mcp-tools.json、skills/<name>/SKILL.md
 - [ ] 管理センターの**エージェント画面**からアップロード→Publish→Status=Available
 - [ ] Cowork に表示 → 初回同意 → データ取得成功
-- [ ] 更新時: version をインクリメント（id 据え置き）→ More actions → Update in store → Publish
+- [ ] 更新時: version をインクリメント（id 据え置き）→ More actions（… / Export の隣）→ Add agent → Upload agent → Publish
 
 ## 参考リンク
 

--- a/.github/skills/cowork/references/portal-registration.md
+++ b/.github/skills/cowork/references/portal-registration.md
@@ -23,3 +23,8 @@ Save すると **OAuth client registration ID** が発行される。これを `
 
 > **referenceId の値**: OAuth 方式では発行された **registration ID をそのまま** `referenceId` に使う
 > （SSO 方式のような `Base64("<tenantId>##<regId>")` 変換は不要）。
+
+> **シークレット入力の注意**: Client secret 欄は**平文表示**で、Playwright の
+> スナップショット/スクショに写り得る。`.env` からの投入は PowerShell `Set-Clipboard` +
+> ブラウザ `Ctrl+V` で行い（値をチャットに出さない）、疎通確認後は**ローテーション**する。
+> 手順は [troubleshooting.md #17](troubleshooting.md) を参照。

--- a/.github/skills/cowork/references/troubleshooting.md
+++ b/.github/skills/cowork/references/troubleshooting.md
@@ -172,3 +172,24 @@ App registration の作成には特権が要る。
 - どうしても付与できない環境では **Azure CLI 版 `setup_entra_oauth.ps1`** にフォールバックする
   （`az login` したユーザーの権限で作成）。
 
+## 17. Playwright でシークレットを画面入力する（チャット非露出）
+
+**課題**: Teams ポータルの Client secret など、`.env` の秘匿値をブラウザに入力したいが、
+`type`/`click` の引数やチャットに**値を出したくない**。また Playwright のコード実行サンドボックスは
+**`require`/`import` が使えず `fs` でファイルを読めない**（`ReferenceError: require is not defined` /
+`A dynamic import callback was not specified`）。
+
+**対処**: PowerShell でクリップボードへ入れ、ブラウザ側は **Ctrl+V で貼り付け**る（値はチャットに出ない）。
+
+```powershell
+# .env から値を取り出しクリップボードへ（値は表示しない）
+$s = ((Get-Content .env | Select-String -Pattern '^COWORK_OAUTH_CLIENT_SECRET=').Line -replace '^COWORK_OAUTH_CLIENT_SECRET=',''); Set-Clipboard -Value $s
+```
+
+→ 対象フィールドをフォーカスして `Control+v` を送る。
+
+> ⚠️ **Teams ポータルの Client secret 欄は平文表示**のため、貼付後のアクセシビリティ
+> スナップショット/スクリーンショットに値が写り得る。貼付後は不要な `browser_snapshot` を避け、
+> 疎通確認が済んだら**シークレットをローテーション**する（Entra で再生成 → `.env` 更新 →
+> ポータルの OAuth 登録のシークレットのみ差し替え。registrationId は不変なので**再ビルド不要**）。
+


### PR DESCRIPTION
CapaMate を M365 管理センターからアップロード〜公開した実運用で得た教訓を cowork スキルへ反映。

## 変更点
- **SKILL.md Step 8**: 「統合アプリ（Integrated apps）」からのアップロード導線は廃止（Agents > All agents へ誘導のみ）と明記。More actions（…）は**ページ中段の Registry ツールバー・Export の右隣**にあり、狭い viewport では折り畳まれるため Playwright は viewport を広げる（例 1600×900）。ファイル選択は input[type=file] に setInputFiles。
- **SKILL.md Step 8 Publish to users**: Specific users/groups は検索ボックスでユーザー/グループを追加し、**Install（None）を明示選択しないと Next が有効化されない**点を追記。
- **SKILL.md チェックリスト**: 更新時の導線を「Update in store」→「Add agent → Upload agent」に修正（Step 10 と整合）。
- **references/troubleshooting.md #17（新規）**: Playwright 実行サンドボックスは fs/require/import 不可 → 秘匿値は PowerShell Set-Clipboard + ブラウザ Ctrl+V で投入（チャット非露出）。Teams ポータルの Client secret 欄は平文表示のため疎通後にローテーション（registrationId 不変＝再ビルド不要）。
- **references/portal-registration.md**: シークレット平文表示の注意と troubleshooting #17 への導線を追記。

validate_skill.py PASS。