### PR TITLE
copilot-studio: 外部サイト WebChat デプロイの教訓（auth_helper AAD デプロイ / トークンEP分割 / ポリシー対応）

### DIFF
--- a/.github/skills/copilot-studio/references/.env.example
+++ b/.github/skills/copilot-studio/references/.env.example
@@ -30,3 +30,16 @@ CONNREF_OUTLOOK={prefix}_outlookConnRef
 # フロー Workflow ID（取得元: 対象フローの URL / Dataverse workflow レコード）
 FLOW_WORKFLOW_ID={workflow-id}
 WF_ID={workflow-id}
+
+# === 外部公開 Web サイト（deploy_website.py 用・オプション）===
+# 取得元: Azure ポータル > サブスクリプション（省略時は最初の有効サブスクリプションを使用）
+AZURE_SUBSCRIPTION_ID={subscription-id}
+# 取得元: 任意（存在しなければ自動作成）
+AZURE_RESOURCE_GROUP=rg-agent-website
+AZURE_LOCATION=japaneast
+# 取得元: 任意の一意名（3-24 文字・小文字英数字・グローバル一意。存在しなければ自動作成）
+AZURE_STORAGE_ACCOUNT={mystorageaccount}
+# アカウントキー方式を使う場合のみ（共有キーがポリシーで禁止されていない環境）
+AZURE_STORAGE_KEY={account-key}
+# WebChat SDK トークンエンドポイント（ホストは ENV_ID のハイフン除去 32 桁を「先頭30.末尾2」に分割）
+WEBCHAT_TOKEN_ENDPOINT=https://{env30}.{env2}.environment.api.powerplatform.com/powervirtualagents/botsbyschema/{BOT_SCHEMA}/directline/token?api-version=2022-03-01-preview

--- a/.github/skills/copilot-studio/references/external-web-embed.md
+++ b/.github/skills/copilot-studio/references/external-web-embed.md
@@ -263,10 +263,12 @@ az rest --method put \
 ```
 ❌ /copilotstudio/dataverse-backed/authenticated/.../conversations API を使う
    → 認証付き API で外部匿名ユーザーはアクセスできない（404）
-❌ Bot Framework WebChat + DirectLine トークンエンドポイント
-   → 「認証なし」では DirectLine トークンエンドポイントは提供されない
+✅ Bot Framework WebChat SDK + DirectLine トークンエンドポイント
+   → 「認証なし」エージェントでも /powervirtualagents/botsbyschema/{SCHEMA}/directline/token は
+     HTTP 200 でトークンを返す（検証済み）。UI 完全カスタマイズ・多言語対応が可能。
+   → 詳細は webchat-sdk-embed.md（推奨パターン）を参照
 ✅ Copilot Studio 埋め込みコード（iframe）を使用する
-   → 認証なしエージェント専用、追加認証不要、最もシンプル
+   → 認証なしエージェント専用、最もシンプル（カスタマイズ不要な場合）
 ```
 
 ## 適用条件

--- a/.github/skills/copilot-studio/references/troubleshooting.md
+++ b/.github/skills/copilot-studio/references/troubleshooting.md
@@ -342,3 +342,54 @@ Q: どのように起動しますか？
 ✅ Flow API (service.flow.microsoft.com) で workflowEntityId を照合して Flow API ID を取得
 ✅ フロー有効化後でないと Flow API に表示されない場合がある
 ```
+
+## 外部サイト（Azure Storage 静的 Web サイト）
+
+### `KeyBasedAuthenticationNotPermitted`（共有キー認証が禁止）
+
+```
+❌ アカウントキー / 接続文字列でアップロード
+   → 組織の Azure Policy が allowSharedKeyAccess=false を強制していると失敗
+   → PATCH で allowSharedKeyAccess=true にしてもポリシーが false に戻す（200 でも反映されない）
+✅ Entra（AAD）データプレーン認証に切り替える
+   → 自分に「Storage Blob Data Owner」ロールを割り当て（roleDef b7e6dc6d-f1e8-4753-8033-0f276bb0955b）
+   → BlobServiceClient(account_url, credential=<AADトークン>) でアップロード
+   → scripts/deploy_website.py（auth_helper AAD 方式）がこの手順を自動化
+```
+
+### `AuthorizationPermissionMismatch`（AAD でアップロード時）
+
+```
+❌ ロール割り当て直後にアップロード → RBAC 伝播前で 403
+✅ RBAC 反映を数十秒〜数分待ってからリトライ
+   → deploy_website.py は AuthorizationPermissionMismatch を検知して自動リトライ（最大 10 回 × 20 秒）
+```
+
+### 静的サイトが表示されない / 公開 BLOB アクセスが無効
+
+```
+✅ 静的 Web サイトエンドポイント（*.z*.web.core.windows.net）は
+   allowBlobPublicAccess=false でも匿名配信される（$web 専用の匿名アクセス）
+   → ポリシーで公開 BLOB を禁止していても静的サイトは公開できる
+```
+
+### DirectLine トークンエンドポイントに繋がらない
+
+```
+❌ ホストに ENV_ID をそのまま入れる（{ENV_ID}.environment.api...）
+✅ ENV_ID のハイフンを除いた 32 桁を「先頭30桁 . 末尾2桁」に分割してホストにする
+   例) aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+       → aaaaaaaabbbbccccddddeeeeeeeeee.ee.environment.api.powerplatform.com
+✅ 「認証なし」エージェント（authenticationmode=2）でも
+   /powervirtualagents/botsbyschema/{SCHEMA}/directline/token は HTTP 200 でトークンを返す
+```
+
+### `az login` が使えない / az CLI が未認証
+
+```
+✅ standard スキルの auth_helper.get_token("https://management.azure.com/.default") で
+   ARM トークンを取得すれば az CLI 無しで ARM REST を呼べる
+✅ データプレーンは get_token("https://storage.azure.com/.default") を
+   TokenCredential ラッパー（HelperCredential）で SDK に渡す
+```
+

--- a/.github/skills/copilot-studio/references/webchat-sdk-embed.md
+++ b/.github/skills/copilot-studio/references/webchat-sdk-embed.md
@@ -54,6 +54,24 @@ https://{ENV_ID}.environment.api.powerplatform.com/powervirtualagents/botsbysche
 /powervirtualagents/botsbyschema/{SCHEMA}/directline/token
 ```
 
+> ✅ **検証済み**: 「認証なし」エージェントでもこのトークンエンドポイントは HTTP 200 で
+> DirectLine トークン（JWT）を返す。サインイン不要で匿名利用できる。
+
+### ホスト名は ENV_ID から導出する（ハイフン除去 + 分割）
+
+トークンエンドポイントのホストは環境 ID（`ENV_ID`）そのものではなく、
+**ハイフンを除いた 32 桁 16 進数を「先頭 30 桁 . 末尾 2 桁」に分割**した形式:
+
+```
+ENV_ID = aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+  → ハイフン除去: aaaaaaaabbbbccccddddeeeeeeeeeeee （32 桁）
+  → 分割:         aaaaaaaabbbbccccddddeeeeeeeeee . ee
+ホスト = aaaaaaaabbbbccccddddeeeeeeeeee.ee.environment.api.powerplatform.com
+```
+
+> 接続文字列をコピーできる場合はそのまま使えばよいが、ENV_ID から組み立てる場合は
+> この分割規則に従うこと（`{ENV_ID}.environment...` のようにそのまま入れると解決しない）。
+
 ## アーキテクチャ
 
 ```
@@ -559,7 +577,33 @@ scripts/
 </html>
 ```
 
-## deploy_website.py テンプレート
+## デプロイ（推奨: auth_helper で az login 不要）
+
+デプロイは [scripts/deploy_website.py](../scripts/deploy_website.py) を使う。
+standard スキルの `auth_helper` で ARM トークンを取得するため **`az login` / az CLI 不要**。
+ARM でリソースグループ・ストレージアカウントを冪等作成し、データプレーンは
+**Entra（AAD）認証**でアップロードする。
+
+```powershell
+python .github/skills/copilot-studio/scripts/deploy_website.py
+```
+
+> ⚠️ **組織の Azure Policy に注意**: 共有キー認証（`allowSharedKeyAccess`）や公開 BLOB アクセス
+> （`allowBlobPublicAccess`）がポリシーで無効化されている環境では、アカウントキー方式は
+> `KeyBasedAuthenticationNotPermitted` で失敗する。上記スクリプトは **AAD データプレーン認証**
+> （自分に Storage Blob Data Owner を割り当て → RBAC 反映待ちリトライ）で回避する。
+> 静的 Web サイトエンドポイント（`*.z*.web.core.windows.net`）は `allowBlobPublicAccess=false`
+> でも匿名配信される（詳細は [troubleshooting.md](troubleshooting.md)）。
+
+### 多言語（i18n）対応
+
+外部サイトを多言語化する場合は、UI ラベル・カテゴリ・プロンプトを言語別の辞書オブジェクトに
+持ち、`localStorage` で選択言語を永続化する。プロンプトは**選択言語の文面**で送信し、
+エージェント側の Instructions も対象言語（例: 日本語/英語/中国語）で応答するよう記述しておく。
+
+## deploy_website.py テンプレート（アカウントキー方式・ポリシー未制限環境のみ）
+
+> ポリシーで共有キーが禁止されている場合は上記 `scripts/deploy_website.py`（AAD 方式）を使う。
 
 ```python
 """Azure Storage 静的 Web サイトを有効化し、index.html をデプロイする"""
@@ -600,12 +644,16 @@ print(f"Deployed: https://{ACCOUNT_NAME}.z11.web.core.windows.net/")
 ## .env 追加項目
 
 ```env
-# Azure Storage（静的 Web サイトホスティング）
-AZURE_STORAGE_ACCOUNT=mystorageaccount
-AZURE_STORAGE_KEY=xxxxx
+# Azure Storage（静的 Web サイトホスティング / auth_helper AAD 方式）
+AZURE_SUBSCRIPTION_ID={subscription-id}   # 省略時は最初の有効サブスクリプションを使用
+AZURE_RESOURCE_GROUP=rg-agent-website
+AZURE_LOCATION=japaneast
+AZURE_STORAGE_ACCOUNT={mystorageaccount}  # 3-24 文字・小文字英数字・グローバル一意
+# アカウントキー方式を使う場合のみ（ポリシー未制限環境）
+AZURE_STORAGE_KEY={account-key}
 
-# WebChat SDK
-WEBCHAT_TOKEN_ENDPOINT=https://{ENV_ID}.environment.api.powerplatform.com/powervirtualagents/botsbyschema/{BOT_SCHEMA}/directline/token?api-version=2022-03-01-preview
+# WebChat SDK（ホストは ENV_ID のハイフン除去 32 桁を「先頭30.末尾2」に分割）
+WEBCHAT_TOKEN_ENDPOINT=https://{env30}.{env2}.environment.api.powerplatform.com/powervirtualagents/botsbyschema/{BOT_SCHEMA}/directline/token?api-version=2022-03-01-preview
 ```
 
 ## 実装手順サマリー

--- a/.github/skills/copilot-studio/scripts/deploy_website.py
+++ b/.github/skills/copilot-studio/scripts/deploy_website.py
@@ -1,0 +1,227 @@
+"""Azure Storage 静的 Web サイトへ外部公開サイトをデプロイする（汎用）。
+
+認証は standard スキルの auth_helper（DeviceCode / PAC プロファイル）を利用し、
+`az login` / az CLI は不要。ARM（コントロールプレーン）でリソースグループと
+ストレージアカウントを冪等に作成し、データプレーンは **Entra（AAD）認証** で
+アップロードする（組織の Azure Policy が共有キー認証・公開 BLOB アクセスを
+禁止していても動作する）。
+
+設定は .env（references/.env.example 参照）から取得する。実値はハードコードしない。
+
+使い方:
+    python .github/skills/copilot-studio/scripts/deploy_website.py
+    python .github/skills/copilot-studio/scripts/deploy_website.py website/index.html
+"""
+import base64
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).resolve().parents[4]  # リポジトリルート
+sys.path.insert(0, str(ROOT / ".github" / "skills" / "standard" / "scripts"))
+import auth_helper  # noqa: E402
+from auth_helper import get_token  # noqa: E402
+
+load_dotenv()
+
+# ── 設定（.env）─────────────────────────────────────
+RESOURCE_GROUP = os.getenv("AZURE_RESOURCE_GROUP", "rg-agent-website")
+LOCATION = os.getenv("AZURE_LOCATION", "japaneast")
+STORAGE_ACCOUNT = os.getenv("AZURE_STORAGE_ACCOUNT", "")
+SUBSCRIPTION_ID = os.getenv("AZURE_SUBSCRIPTION_ID", "")
+INDEX_FILE = ROOT / (sys.argv[1] if len(sys.argv) > 1 else "website/index.html")
+
+ARM = "https://management.azure.com"
+ARM_SCOPE = "https://management.azure.com/.default"
+STORAGE_SCOPE = "https://storage.azure.com/.default"
+API = "2023-01-01"
+# Storage Blob Data Owner（データプレーン AAD 認証用のロール定義 ID）
+BLOB_DATA_OWNER = "b7e6dc6d-f1e8-4753-8033-0f276bb0955b"
+
+
+class HelperCredential:
+    """auth_helper.get_token を azure SDK の TokenCredential として橋渡しする。"""
+
+    def get_token(self, *scopes, **kwargs):
+        from azure.core.credentials import AccessToken
+
+        scope = scopes[0]
+        token = get_token(scope)
+        _, expires_on = auth_helper._inmemory_tokens[scope]
+        return AccessToken(token, int(expires_on))
+
+
+def arm_headers():
+    return {"Authorization": f"Bearer {get_token(ARM_SCOPE)}", "Content-Type": "application/json"}
+
+
+def pick_subscription() -> str:
+    if SUBSCRIPTION_ID:
+        return SUBSCRIPTION_ID
+    r = requests.get(f"{ARM}/subscriptions?api-version=2022-12-01", headers=arm_headers(), timeout=60)
+    r.raise_for_status()
+    subs = [s for s in r.json().get("value", []) if s.get("state") == "Enabled"]
+    if not subs:
+        raise SystemExit("有効なサブスクリプションが見つかりません。AZURE_SUBSCRIPTION_ID を設定してください。")
+    sub = subs[0]
+    print(f"サブスクリプション: {sub.get('displayName')} ({sub['subscriptionId']})")
+    return sub["subscriptionId"]
+
+
+def ensure_provider(sub: str):
+    requests.post(
+        f"{ARM}/subscriptions/{sub}/providers/Microsoft.Storage/register?api-version=2022-12-01",
+        headers=arm_headers(),
+        timeout=60,
+    )
+
+
+def ensure_resource_group(sub: str):
+    r = requests.put(
+        f"{ARM}/subscriptions/{sub}/resourcegroups/{RESOURCE_GROUP}?api-version=2021-04-01",
+        headers=arm_headers(),
+        json={"location": LOCATION},
+        timeout=60,
+    )
+    r.raise_for_status()
+    print(f"リソースグループ: {RESOURCE_GROUP}")
+
+
+def ensure_storage_account(sub: str) -> str:
+    base = (
+        f"{ARM}/subscriptions/{sub}/resourceGroups/{RESOURCE_GROUP}"
+        f"/providers/Microsoft.Storage/storageAccounts/{STORAGE_ACCOUNT}"
+    )
+    r = requests.get(f"{base}?api-version={API}", headers=arm_headers(), timeout=60)
+    if r.status_code == 200:
+        print(f"ストレージアカウント既存: {STORAGE_ACCOUNT}")
+        return base
+
+    chk = requests.post(
+        f"{ARM}/subscriptions/{sub}/providers/Microsoft.Storage/checkNameAvailability?api-version={API}",
+        headers=arm_headers(),
+        json={"name": STORAGE_ACCOUNT, "type": "Microsoft.Storage/storageAccounts"},
+        timeout=60,
+    )
+    chk.raise_for_status()
+    if not chk.json().get("nameAvailable"):
+        raise SystemExit(
+            f"ストレージアカウント名 '{STORAGE_ACCOUNT}' は使用できません: "
+            f"{chk.json().get('message')} — AZURE_STORAGE_ACCOUNT で別名を指定してください。"
+        )
+
+    body = {
+        "sku": {"name": "Standard_LRS"},
+        "kind": "StorageV2",
+        "location": LOCATION,
+        "properties": {"minimumTlsVersion": "TLS1_2"},
+    }
+    cr = requests.put(f"{base}?api-version={API}", headers=arm_headers(), json=body, timeout=120)
+    cr.raise_for_status()
+    print(f"ストレージアカウント作成中: {STORAGE_ACCOUNT} …")
+    for _ in range(30):
+        time.sleep(6)
+        g = requests.get(f"{base}?api-version={API}", headers=arm_headers(), timeout=60)
+        if g.status_code == 200 and g.json().get("properties", {}).get("provisioningState") == "Succeeded":
+            print("  作成完了")
+            return base
+    raise SystemExit("ストレージアカウントのプロビジョニングがタイムアウトしました。")
+
+
+def _token_oid() -> str:
+    tok = get_token(ARM_SCOPE)
+    payload = tok.split(".")[1]
+    payload += "=" * (-len(payload) % 4)
+    return json.loads(base64.urlsafe_b64decode(payload))["oid"]
+
+
+def ensure_role_assignment(base: str, sub: str):
+    """自分に Storage Blob Data Owner を割り当てる（データプレーン AAD 認証用）。"""
+    role_def = (
+        f"/subscriptions/{sub}/providers/Microsoft.Authorization"
+        f"/roleDefinitions/{BLOB_DATA_OWNER}"
+    )
+    body = {
+        "properties": {
+            "roleDefinitionId": role_def,
+            "principalId": _token_oid(),
+            "principalType": "User",
+        }
+    }
+    r = requests.put(
+        f"{base}/providers/Microsoft.Authorization/roleAssignments/{uuid.uuid4()}?api-version=2022-04-01",
+        headers=arm_headers(),
+        json=body,
+        timeout=60,
+    )
+    if r.status_code in (200, 201):
+        print("ロール割り当て: Storage Blob Data Owner 付与（反映待ち）")
+        time.sleep(30)
+    elif r.status_code == 409 or "RoleAssignmentExists" in r.text:
+        print("ロール割り当て: 既存")
+    else:
+        r.raise_for_status()
+
+
+def deploy_blob():
+    from azure.core.exceptions import HttpResponseError
+    from azure.storage.blob import BlobServiceClient, ContentSettings
+
+    svc = BlobServiceClient(
+        account_url=f"https://{STORAGE_ACCOUNT}.blob.core.windows.net",
+        credential=HelperCredential(),
+    )
+    svc.set_service_properties(
+        static_website={
+            "enabled": True,
+            "index_document": "index.html",
+            "error_document404_path": "index.html",
+        }
+    )
+    print("静的 Web サイト有効化")
+    web = svc.get_container_client("$web")
+    last_err = None
+    for attempt in range(10):
+        try:
+            with open(INDEX_FILE, "rb") as f:
+                web.upload_blob(
+                    name="index.html",
+                    data=f,
+                    overwrite=True,
+                    content_settings=ContentSettings(content_type="text/html; charset=utf-8"),
+                )
+            print("index.html アップロード完了")
+            return
+        except HttpResponseError as e:
+            if "AuthorizationPermissionMismatch" in str(e):
+                last_err = e
+                print(f"  RBAC 反映待ち… 再試行 {attempt + 1}/10")
+                time.sleep(20)
+                continue
+            raise
+    raise SystemExit(f"アップロードに失敗しました（RBAC 反映待ちタイムアウト）: {last_err}")
+
+
+def main():
+    if not STORAGE_ACCOUNT:
+        raise SystemExit("AZURE_STORAGE_ACCOUNT を .env に設定してください（3-24 文字・小文字英数字・グローバル一意）。")
+    if not INDEX_FILE.exists():
+        raise SystemExit(f"index.html が見つかりません: {INDEX_FILE}")
+    sub = pick_subscription()
+    ensure_provider(sub)
+    ensure_resource_group(sub)
+    base = ensure_storage_account(sub)
+    ensure_role_assignment(base, sub)
+    deploy_blob()
+    print("\n✅ デプロイ完了")
+    print(f"   https://{STORAGE_ACCOUNT}.z11.web.core.windows.net/")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/update-skills/scripts/validate_skill.py
+++ b/.github/skills/update-skills/scripts/validate_skill.py
@@ -68,6 +68,7 @@ ALLOWLIST = {
     "00000001-0000-0000-0001-00000000009b",  # Dataverse Default Solution（全環境固定）
     "953b9fac-1e5e-e611-80d6-00155ded156f",  # システムデフォルト WebResource（標準アイコン・全環境固定）
     "4273edbd-ac1d-40d3-9fb2-095c621b552d",  # 標準フォームコントロール CLASSID（全環境固定）
+    "b7e6dc6d-f1e8-4753-8033-0f276bb0955b",  # Azure 組み込みロール Storage Blob Data Owner（全 Azure 固定）
 }
 
 NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")


### PR DESCRIPTION
## 概要

外部公開サイト（Copilot Studio エージェント + WebChat SDK）を Azure Storage 静的 Web サイトに
デプロイした際の教訓を `copilot-studio` スキルに反映します。

## 変更点

### `scripts/deploy_website.py`（新規）
- `auth_helper`（standard スキル）の ARM トークンでデプロイ → **`az login` / az CLI 不要**
- ARM でリソースグループ・ストレージアカウントを冪等作成
- データプレーンは **Entra（AAD）認証**（自分に Storage Blob Data Owner を割り当て → RBAC 反映待ちリトライ）
  → 組織の Azure Policy が共有キー認証・公開 BLOB アクセスを禁止していても動作
- 設定は `.env` から取得（値のハードコードなし・汎用化）

### `references/webchat-sdk-embed.md`
- DirectLine トークンエンドポイントの**ホストは ENV_ID のハイフン除去 32 桁を「先頭30.末尾2」に分割**する点を明記（検証済み）
- 「認証なし」エージェントでもトークンエンドポイントが HTTP 200 を返すことを検証済みとして追記
- AAD デプロイ（`scripts/deploy_website.py`）と多言語（i18n）対応の手順を追記
- アカウントキー方式テンプレートは「ポリシー未制限環境のみ」と注記

### `references/external-web-embed.md`
- 旧記載の誤り（「認証なしでは DirectLine トークンエンドポイントは提供されない」）を**検証結果に基づき訂正**

### `references/troubleshooting.md`
- `KeyBasedAuthenticationNotPermitted`（共有キー禁止ポリシー）→ AAD データプレーンへ切替
- `AuthorizationPermissionMismatch` → RBAC 伝播待ちリトライ
- 静的 Web サイトは `allowBlobPublicAccess=false` でも匿名配信される
- DirectLine トークンエンドポイントのホスト分割 / 認証なしでも 200
- `az login` 不要（auth_helper で ARM/Storage トークン取得）

### `references/.env.example`
- `AZURE_SUBSCRIPTION_ID` / `AZURE_RESOURCE_GROUP` / `AZURE_LOCATION` / `AZURE_STORAGE_ACCOUNT` / `WEBCHAT_TOKEN_ENDPOINT` を追加

### `update-skills/scripts/validate_skill.py`（同梱）
- Azure 組み込みロール **Storage Blob Data Owner** の固定 ID を許可リストに追加（誤検出回避）

## 検証
- `validate_skill.py .github/skills/copilot-studio` → ✅ PASS
- 秘匿情報スキャン: 環境固有 GUID はプレースホルダー化済み

## マージ順
- 単独 PR（他のオープン PR と無関係）
