### PR TITLE
code-apps: レイアウトと配色を2軸に分離＋レイアウトテンプレート5種＋Fluent v2 アイコン対応

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -93,12 +93,13 @@ Code Apps 開発は **設計 → 初回デプロイ → データソース接続
 
 ### 設計フェーズ（実装前に必須）
 
-**コードを書く前に、デザインテンプレートの選択と UI 設計を行い、ユーザーの承認を得ること。** 手順:
+**コードを書く前に、デザインテンプレート（レイアウト）とカラーパレット（配色）の選択、UI 設計を行い、ユーザーの承認を得ること。** 手順:
 
-1. [デザインテンプレート集](references/design-templates.md) の 6 種を一覧＋プレビューで提示し、ユーザーに 1 つ選んでもらう（デプロイされるアプリは常に 1 テンプレート。dark/light は `ThemeProvider` + `ModeToggle`）。
-2. [デザインシステム](references/design-system.md) を読み込み、画面構成・コンポーネント選定・Lookup 名前解決パターンを設計する。
-3. 設計（選択テンプレート＋画面設計）を提示し、「この設計で進めてよいですか？」と承認を得る。
-4. 承認後、選択テンプレートの CSS Variables を `styles/index.pcss` に適用してから実装する（変数一式・適用手順は [デザインテンプレート集](references/design-templates.md)）。
+1. [デザインテンプレート（レイアウト）](references/design-templates.md) の 5 種（Sidebar / Dashboard / Workspace / Hero Cards / Minimal）を一覧＋プレビューで提示し、**画面の骨格**を 1 つ選んでもらう。
+2. [カラーパレット集](references/color-palettes.md) の 6 種を一覧＋プレビューで提示し、**配色**を 1 つ選んでもらう（デプロイされるアプリは常に 1 レイアウト＋1 パレット。dark/light は `ThemeProvider` + `ModeToggle`）。
+3. [デザインシステム](references/design-system.md) を読み込み、画面構成・コンポーネント選定・Lookup 名前解決パターンを設計する。
+4. 設計（選択レイアウト＋選択パレット＋画面設計）を提示し、「この設計で進めてよいですか？」と承認を得る。
+5. 承認後、選択レイアウトのアプリシェルで実装し、選択パレットの CSS Variables を `styles/index.pcss` に適用する（変数一式・適用手順は [カラーパレット集](references/color-palettes.md)）。
 
 > **CRUD 画面は [CRUD UI 標準パターン](references/crud-ui-pattern.md) に必ず従う**: 一覧は行／カード全体をクリックして詳細を開く（目アイコン等の小さなクリック領域は使わない）、詳細の編集はモーダルではなくインライン編集モード、行内の削除・クイック操作は `e.stopPropagation()`、削除確認はブラウザの `confirm()` ではなくモーダル（`useConfirm()` / AlertDialog）。**指示がなくても、テーブルごとに「一覧・詳細（インライン編集）・作成・削除」を標準実装すること。**
 
@@ -302,9 +303,11 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 
 | リファレンス | 内容 |
 |---|---|
-| [デザインテンプレート集](references/design-templates.md) | 設計時に選択する配色テンプレート 6 種（プレビュー HTML・CSS Variables 一式・light/dark 対応） |
+| [デザインテンプレート集（レイアウト）](references/design-templates.md) | 設計時に選択する画面の骨格 5 種（Sidebar / Dashboard / Workspace / Hero Cards / Minimal、プレビュー HTML・アプリシェル骨格） |
+| [カラーパレット集](references/color-palettes.md) | 設計時に選択する配色 6 種（プレビュー HTML・CSS Variables 一式・light/dark 対応） |
 | [デザインシステム](references/design-system.md) | shadcn/ui + Tailwind CSS v4 のコンポーネント選定・画面設計パターン |
 | [コンポーネントカタログ](references/component-catalog.md) | 全コンポーネントの詳細仕様・使用例 |
+| [Fluent UI v2 アイコン](references/fluent-icons.md) | @fluentui/react-icons の導入・使用・CSP 安全性と、キーワードからアイコン名を検索する `find_fluent_icon.mjs` |
 | [ステージ矢羽パターン](references/stage-path-pattern.md) | OptionSet（ステージ／ステータス）を Salesforce 風の矢羽で可視化・クリックで変更 |
 | [構築リファレンス](references/build-reference.md) | ビルド・デプロイの詳細手順・vite.config.ts 必須設定・TypeScript エラー対処 |
 | [データソースパターン](references/data-source-patterns.md) | SDK 生成サービス・dataSourcesInfo・getClient(dataSourcesInfo)・TanStack React Query |

--- a/.github/skills/code-apps/references/color-palettes.md
+++ b/.github/skills/code-apps/references/color-palettes.md
@@ -1,0 +1,603 @@
+# Code Apps カラーパレット集
+
+> **用途**: Code Apps の設計フェーズで **配色（カラーパレット）** をユーザーに提案し、選択されたパレットの CSS 変数一式を `styles/index.pcss`（または任意の CSS ファイル）の `:root` / `.dark` に適用する。
+> **ランタイム切替ではない**: デプロイされるアプリは常に 1 パレット。設計時に選択する（ダーク/ライト切替は `ThemeProvider` + `ModeToggle` で行う）。
+>
+> **配色とレイアウトは別軸**: このファイルは **配色（色）** のみを定義する。画面の骨格（サイドバー型・ダッシュボード型など）の選択は [デザインテンプレート集（レイアウト）](design-templates.md) を参照。設計フェーズでは **レイアウトを選択 → 配色を選択** の順で提案する。
+
+---
+
+## パレット選択ワークフロー
+
+```
+1. ユーザーが Code Apps の構築を依頼
+2. エージェントがまず design-templates.md でレイアウトを提示・選択
+3. 続いてこのファイルを読み込み、カラーパレット一覧を提示
+4. ユーザーが視覚プレビューを確認して 1 つ選択
+5. 選択されたパレットの CSS Variables を :root / .dark に適用
+6. --radius をパレット指定値に変更
+7. design-system.md の設計フェーズ（画面一覧・コンポーネント選定）と合わせてユーザー承認を得る
+```
+
+### 提案フォーマット（ユーザーに見せる形式）
+
+パレット一覧と視覚プレビューへのパスを以下の形式で提示すること:
+
+```
+## カラーパレットを選んでください
+
+| # | パレット名 | 配色 | 印象 | プレビュー |
+|---|--------------|------|------|-----------|
+| 1 | Ocean Blue | 🔵 ブルー | 爽やか・標準・業務アプリ全般 | previews/ocean-blue.html |
+| 2 | Indigo / Violet | 🟣 インディゴ + バイオレット | モダン・先進的・クリエイティブ | previews/indigo-violet.html |
+| 3 | Emerald / Teal | 🟢 エメラルド + ティール | ナチュラル・安心感・ヘルスケア | previews/emerald-teal.html |
+| 4 | Amber / Orange | 🟠 アンバー + オレンジ | エネルギッシュ・製造・建設 | previews/amber-orange.html |
+| 5 | Rose / Pink | 🌸 ローズ + ピンク | 親しみやすい・カジュアル・サービス業 | previews/rose-pink.html |
+| 6 | Slate Mono | ⚫ スレート（モノトーン） | ミニマル・堅実・エンタープライズ | previews/slate-mono.html |
+
+プレビュー HTML をブラウザで開くと実際の配色・レイアウトを確認できます。
+番号で選んでください（デフォルト: 1）
+```
+
+---
+
+## 共通ルール
+
+### フォントは全パレット共通（システムフォント固定）
+
+Code Apps は Google Fonts 禁止（外部通信・CSP の制約）。パレットで切り替えるのは **配色と `--radius` のみ**。フォントは変更しない:
+
+```css
+:root {
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+}
+```
+
+### バッジ変数は全パレット共通
+
+`--badge-beginner` / `--badge-intermediate` / `--badge-advanced` / `--badge-administrator` / `--badge-developer` は
+**ステータスの意味（色の記号性）を担う**ため、パレットを切り替えても変更しない。
+
+### 適用対象の変数一覧
+
+各パレットは以下の変数を上書きする:
+
+`--radius` / `--background` / `--foreground` / `--card` / `--card-foreground` / `--popover` / `--popover-foreground` /
+`--primary` / `--primary-foreground` / `--secondary` / `--secondary-foreground` / `--muted` / `--muted-foreground` /
+`--accent` / `--accent-foreground` / `--accent-hover` / `--destructive` / `--border` / `--input` / `--ring` /
+`--chart-1` 〜 `--chart-5` / `--sidebar` 系 8 変数 / `--header-bg` / `--menu-bg`
+
+---
+
+## パレット定義
+
+### 1. Ocean Blue（デフォルト）
+
+**印象**: 爽やか・標準・業務アプリ全般
+**--radius**: `0.625rem`
+**視覚プレビュー**: [previews/ocean-blue.html](previews/ocean-blue.html)
+
+#### Light Mode `:root`
+
+```css
+--background: #f0f7ff;
+--foreground: #0c2d5e;
+--card: #ffffff;
+--card-foreground: #0c2d5e;
+--popover: #ffffff;
+--popover-foreground: #0c2d5e;
+--primary: #3b82f6;
+--primary-foreground: #ffffff;
+--secondary: #dbeafe;
+--secondary-foreground: #1e3a8a;
+--muted: #e0f2fe;
+--muted-foreground: #475569;
+--accent: #60a5fa;
+--accent-foreground: #ffffff;
+--accent-hover: #bfdbfe;
+--destructive: #ef4444;
+--border: #bfdbfe;
+--input: #bfdbfe;
+--ring: #3b82f6;
+--chart-1: #3b82f6;
+--chart-2: #60a5fa;
+--chart-3: #93c5fd;
+--chart-4: #bfdbfe;
+--chart-5: #dbeafe;
+--sidebar: #f8fafc;
+--sidebar-foreground: #0c2d5e;
+--sidebar-primary: #3b82f6;
+--sidebar-primary-foreground: #ffffff;
+--sidebar-accent: #dbeafe;
+--sidebar-accent-foreground: #1e3a8a;
+--sidebar-border: #bfdbfe;
+--sidebar-ring: #3b82f6;
+--header-bg: #ffffff;
+--menu-bg: #f0f7ff;
+```
+
+#### Dark Mode `.dark`
+
+```css
+--background: #0a1929;
+--foreground: #e3f2fd;
+--card: #1e293b;
+--card-foreground: #e3f2fd;
+--popover: #1e293b;
+--popover-foreground: #e3f2fd;
+--primary: #60a5fa;
+--primary-foreground: #0a1929;
+--secondary: #1e3a8a;
+--secondary-foreground: #dbeafe;
+--muted: #1e3a8a;
+--muted-foreground: #94a3b8;
+--accent: #60a5fa;
+--accent-foreground: #0a1929;
+--accent-hover: #1e3a8a;
+--destructive: #ef4444;
+--border: #1e3a8a;
+--input: #1e3a8a;
+--ring: #60a5fa;
+--chart-1: #60a5fa;
+--chart-2: #93c5fd;
+--chart-3: #bfdbfe;
+--chart-4: #dbeafe;
+--chart-5: #eff6ff;
+--sidebar: #0f1f33;
+--sidebar-foreground: #e3f2fd;
+--sidebar-primary: #60a5fa;
+--sidebar-primary-foreground: #0a1929;
+--sidebar-accent: #1e3a8a;
+--sidebar-accent-foreground: #dbeafe;
+--sidebar-border: #1e3a8a;
+--sidebar-ring: #60a5fa;
+--header-bg: #0a1929;
+--menu-bg: #1e293b;
+```
+
+---
+
+### 2. Indigo / Violet
+
+**印象**: モダン・先進的・クリエイティブ
+**--radius**: `0.75rem`
+**視覚プレビュー**: [previews/indigo-violet.html](previews/indigo-violet.html)
+
+#### Light Mode `:root`
+
+```css
+--background: #f8fafc;
+--foreground: #0f172a;
+--card: #ffffff;
+--card-foreground: #0f172a;
+--popover: #ffffff;
+--popover-foreground: #0f172a;
+--primary: #6366f1;
+--primary-foreground: #ffffff;
+--secondary: #eef2ff;
+--secondary-foreground: #312e81;
+--muted: #f1f5f9;
+--muted-foreground: #64748b;
+--accent: #8b5cf6;
+--accent-foreground: #ffffff;
+--accent-hover: #e0e7ff;
+--destructive: #ef4444;
+--border: #e2e8f0;
+--input: #e2e8f0;
+--ring: #6366f1;
+--chart-1: #6366f1;
+--chart-2: #8b5cf6;
+--chart-3: #a78bfa;
+--chart-4: #c4b5fd;
+--chart-5: #ddd6fe;
+--sidebar: #f8fafc;
+--sidebar-foreground: #0f172a;
+--sidebar-primary: #6366f1;
+--sidebar-primary-foreground: #ffffff;
+--sidebar-accent: #e0e7ff;
+--sidebar-accent-foreground: #312e81;
+--sidebar-border: #e2e8f0;
+--sidebar-ring: #6366f1;
+--header-bg: #ffffff;
+--menu-bg: #f8fafc;
+```
+
+#### Dark Mode `.dark`
+
+```css
+--background: #030712;
+--foreground: #f1f5f9;
+--card: #111827;
+--card-foreground: #f1f5f9;
+--popover: #111827;
+--popover-foreground: #f1f5f9;
+--primary: #818cf8;
+--primary-foreground: #030712;
+--secondary: #1e293b;
+--secondary-foreground: #e2e8f0;
+--muted: #1e293b;
+--muted-foreground: #94a3b8;
+--accent: #a78bfa;
+--accent-foreground: #030712;
+--accent-hover: #312e81;
+--destructive: #f87171;
+--border: #1e293b;
+--input: #1e293b;
+--ring: #818cf8;
+--chart-1: #818cf8;
+--chart-2: #a78bfa;
+--chart-3: #c4b5fd;
+--chart-4: #ddd6fe;
+--chart-5: #ede9fe;
+--sidebar: #0a0f1e;
+--sidebar-foreground: #f1f5f9;
+--sidebar-primary: #818cf8;
+--sidebar-primary-foreground: #030712;
+--sidebar-accent: #312e81;
+--sidebar-accent-foreground: #e0e7ff;
+--sidebar-border: #1e293b;
+--sidebar-ring: #818cf8;
+--header-bg: #030712;
+--menu-bg: #111827;
+```
+
+---
+
+### 3. Emerald / Teal
+
+**印象**: ナチュラル・安心感・ヘルスケア
+**--radius**: `0.75rem`
+**視覚プレビュー**: [previews/emerald-teal.html](previews/emerald-teal.html)
+
+#### Light Mode `:root`
+
+```css
+--background: #f0fdf4;
+--foreground: #052e16;
+--card: #ffffff;
+--card-foreground: #052e16;
+--popover: #ffffff;
+--popover-foreground: #052e16;
+--primary: #059669;
+--primary-foreground: #ffffff;
+--secondary: #d1fae5;
+--secondary-foreground: #064e3b;
+--muted: #ecfdf5;
+--muted-foreground: #4b5563;
+--accent: #14b8a6;
+--accent-foreground: #ffffff;
+--accent-hover: #a7f3d0;
+--destructive: #ef4444;
+--border: #d1fae5;
+--input: #d1fae5;
+--ring: #059669;
+--chart-1: #059669;
+--chart-2: #10b981;
+--chart-3: #34d399;
+--chart-4: #6ee7b7;
+--chart-5: #a7f3d0;
+--sidebar: #ecfdf5;
+--sidebar-foreground: #052e16;
+--sidebar-primary: #059669;
+--sidebar-primary-foreground: #ffffff;
+--sidebar-accent: #d1fae5;
+--sidebar-accent-foreground: #064e3b;
+--sidebar-border: #d1fae5;
+--sidebar-ring: #059669;
+--header-bg: #ffffff;
+--menu-bg: #f0fdf4;
+```
+
+#### Dark Mode `.dark`
+
+```css
+--background: #022c22;
+--foreground: #d1fae5;
+--card: #064e3b;
+--card-foreground: #d1fae5;
+--popover: #064e3b;
+--popover-foreground: #d1fae5;
+--primary: #34d399;
+--primary-foreground: #022c22;
+--secondary: #065f46;
+--secondary-foreground: #d1fae5;
+--muted: #065f46;
+--muted-foreground: #9ca3af;
+--accent: #2dd4bf;
+--accent-foreground: #022c22;
+--accent-hover: #065f46;
+--destructive: #f87171;
+--border: #065f46;
+--input: #065f46;
+--ring: #34d399;
+--chart-1: #34d399;
+--chart-2: #6ee7b7;
+--chart-3: #a7f3d0;
+--chart-4: #d1fae5;
+--chart-5: #ecfdf5;
+--sidebar: #04231c;
+--sidebar-foreground: #d1fae5;
+--sidebar-primary: #34d399;
+--sidebar-primary-foreground: #022c22;
+--sidebar-accent: #065f46;
+--sidebar-accent-foreground: #d1fae5;
+--sidebar-border: #065f46;
+--sidebar-ring: #34d399;
+--header-bg: #022c22;
+--menu-bg: #064e3b;
+```
+
+---
+
+### 4. Amber / Orange
+
+**印象**: エネルギッシュ・製造・建設
+**--radius**: `0.5rem`
+**視覚プレビュー**: [previews/amber-orange.html](previews/amber-orange.html)
+
+#### Light Mode `:root`
+
+```css
+--background: #fffbeb;
+--foreground: #431407;
+--card: #ffffff;
+--card-foreground: #431407;
+--popover: #ffffff;
+--popover-foreground: #431407;
+--primary: #ea580c;
+--primary-foreground: #ffffff;
+--secondary: #ffedd5;
+--secondary-foreground: #7c2d12;
+--muted: #fef3c7;
+--muted-foreground: #78716c;
+--accent: #f59e0b;
+--accent-foreground: #ffffff;
+--accent-hover: #fed7aa;
+--destructive: #dc2626;
+--border: #fde68a;
+--input: #fde68a;
+--ring: #ea580c;
+--chart-1: #ea580c;
+--chart-2: #f97316;
+--chart-3: #fb923c;
+--chart-4: #fdba74;
+--chart-5: #fed7aa;
+--sidebar: #fff7ed;
+--sidebar-foreground: #431407;
+--sidebar-primary: #ea580c;
+--sidebar-primary-foreground: #ffffff;
+--sidebar-accent: #ffedd5;
+--sidebar-accent-foreground: #7c2d12;
+--sidebar-border: #fde68a;
+--sidebar-ring: #ea580c;
+--header-bg: #ffffff;
+--menu-bg: #fffbeb;
+```
+
+#### Dark Mode `.dark`
+
+```css
+--background: #0c0a09;
+--foreground: #fef3c7;
+--card: #1c1917;
+--card-foreground: #fef3c7;
+--popover: #1c1917;
+--popover-foreground: #fef3c7;
+--primary: #fb923c;
+--primary-foreground: #0c0a09;
+--secondary: #292524;
+--secondary-foreground: #fed7aa;
+--muted: #292524;
+--muted-foreground: #a8a29e;
+--accent: #fbbf24;
+--accent-foreground: #0c0a09;
+--accent-hover: #7c2d12;
+--destructive: #f87171;
+--border: #292524;
+--input: #292524;
+--ring: #fb923c;
+--chart-1: #fb923c;
+--chart-2: #fdba74;
+--chart-3: #fed7aa;
+--chart-4: #fef3c7;
+--chart-5: #fffbeb;
+--sidebar: #171310;
+--sidebar-foreground: #fef3c7;
+--sidebar-primary: #fb923c;
+--sidebar-primary-foreground: #0c0a09;
+--sidebar-accent: #7c2d12;
+--sidebar-accent-foreground: #fed7aa;
+--sidebar-border: #292524;
+--sidebar-ring: #fb923c;
+--header-bg: #0c0a09;
+--menu-bg: #1c1917;
+```
+
+---
+
+### 5. Rose / Pink
+
+**印象**: 親しみやすい・カジュアル・サービス業
+**--radius**: `1rem`
+**視覚プレビュー**: [previews/rose-pink.html](previews/rose-pink.html)
+
+> primary がローズ系のため、destructive は赤の彩度・明度を変えた `#b91c1c`（light）/ `#f87171`（dark）で区別する。
+
+#### Light Mode `:root`
+
+```css
+--background: #fff1f2;
+--foreground: #4c0519;
+--card: #ffffff;
+--card-foreground: #4c0519;
+--popover: #ffffff;
+--popover-foreground: #4c0519;
+--primary: #e11d48;
+--primary-foreground: #ffffff;
+--secondary: #ffe4e6;
+--secondary-foreground: #881337;
+--muted: #fce7f3;
+--muted-foreground: #6b7280;
+--accent: #ec4899;
+--accent-foreground: #ffffff;
+--accent-hover: #fecdd3;
+--destructive: #b91c1c;
+--border: #fecdd3;
+--input: #fecdd3;
+--ring: #e11d48;
+--chart-1: #e11d48;
+--chart-2: #f43f5e;
+--chart-3: #fb7185;
+--chart-4: #fda4af;
+--chart-5: #fecdd3;
+--sidebar: #fff1f2;
+--sidebar-foreground: #4c0519;
+--sidebar-primary: #e11d48;
+--sidebar-primary-foreground: #ffffff;
+--sidebar-accent: #ffe4e6;
+--sidebar-accent-foreground: #881337;
+--sidebar-border: #fecdd3;
+--sidebar-ring: #e11d48;
+--header-bg: #ffffff;
+--menu-bg: #fff1f2;
+```
+
+#### Dark Mode `.dark`
+
+```css
+--background: #1a0a12;
+--foreground: #ffe4e6;
+--card: #2a141e;
+--card-foreground: #ffe4e6;
+--popover: #2a141e;
+--popover-foreground: #ffe4e6;
+--primary: #fb7185;
+--primary-foreground: #1a0a12;
+--secondary: #4c0519;
+--secondary-foreground: #fecdd3;
+--muted: #3f1322;
+--muted-foreground: #b89aa5;
+--accent: #f472b6;
+--accent-foreground: #1a0a12;
+--accent-hover: #4c0519;
+--destructive: #f87171;
+--border: #3f1322;
+--input: #3f1322;
+--ring: #fb7185;
+--chart-1: #fb7185;
+--chart-2: #fda4af;
+--chart-3: #fecdd3;
+--chart-4: #ffe4e6;
+--chart-5: #fff1f2;
+--sidebar: #200d16;
+--sidebar-foreground: #ffe4e6;
+--sidebar-primary: #fb7185;
+--sidebar-primary-foreground: #1a0a12;
+--sidebar-accent: #4c0519;
+--sidebar-accent-foreground: #fecdd3;
+--sidebar-border: #3f1322;
+--sidebar-ring: #fb7185;
+--header-bg: #1a0a12;
+--menu-bg: #2a141e;
+```
+
+---
+
+### 6. Slate Mono
+
+**印象**: ミニマル・堅実・エンタープライズ
+**--radius**: `0.375rem`
+**視覚プレビュー**: [previews/slate-mono.html](previews/slate-mono.html)
+
+> 彩色をほぼ持たないモノトーン。チャートはスレートのグラデーションになるため、
+> 系列数が多いダッシュボードでは系列の区別がつきにくい。チャート中心のアプリでは 1〜5 を推奨。
+
+#### Light Mode `:root`
+
+```css
+--background: #f8fafc;
+--foreground: #0f172a;
+--card: #ffffff;
+--card-foreground: #0f172a;
+--popover: #ffffff;
+--popover-foreground: #0f172a;
+--primary: #334155;
+--primary-foreground: #ffffff;
+--secondary: #f1f5f9;
+--secondary-foreground: #334155;
+--muted: #f1f5f9;
+--muted-foreground: #64748b;
+--accent: #475569;
+--accent-foreground: #ffffff;
+--accent-hover: #e2e8f0;
+--destructive: #dc2626;
+--border: #e2e8f0;
+--input: #e2e8f0;
+--ring: #334155;
+--chart-1: #334155;
+--chart-2: #475569;
+--chart-3: #64748b;
+--chart-4: #94a3b8;
+--chart-5: #cbd5e1;
+--sidebar: #f1f5f9;
+--sidebar-foreground: #0f172a;
+--sidebar-primary: #334155;
+--sidebar-primary-foreground: #ffffff;
+--sidebar-accent: #e2e8f0;
+--sidebar-accent-foreground: #334155;
+--sidebar-border: #e2e8f0;
+--sidebar-ring: #334155;
+--header-bg: #ffffff;
+--menu-bg: #f8fafc;
+```
+
+#### Dark Mode `.dark`
+
+```css
+--background: #020617;
+--foreground: #e2e8f0;
+--card: #0f172a;
+--card-foreground: #e2e8f0;
+--popover: #0f172a;
+--popover-foreground: #e2e8f0;
+--primary: #94a3b8;
+--primary-foreground: #020617;
+--secondary: #1e293b;
+--secondary-foreground: #e2e8f0;
+--muted: #1e293b;
+--muted-foreground: #94a3b8;
+--accent: #cbd5e1;
+--accent-foreground: #020617;
+--accent-hover: #1e293b;
+--destructive: #f87171;
+--border: #1e293b;
+--input: #1e293b;
+--ring: #94a3b8;
+--chart-1: #94a3b8;
+--chart-2: #cbd5e1;
+--chart-3: #e2e8f0;
+--chart-4: #f1f5f9;
+--chart-5: #f8fafc;
+--sidebar: #0b1120;
+--sidebar-foreground: #e2e8f0;
+--sidebar-primary: #94a3b8;
+--sidebar-primary-foreground: #020617;
+--sidebar-accent: #1e293b;
+--sidebar-accent-foreground: #e2e8f0;
+--sidebar-border: #1e293b;
+--sidebar-ring: #94a3b8;
+--header-bg: #020617;
+--menu-bg: #0f172a;
+```
+
+---
+
+## 適用チェックリスト
+
+テンプレート適用後、以下を確認する:
+
+- [ ] `:root` / `.dark` の両方に全変数を適用した（片方だけ適用すると切替時に旧テーマが残る）
+- [ ] `--radius` をテンプレート指定値に変更した
+- [ ] バッジ変数（`--badge-*`）は変更していない
+- [ ] フォント設定（`font-family`）は変更していない
+- [ ] ライト/ダーク両モードで主要画面の文字コントラストを目視確認した

--- a/.github/skills/code-apps/references/design-system.md
+++ b/.github/skills/code-apps/references/design-system.md
@@ -57,26 +57,26 @@ Code Apps の画面を設計・実装する。
 | カラム定義 | テーブルのカラム構成・render 関数 |
 | Lookup 名前解決 | `_xxx_value` + `useMemo` Map パターンでどの Lookup を解決するか |
 | ナビゲーション | サイドバー項目・ページ遷移 |
-| デザインテンプレート | [デザインテンプレート集](design-templates.md) から選択した配色 |
+| デザインテンプレート（レイアウト） | [デザインテンプレート集](design-templates.md) から選択した画面の骨格 |
+| カラーパレット | [カラーパレット集](color-palettes.md) から選択した配色 |
 | テーマ | ダーク/ライトモード対応 |
 
 ```
 フロー: code-apps（design-system）で設計 → ユーザー承認 → code-apps で実装
 ```
 
-## デザインテンプレート選択
+## デザインテンプレート（レイアウト）＋カラーパレット選択
 
-新しい Code Apps の設計時は、まず **[デザインテンプレート集](design-templates.md)** を読み込み、ユーザーにテンプレートを提案すること。
+新しい Code Apps の設計時は、まず **[デザインテンプレート集（レイアウト）](design-templates.md)** で画面の骨格を提案し、続いて **[カラーパレット集](color-palettes.md)** で配色を提案すること。
 
 **ワークフロー**:
-1. `design-templates.md` を読み込む
-2. テンプレート一覧表をユーザーに提示
-3. ユーザーが番号で選択
-4. 選択テンプレートの CSS Variables を `styles/index.pcss` の `:root` / `.dark` に適用
-5. デフォルト未指定の場合は **1. Ocean Blue** を使用
+1. `design-templates.md` を読み込み、レイアウト一覧表を提示 → ユーザーが番号で選択（デフォルト: **1. Sidebar**）
+2. `color-palettes.md` を読み込み、カラーパレット一覧表を提示 → ユーザーが番号で選択（デフォルト: **1. Ocean Blue**）
+3. 選択パレットの CSS Variables を `styles/index.pcss` の `:root` / `.dark` に適用
+4. 選択レイアウトのアプリシェルで実装
 
-> テンプレートはビルド時に確定する（ランタイム切替は行わない）。
-> 切り替えるのは配色と `--radius` のみ。フォントはシステムフォント固定（下記「標準フォント方針」参照）、
+> レイアウトも配色もビルド時に確定する（ランタイム切替は行わない）。
+> 配色で切り替えるのは色と `--radius` のみ。フォントはシステムフォント固定（下記「標準フォント方針」参照）、
 > バッジ変数・`@theme inline` ブロックは変更しない。
 
 ## 大前提: 一つのソリューション内に開発
@@ -90,7 +90,7 @@ UI コンポーネントの実装先となる Code Apps も同一ソリューシ
 |---------|------|
 | スタイリング | Tailwind CSS v4 + CSS カスタムプロパティ |
 | UIプリミティブ | shadcn/ui（Radix UI ベース） |
-| アイコン | lucide-react |
+| アイコン | lucide-react（shadcn 内部の標準）/ 任意で @fluentui/react-icons（Fluent UI v2、[fluent-icons.md](fluent-icons.md)） |
 | チャート | Recharts |
 | ドラッグ＆ドロップ | dnd-kit v6 |
 | ダイアグラム | Mermaid |

--- a/.github/skills/code-apps/references/design-templates.md
+++ b/.github/skills/code-apps/references/design-templates.md
@@ -1,7 +1,10 @@
-# Code Apps デザインテンプレート集
+# Code Apps デザインテンプレート集（レイアウト）
 
-> **用途**: Code Apps の設計フェーズでユーザーにデザインテンプレートを提案し、選択されたテンプレートの CSS 変数一式を `styles/index.pcss`（または任意の CSS ファイル）の `:root` / `.dark` に適用する。
-> **ランタイム切替ではない**: デプロイされるアプリは常に 1 テンプレート。設計時に選択する（ダーク/ライト切替は `ThemeProvider` + `ModeToggle` で行う）。
+> **用途**: Code Apps の設計フェーズで **画面の骨格（レイアウト）** をユーザーに提案し、選択されたレイアウトのアプリシェル構造（React + Tailwind + shadcn/ui）で実装する。
+> **配色とは別軸**: このファイルは **レイアウト（画面構造）** のみを定義する。色は [カラーパレット集](color-palettes.md) を参照。設計フェーズでは **レイアウトを選択 → 配色を選択** の順で提案する。
+> **ランタイム切替ではない**: デプロイされるアプリは常に 1 レイアウト。設計時に選択する。
+
+> **既存 samples はそのまま**: `samples/` の各アプリ（geek-sales / geek-hr 等）は **Sidebar レイアウト（下記 #1）** をベースに機能実装済み。テンプレートは色違いではなく、**画面の骨格の違い**で選ぶ。
 
 ---
 
@@ -9,592 +12,241 @@
 
 ```
 1. ユーザーが Code Apps の構築を依頼
-2. エージェントがこのファイルを読み込み、テンプレート一覧を提示
+2. エージェントがこのファイルを読み込み、レイアウト一覧＋プレビューを提示
 3. ユーザーが視覚プレビューを確認して 1 つ選択
-4. 選択されたテンプレートの CSS Variables を :root / .dark に適用
-5. --radius をテンプレート指定値に変更
-6. design-system.md の設計フェーズ（画面一覧・コンポーネント選定）と合わせてユーザー承認を得る
+4. 続いて color-palettes.md でカラーパレットを選択
+5. design-system.md の設計フェーズ（画面一覧・コンポーネント選定）と合わせてユーザー承認を得る
+6. 承認後、選択レイアウトのアプリシェルで実装（配色は選択パレットの CSS Variables を適用）
 ```
 
 ### 提案フォーマット（ユーザーに見せる形式）
 
-テンプレート一覧と視覚プレビューへのパスを以下の形式で提示すること:
-
 ```
-## デザインテンプレートを選んでください
+## デザインテンプレート（レイアウト）を選んでください
 
-| # | テンプレート名 | 配色 | 印象 | プレビュー |
-|---|--------------|------|------|-----------|
-| 1 | Ocean Blue | 🔵 ブルー | 爽やか・標準・業務アプリ全般 | previews/ocean-blue.html |
-| 2 | Indigo / Violet | 🟣 インディゴ + バイオレット | モダン・先進的・クリエイティブ | previews/indigo-violet.html |
-| 3 | Emerald / Teal | 🟢 エメラルド + ティール | ナチュラル・安心感・ヘルスケア | previews/emerald-teal.html |
-| 4 | Amber / Orange | 🟠 アンバー + オレンジ | エネルギッシュ・製造・建設 | previews/amber-orange.html |
-| 5 | Rose / Pink | 🌸 ローズ + ピンク | 親しみやすい・カジュアル・サービス業 | previews/rose-pink.html |
-| 6 | Slate Mono | ⚫ スレート（モノトーン） | ミニマル・堅実・エンタープライズ | previews/slate-mono.html |
+| # | レイアウト名 | 骨格 | 向いている用途 | プレビュー |
+|---|-----------|------|--------------|-----------|
+| 1 | Sidebar（標準） | 固定左ナビ + フル高さコンテンツ | 業務アプリ全般（samples の標準） | previews/layout-sidebar.html |
+| 2 | Dashboard | ヘッダー + KPI スタットカード + メイン | 数値サマリ重視の管理画面 | previews/layout-dashboard.html |
+| 3 | Workspace | 2 カラム（左作業パネル + 右メイン） | フィルタ/操作と詳細を並置 | previews/layout-workspace.html |
+| 4 | Hero Cards | ヒーロー + 特徴カード + セクション | ポータルのトップ/ランディング | previews/layout-hero-cards.html |
+| 5 | Minimal | 中央 1 カラム（最大幅制限） | フォーム中心・単機能アプリ | previews/layout-minimal.html |
 
-プレビュー HTML をブラウザで開くと実際の配色・レイアウトを確認できます。
+プレビュー HTML をブラウザで開くと実際の骨格を確認できます。
 番号で選んでください（デフォルト: 1）
 ```
+
+> このレイアウト集は、外部公開 WebChat のライトモード・レイアウト
+> （copilot-studio スキルの [webchat-sdk-light-templates.md](../../copilot-studio/references/webchat-sdk-light-templates.md)）を
+> Code Apps（React + Tailwind + shadcn/ui）のアプリシェルに変換したもの。用途は同じ発想で選ぶ。
 
 ---
 
 ## 共通ルール
 
-### フォントは全テンプレート共通（システムフォント固定）
+### レイアウトは「アプリシェル」で表現する
 
-Code Apps は Google Fonts 禁止（外部通信・CSP の制約）。テンプレートで切り替えるのは **配色と `--radius` のみ**。フォントは変更しない:
+レイアウトは配色（CSS Variables）ではなく、**アプリシェル（`App.tsx` / `src/components/layout/*`）の構造**で決まる。
+どのレイアウトでも:
 
-```css
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-}
-```
+- ルーティングは `react-router` を使う（ページはレイアウト内の `<Outlet />` / メイン領域に描画）。
+- 色は [color-palettes.md](color-palettes.md) の CSS Variables（`--background` / `--card` / `--sidebar` 系など）を使い、レイアウト側では **色をハードコードしない**。
+- コンポーネントは shadcn/ui（`Card` / `Button` / `Sidebar` / `Table` など）を使う。
+- ダーク/ライト切替は `ThemeProvider` + `ModeToggle`。フォントはシステムフォント固定（Google Fonts 禁止）。
 
-### バッジ変数は全テンプレート共通
+### レスポンシブ（sticky 重なり対策）
 
-`--badge-beginner` / `--badge-intermediate` / `--badge-advanced` / `--badge-administrator` / `--badge-developer` は
-**ステータスの意味（色の記号性）を担う**ため、テンプレートを切り替えても変更しない。
-
-### 適用対象の変数一覧
-
-各テンプレートは以下の変数を上書きする:
-
-`--radius` / `--background` / `--foreground` / `--card` / `--card-foreground` / `--popover` / `--popover-foreground` /
-`--primary` / `--primary-foreground` / `--secondary` / `--secondary-foreground` / `--muted` / `--muted-foreground` /
-`--accent` / `--accent-foreground` / `--accent-hover` / `--destructive` / `--border` / `--input` / `--ring` /
-`--chart-1` 〜 `--chart-5` / `--sidebar` 系 8 変数 / `--header-bg` / `--menu-bg`
+2 カラム系（Workspace / Dashboard）で左パネルや右パネルを `sticky` にする場合、
+シングルカラムに落とすブレークポイントで **必ず `position: static` に戻す**（`sticky` が残ると縦スクロール時に重なる）。
+Tailwind では `lg:sticky lg:top-6`（＝小画面では sticky を付けない）で表現する。
 
 ---
 
 ## テンプレート定義
 
-### 1. Ocean Blue（デフォルト）
+### 1. Sidebar（標準・デフォルト）
 
-**印象**: 爽やか・標準・業務アプリ全般
-**--radius**: `0.625rem`
-**視覚プレビュー**: [previews/ocean-blue.html](previews/ocean-blue.html)
+**印象/用途**: 業務アプリ全般。ナビ項目が多い CRUD 中心のアプリ。**既存 samples の標準レイアウト**。
+**骨格**:
 
-#### Light Mode `:root`
-
-```css
---background: #f0f7ff;
---foreground: #0c2d5e;
---card: #ffffff;
---card-foreground: #0c2d5e;
---popover: #ffffff;
---popover-foreground: #0c2d5e;
---primary: #3b82f6;
---primary-foreground: #ffffff;
---secondary: #dbeafe;
---secondary-foreground: #1e3a8a;
---muted: #e0f2fe;
---muted-foreground: #475569;
---accent: #60a5fa;
---accent-foreground: #ffffff;
---accent-hover: #bfdbfe;
---destructive: #ef4444;
---border: #bfdbfe;
---input: #bfdbfe;
---ring: #3b82f6;
---chart-1: #3b82f6;
---chart-2: #60a5fa;
---chart-3: #93c5fd;
---chart-4: #bfdbfe;
---chart-5: #dbeafe;
---sidebar: #f8fafc;
---sidebar-foreground: #0c2d5e;
---sidebar-primary: #3b82f6;
---sidebar-primary-foreground: #ffffff;
---sidebar-accent: #dbeafe;
---sidebar-accent-foreground: #1e3a8a;
---sidebar-border: #bfdbfe;
---sidebar-ring: #3b82f6;
---header-bg: #ffffff;
---menu-bg: #f0f7ff;
+```
+┌────────────┬──────────────────────────────┐
+│            │  ヘッダー（タイトル / ModeToggle）│
+│  固定       ├──────────────────────────────┤
+│  左ナビ     │                              │
+│  (Sidebar) │  メイン（<Outlet /> ページ）     │
+│            │                              │
+└────────────┴──────────────────────────────┘
 ```
 
-#### Dark Mode `.dark`
+**使用コンポーネント**: shadcn `Sidebar` / `SidebarProvider` / `SidebarTrigger`、`Card`、`Table`。
+**アプリシェル骨格**:
 
-```css
---background: #0a1929;
---foreground: #e3f2fd;
---card: #1e293b;
---card-foreground: #e3f2fd;
---popover: #1e293b;
---popover-foreground: #e3f2fd;
---primary: #60a5fa;
---primary-foreground: #0a1929;
---secondary: #1e3a8a;
---secondary-foreground: #dbeafe;
---muted: #1e3a8a;
---muted-foreground: #94a3b8;
---accent: #60a5fa;
---accent-foreground: #0a1929;
---accent-hover: #1e3a8a;
---destructive: #ef4444;
---border: #1e3a8a;
---input: #1e3a8a;
---ring: #60a5fa;
---chart-1: #60a5fa;
---chart-2: #93c5fd;
---chart-3: #bfdbfe;
---chart-4: #dbeafe;
---chart-5: #eff6ff;
---sidebar: #0f1f33;
---sidebar-foreground: #e3f2fd;
---sidebar-primary: #60a5fa;
---sidebar-primary-foreground: #0a1929;
---sidebar-accent: #1e3a8a;
---sidebar-accent-foreground: #dbeafe;
---sidebar-border: #1e3a8a;
---sidebar-ring: #60a5fa;
---header-bg: #0a1929;
---menu-bg: #1e293b;
+```tsx
+<SidebarProvider>
+  <AppSidebar />               {/* 固定左ナビ（ロゴ + メニュー） */}
+  <SidebarInset>
+    <header className="flex h-14 items-center gap-2 border-b px-4">
+      <SidebarTrigger />
+      <h1 className="text-sm font-semibold">{title}</h1>
+      <div className="ml-auto"><ModeToggle /></div>
+    </header>
+    <main className="flex-1 p-6"><Outlet /></main>
+  </SidebarInset>
+</SidebarProvider>
 ```
 
 ---
 
-### 2. Indigo / Violet
+### 2. Dashboard
 
-**印象**: モダン・先進的・クリエイティブ
-**--radius**: `0.75rem`
-**視覚プレビュー**: [previews/indigo-violet.html](previews/indigo-violet.html)
+**印象/用途**: 数値サマリ重視の管理画面。トップに KPI、その下に一覧やグラフ。
+**骨格**:
 
-#### Light Mode `:root`
-
-```css
---background: #f8fafc;
---foreground: #0f172a;
---card: #ffffff;
---card-foreground: #0f172a;
---popover: #ffffff;
---popover-foreground: #0f172a;
---primary: #6366f1;
---primary-foreground: #ffffff;
---secondary: #eef2ff;
---secondary-foreground: #312e81;
---muted: #f1f5f9;
---muted-foreground: #64748b;
---accent: #8b5cf6;
---accent-foreground: #ffffff;
---accent-hover: #e0e7ff;
---destructive: #ef4444;
---border: #e2e8f0;
---input: #e2e8f0;
---ring: #6366f1;
---chart-1: #6366f1;
---chart-2: #8b5cf6;
---chart-3: #a78bfa;
---chart-4: #c4b5fd;
---chart-5: #ddd6fe;
---sidebar: #f8fafc;
---sidebar-foreground: #0f172a;
---sidebar-primary: #6366f1;
---sidebar-primary-foreground: #ffffff;
---sidebar-accent: #e0e7ff;
---sidebar-accent-foreground: #312e81;
---sidebar-border: #e2e8f0;
---sidebar-ring: #6366f1;
---header-bg: #ffffff;
---menu-bg: #f8fafc;
+```
+┌──────────────────────────────────────────┐
+│  ヘッダー（タイトル / ModeToggle）            │
+├──────────────────────────────────────────┤
+│ [KPI] [KPI] [KPI] [KPI]   ← スタットカード列  │
+├────────────────────────┬─────────────────┤
+│  メイン（一覧 / グラフ）    │  サブ（内訳 / 直近）│
+└────────────────────────┴─────────────────┘
 ```
 
-#### Dark Mode `.dark`
+**使用コンポーネント**: `Card`（KPI）、`Table`、chart（recharts + `--chart-1〜5`）。
+**アプリシェル骨格**:
 
-```css
---background: #030712;
---foreground: #f1f5f9;
---card: #111827;
---card-foreground: #f1f5f9;
---popover: #111827;
---popover-foreground: #f1f5f9;
---primary: #818cf8;
---primary-foreground: #030712;
---secondary: #1e293b;
---secondary-foreground: #e2e8f0;
---muted: #1e293b;
---muted-foreground: #94a3b8;
---accent: #a78bfa;
---accent-foreground: #030712;
---accent-hover: #312e81;
---destructive: #f87171;
---border: #1e293b;
---input: #1e293b;
---ring: #818cf8;
---chart-1: #818cf8;
---chart-2: #a78bfa;
---chart-3: #c4b5fd;
---chart-4: #ddd6fe;
---chart-5: #ede9fe;
---sidebar: #0a0f1e;
---sidebar-foreground: #f1f5f9;
---sidebar-primary: #818cf8;
---sidebar-primary-foreground: #030712;
---sidebar-accent: #312e81;
---sidebar-accent-foreground: #e0e7ff;
---sidebar-border: #1e293b;
---sidebar-ring: #818cf8;
---header-bg: #030712;
---menu-bg: #111827;
+```tsx
+<div className="min-h-svh bg-background">
+  <header className="flex h-14 items-center border-b px-6">
+    <h1 className="font-semibold">{title}</h1>
+    <div className="ml-auto"><ModeToggle /></div>
+  </header>
+  <main className="mx-auto max-w-7xl space-y-6 p-6">
+    <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {kpis.map(k => <StatCard key={k.id} {...k} />)}
+    </section>
+    <div className="grid gap-6 lg:grid-cols-3">
+      <div className="lg:col-span-2"><Outlet /></div>
+      <aside className="space-y-4">{/* 内訳・直近 */}</aside>
+    </div>
+  </main>
+</div>
 ```
 
 ---
 
-### 3. Emerald / Teal
+### 3. Workspace
 
-**印象**: ナチュラル・安心感・ヘルスケア
-**--radius**: `0.75rem`
-**視覚プレビュー**: [previews/emerald-teal.html](previews/emerald-teal.html)
+**印象/用途**: 左に作業パネル（フィルタ・アクション・カテゴリ）、右にメイン。操作と結果を並置する業務ポータル。
+**骨格**:
 
-#### Light Mode `:root`
-
-```css
---background: #f0fdf4;
---foreground: #052e16;
---card: #ffffff;
---card-foreground: #052e16;
---popover: #ffffff;
---popover-foreground: #052e16;
---primary: #059669;
---primary-foreground: #ffffff;
---secondary: #d1fae5;
---secondary-foreground: #064e3b;
---muted: #ecfdf5;
---muted-foreground: #4b5563;
---accent: #14b8a6;
---accent-foreground: #ffffff;
---accent-hover: #a7f3d0;
---destructive: #ef4444;
---border: #d1fae5;
---input: #d1fae5;
---ring: #059669;
---chart-1: #059669;
---chart-2: #10b981;
---chart-3: #34d399;
---chart-4: #6ee7b7;
---chart-5: #a7f3d0;
---sidebar: #ecfdf5;
---sidebar-foreground: #052e16;
---sidebar-primary: #059669;
---sidebar-primary-foreground: #ffffff;
---sidebar-accent: #d1fae5;
---sidebar-accent-foreground: #064e3b;
---sidebar-border: #d1fae5;
---sidebar-ring: #059669;
---header-bg: #ffffff;
---menu-bg: #f0fdf4;
+```
+┌──────────────────────────────────────────┐
+│  ヘッダー                                    │
+├──────────────┬───────────────────────────┤
+│  左パネル      │                           │
+│ (フィルタ/操作)  │  メイン（<Outlet />）        │
+│  lg:sticky    │                           │
+└──────────────┴───────────────────────────┘
 ```
 
-#### Dark Mode `.dark`
+**使用コンポーネント**: `Card`（左パネル）、`Button` / `Input` / `Select`（操作）、右は `Table` / 詳細。
+**アプリシェル骨格**:
 
-```css
---background: #022c22;
---foreground: #d1fae5;
---card: #064e3b;
---card-foreground: #d1fae5;
---popover: #064e3b;
---popover-foreground: #d1fae5;
---primary: #34d399;
---primary-foreground: #022c22;
---secondary: #065f46;
---secondary-foreground: #d1fae5;
---muted: #065f46;
---muted-foreground: #9ca3af;
---accent: #2dd4bf;
---accent-foreground: #022c22;
---accent-hover: #065f46;
---destructive: #f87171;
---border: #065f46;
---input: #065f46;
---ring: #34d399;
---chart-1: #34d399;
---chart-2: #6ee7b7;
---chart-3: #a7f3d0;
---chart-4: #d1fae5;
---chart-5: #ecfdf5;
---sidebar: #04231c;
---sidebar-foreground: #d1fae5;
---sidebar-primary: #34d399;
---sidebar-primary-foreground: #022c22;
---sidebar-accent: #065f46;
---sidebar-accent-foreground: #d1fae5;
---sidebar-border: #065f46;
---sidebar-ring: #34d399;
---header-bg: #022c22;
---menu-bg: #064e3b;
+```tsx
+<div className="min-h-svh bg-background">
+  <header className="flex h-14 items-center border-b px-6">…</header>
+  <div className="mx-auto grid max-w-7xl gap-6 p-6 lg:grid-cols-[320px_1fr]">
+    <aside className="space-y-4 lg:sticky lg:top-6 lg:self-start">
+      {/* フィルタ・カテゴリ・アクション */}
+    </aside>
+    <main><Outlet /></main>
+  </div>
+</div>
+```
+
+> `lg:sticky lg:top-6` は **大画面のみ** sticky。小画面ではシングルカラムに落ちて重ならない。
+
+---
+
+### 4. Hero Cards
+
+**印象/用途**: ポータルのトップ/ランディング。ヒーロー見出し + 機能への入口カード + セクション。
+**骨格**:
+
+```
+┌──────────────────────────────────────────┐
+│            ヒーロー（見出し + CTA）           │
+├────────────┬────────────┬────────────────┤
+│  特徴カード   │  特徴カード   │  特徴カード       │
+├────────────┴────────────┴────────────────┤
+│            セクション（一覧 / 説明）          │
+└──────────────────────────────────────────┘
+```
+
+**使用コンポーネント**: `Card`（特徴カード、`Link` でページ遷移）、`Button`（CTA）。
+**アプリシェル骨格**:
+
+```tsx
+<div className="min-h-svh bg-background">
+  <header className="flex h-14 items-center border-b px-6">…</header>
+  <main className="mx-auto max-w-6xl space-y-12 p-6">
+    <section className="space-y-4 py-10 text-center">
+      <h1 className="text-3xl font-bold">{title}</h1>
+      <p className="text-muted-foreground">{subtitle}</p>
+      <Button asChild><Link to="/start">はじめる</Link></Button>
+    </section>
+    <section className="grid gap-6 md:grid-cols-3">
+      {features.map(f => (
+        <Card key={f.id} className="transition hover:-translate-y-1">…</Card>
+      ))}
+    </section>
+    <section><Outlet /></section>
+  </main>
+</div>
 ```
 
 ---
 
-### 4. Amber / Orange
+### 5. Minimal
 
-**印象**: エネルギッシュ・製造・建設
-**--radius**: `0.5rem`
-**視覚プレビュー**: [previews/amber-orange.html](previews/amber-orange.html)
+**印象/用途**: フォーム中心・単機能アプリ。中央 1 カラムで最大幅を絞り、余白で読みやすく。
+**骨格**:
 
-#### Light Mode `:root`
-
-```css
---background: #fffbeb;
---foreground: #431407;
---card: #ffffff;
---card-foreground: #431407;
---popover: #ffffff;
---popover-foreground: #431407;
---primary: #ea580c;
---primary-foreground: #ffffff;
---secondary: #ffedd5;
---secondary-foreground: #7c2d12;
---muted: #fef3c7;
---muted-foreground: #78716c;
---accent: #f59e0b;
---accent-foreground: #ffffff;
---accent-hover: #fed7aa;
---destructive: #dc2626;
---border: #fde68a;
---input: #fde68a;
---ring: #ea580c;
---chart-1: #ea580c;
---chart-2: #f97316;
---chart-3: #fb923c;
---chart-4: #fdba74;
---chart-5: #fed7aa;
---sidebar: #fff7ed;
---sidebar-foreground: #431407;
---sidebar-primary: #ea580c;
---sidebar-primary-foreground: #ffffff;
---sidebar-accent: #ffedd5;
---sidebar-accent-foreground: #7c2d12;
---sidebar-border: #fde68a;
---sidebar-ring: #ea580c;
---header-bg: #ffffff;
---menu-bg: #fffbeb;
+```
+┌──────────────────────────────────────────┐
+│  ヘッダー（中央寄せ / ModeToggle）            │
+├──────────────────────────────────────────┤
+│              ┌──────────────┐              │
+│              │  中央コンテンツ   │  ← max-w   │
+│              │  (<Outlet />)  │              │
+│              └──────────────┘              │
+└──────────────────────────────────────────┘
 ```
 
-#### Dark Mode `.dark`
+**使用コンポーネント**: `Card`、`Form`（react-hook-form + zod）、`Input` / `Button`。
+**アプリシェル骨格**:
 
-```css
---background: #0c0a09;
---foreground: #fef3c7;
---card: #1c1917;
---card-foreground: #fef3c7;
---popover: #1c1917;
---popover-foreground: #fef3c7;
---primary: #fb923c;
---primary-foreground: #0c0a09;
---secondary: #292524;
---secondary-foreground: #fed7aa;
---muted: #292524;
---muted-foreground: #a8a29e;
---accent: #fbbf24;
---accent-foreground: #0c0a09;
---accent-hover: #7c2d12;
---destructive: #f87171;
---border: #292524;
---input: #292524;
---ring: #fb923c;
---chart-1: #fb923c;
---chart-2: #fdba74;
---chart-3: #fed7aa;
---chart-4: #fef3c7;
---chart-5: #fffbeb;
---sidebar: #171310;
---sidebar-foreground: #fef3c7;
---sidebar-primary: #fb923c;
---sidebar-primary-foreground: #0c0a09;
---sidebar-accent: #7c2d12;
---sidebar-accent-foreground: #fed7aa;
---sidebar-border: #292524;
---sidebar-ring: #fb923c;
---header-bg: #0c0a09;
---menu-bg: #1c1917;
+```tsx
+<div className="min-h-svh bg-background">
+  <header className="flex h-14 items-center justify-center border-b px-6">
+    <h1 className="font-semibold">{title}</h1>
+    <div className="absolute right-6"><ModeToggle /></div>
+  </header>
+  <main className="mx-auto max-w-xl p-6"><Outlet /></main>
+</div>
 ```
 
 ---
 
-### 5. Rose / Pink
+## 実装フロー
 
-**印象**: 親しみやすい・カジュアル・サービス業
-**--radius**: `1rem`
-**視覚プレビュー**: [previews/rose-pink.html](previews/rose-pink.html)
+1. 上表でレイアウトを提示 → ユーザーが 1 つ選択。
+2. [color-palettes.md](color-palettes.md) でカラーパレットを提示 → ユーザーが 1 つ選択。
+3. [design-system.md](design-system.md) で画面一覧・コンポーネント選定 → 承認。
+4. 承認後、選択レイアウトのアプリシェルを `App.tsx` / `src/components/layout/*` に実装し、
+   選択パレットの CSS Variables を `styles/index.pcss` に適用して実装する。
 
-> primary がローズ系のため、destructive は赤の彩度・明度を変えた `#b91c1c`（light）/ `#f87171`（dark）で区別する。
-
-#### Light Mode `:root`
-
-```css
---background: #fff1f2;
---foreground: #4c0519;
---card: #ffffff;
---card-foreground: #4c0519;
---popover: #ffffff;
---popover-foreground: #4c0519;
---primary: #e11d48;
---primary-foreground: #ffffff;
---secondary: #ffe4e6;
---secondary-foreground: #881337;
---muted: #fce7f3;
---muted-foreground: #6b7280;
---accent: #ec4899;
---accent-foreground: #ffffff;
---accent-hover: #fecdd3;
---destructive: #b91c1c;
---border: #fecdd3;
---input: #fecdd3;
---ring: #e11d48;
---chart-1: #e11d48;
---chart-2: #f43f5e;
---chart-3: #fb7185;
---chart-4: #fda4af;
---chart-5: #fecdd3;
---sidebar: #fff1f2;
---sidebar-foreground: #4c0519;
---sidebar-primary: #e11d48;
---sidebar-primary-foreground: #ffffff;
---sidebar-accent: #ffe4e6;
---sidebar-accent-foreground: #881337;
---sidebar-border: #fecdd3;
---sidebar-ring: #e11d48;
---header-bg: #ffffff;
---menu-bg: #fff1f2;
-```
-
-#### Dark Mode `.dark`
-
-```css
---background: #1a0a12;
---foreground: #ffe4e6;
---card: #2a141e;
---card-foreground: #ffe4e6;
---popover: #2a141e;
---popover-foreground: #ffe4e6;
---primary: #fb7185;
---primary-foreground: #1a0a12;
---secondary: #4c0519;
---secondary-foreground: #fecdd3;
---muted: #3f1322;
---muted-foreground: #b89aa5;
---accent: #f472b6;
---accent-foreground: #1a0a12;
---accent-hover: #4c0519;
---destructive: #f87171;
---border: #3f1322;
---input: #3f1322;
---ring: #fb7185;
---chart-1: #fb7185;
---chart-2: #fda4af;
---chart-3: #fecdd3;
---chart-4: #ffe4e6;
---chart-5: #fff1f2;
---sidebar: #200d16;
---sidebar-foreground: #ffe4e6;
---sidebar-primary: #fb7185;
---sidebar-primary-foreground: #1a0a12;
---sidebar-accent: #4c0519;
---sidebar-accent-foreground: #fecdd3;
---sidebar-border: #3f1322;
---sidebar-ring: #fb7185;
---header-bg: #1a0a12;
---menu-bg: #2a141e;
-```
-
----
-
-### 6. Slate Mono
-
-**印象**: ミニマル・堅実・エンタープライズ
-**--radius**: `0.375rem`
-**視覚プレビュー**: [previews/slate-mono.html](previews/slate-mono.html)
-
-> 彩色をほぼ持たないモノトーン。チャートはスレートのグラデーションになるため、
-> 系列数が多いダッシュボードでは系列の区別がつきにくい。チャート中心のアプリでは 1〜5 を推奨。
-
-#### Light Mode `:root`
-
-```css
---background: #f8fafc;
---foreground: #0f172a;
---card: #ffffff;
---card-foreground: #0f172a;
---popover: #ffffff;
---popover-foreground: #0f172a;
---primary: #334155;
---primary-foreground: #ffffff;
---secondary: #f1f5f9;
---secondary-foreground: #334155;
---muted: #f1f5f9;
---muted-foreground: #64748b;
---accent: #475569;
---accent-foreground: #ffffff;
---accent-hover: #e2e8f0;
---destructive: #dc2626;
---border: #e2e8f0;
---input: #e2e8f0;
---ring: #334155;
---chart-1: #334155;
---chart-2: #475569;
---chart-3: #64748b;
---chart-4: #94a3b8;
---chart-5: #cbd5e1;
---sidebar: #f1f5f9;
---sidebar-foreground: #0f172a;
---sidebar-primary: #334155;
---sidebar-primary-foreground: #ffffff;
---sidebar-accent: #e2e8f0;
---sidebar-accent-foreground: #334155;
---sidebar-border: #e2e8f0;
---sidebar-ring: #334155;
---header-bg: #ffffff;
---menu-bg: #f8fafc;
-```
-
-#### Dark Mode `.dark`
-
-```css
---background: #020617;
---foreground: #e2e8f0;
---card: #0f172a;
---card-foreground: #e2e8f0;
---popover: #0f172a;
---popover-foreground: #e2e8f0;
---primary: #94a3b8;
---primary-foreground: #020617;
---secondary: #1e293b;
---secondary-foreground: #e2e8f0;
---muted: #1e293b;
---muted-foreground: #94a3b8;
---accent: #cbd5e1;
---accent-foreground: #020617;
---accent-hover: #1e293b;
---destructive: #f87171;
---border: #1e293b;
---input: #1e293b;
---ring: #94a3b8;
---chart-1: #94a3b8;
---chart-2: #cbd5e1;
---chart-3: #e2e8f0;
---chart-4: #f1f5f9;
---chart-5: #f8fafc;
---sidebar: #0b1120;
---sidebar-foreground: #e2e8f0;
---sidebar-primary: #94a3b8;
---sidebar-primary-foreground: #020617;
---sidebar-accent: #1e293b;
---sidebar-accent-foreground: #e2e8f0;
---sidebar-border: #1e293b;
---sidebar-ring: #94a3b8;
---header-bg: #020617;
---menu-bg: #0f172a;
-```
-
----
-
-## 適用チェックリスト
-
-テンプレート適用後、以下を確認する:
-
-- [ ] `:root` / `.dark` の両方に全変数を適用した（片方だけ適用すると切替時に旧テーマが残る）
-- [ ] `--radius` をテンプレート指定値に変更した
-- [ ] バッジ変数（`--badge-*`）は変更していない
-- [ ] フォント設定（`font-family`）は変更していない
-- [ ] ライト/ダーク両モードで主要画面の文字コントラストを目視確認した
+> **既存 samples を出発点にする場合**: samples は Sidebar レイアウト。他レイアウトにするときはアプリシェルのみ差し替え、
+> ページ（`src/pages/*`）とデータ層はそのまま流用できる。新規テーマの scaffold は **@GeekPowerCode** に依頼する。

--- a/.github/skills/code-apps/references/fluent-icons.md
+++ b/.github/skills/code-apps/references/fluent-icons.md
@@ -1,0 +1,141 @@
+# Fluent UI v2 アイコン（@fluentui/react-icons）
+
+Code Apps で **Fluent UI v2（Fluent 2 / Fluent System Icons）** のアイコンを使うための導入・使用・検索方法。
+Microsoft 製品と揃った見た目にしたいときに使う。
+
+> **標準は lucide-react**: shadcn/ui の内部（`src/components/ui/*`）は lucide-react に依存しているため **そのまま残す**。
+> Fluent アイコンは**アプリ側の UI（ナビ・ボタン・ヘッダー・カード等）で lucide と共存**させる。丸ごと置き換えない。
+
+---
+
+## 1. インストール
+
+```bash
+npm i @fluentui/react-icons
+```
+
+- **CSP 安全**: 各アイコンは npm でバンドルされる React 製 SVG コンポーネント。外部 fetch は発生しない（Google Fonts のような外部通信なし）。
+- **必ず名前指定 import**（tree-shaking）: `import * as Icons from ...` は禁止。バンドルが数 MB に膨らむ。
+
+---
+
+## 2. アイコン名の規則
+
+Fluent のアイコン名は **`{Name}{Size}{Variant}`** で構成される。
+
+| 要素 | 値 |
+|---|---|
+| Name | 機能名（`Add` / `Delete` / `Person` / `Home` / `Search` …、英語） |
+| Size | `16` / `20` / `24` / `28` / `32` / `48`（デザイン基準サイズ） |
+| Variant | `Regular`（既定）/ `Filled`（選択・アクティブ状態向け） |
+
+例: `Add24Regular`、`Delete20Regular`、`Home24Filled`
+
+- **既定は 24 + Regular**。小さめの行内アイコンは 20、大きな見出しは 32。
+- **Filled は「選択中／アクティブ」状態**に使い分ける（通常は Regular）。
+
+---
+
+## 3. 使い方
+
+```tsx
+import { Add24Regular, Search20Regular } from "@fluentui/react-icons";
+
+export function Toolbar() {
+  return (
+    <div className="flex items-center gap-2">
+      <button className="inline-flex items-center gap-1">
+        <Add24Regular />
+        追加
+      </button>
+      <Search20Regular className="text-muted-foreground" />
+    </div>
+  );
+}
+```
+
+### サイズと色
+
+- **色**: 既定で `fill="currentColor"`。親の `text-*`（Tailwind）や CSS の `color` がそのまま反映される → **色はハードコードしない**。
+- **サイズ**: 基本は名前のサイズ（例 `24`）で決まる。微調整したいときは `className` / `style` で `width`/`height` を上書きできる。
+  ```tsx
+  <Add24Regular style={{ width: 18, height: 18 }} />
+  ```
+- **primaryFill prop**: 明示的に色を変えたいときは `<Add24Regular primaryFill="var(--primary)" />`（原則は currentColor 推奨）。
+
+### shadcn ボタンと組み合わせる
+
+```tsx
+import { Button } from "@/components/ui/button";
+import { Add24Regular } from "@fluentui/react-icons";
+
+<Button size="sm"><Add24Regular className="mr-1 size-4" />新規作成</Button>
+```
+
+> `size-4`（=16px）等で lucide アイコンと視覚的な大きさを揃えると混在しても違和感が出ない。
+
+---
+
+## 4. 適切なアイコンを探す（検索スキル）
+
+### 方法 A: 検索スクリプト（推奨・インストール済みバージョンに一致）
+
+キーワード（英語）から、インストール済みの `@fluentui/react-icons` に存在するアイコン名を検索する。
+
+```bash
+node .github/skills/code-apps/scripts/find_fluent_icon.mjs <keyword> [--size 24] [--variant Regular|Filled] [--limit 40]
+```
+
+例:
+
+```bash
+node .github/skills/code-apps/scripts/find_fluent_icon.mjs add
+node .github/skills/code-apps/scripts/find_fluent_icon.mjs delete --size 20 --variant Regular
+node .github/skills/code-apps/scripts/find_fluent_icon.mjs person
+```
+
+出力は base 名ごとに「利用可能なサイズ／バリアント」と、そのまま貼れる import 文を表示する:
+
+```
+● Add  (size: 16, 20, 24, 28, 32, 48 / Regular/Filled)
+   import { Add24Regular } from "@fluentui/react-icons";
+```
+
+> **前提**: プロジェクトに `@fluentui/react-icons` がインストール済みであること（手順 1）。
+> インストール済みパッケージを走査するため、**バージョンに存在するアイコンだけ**が返る（存在しない名前を import してビルドエラーになる事故を防げる）。
+
+### 方法 B: 公式カタログ（ブラウザ）
+
+- 公式アイコンカタログ: https://react.fluentui.dev/?path=/docs/icons-catalog--docs
+- Fluent System Icons リポジトリ: https://github.com/microsoft/fluentui-system-icons
+
+キーワードで検索 → 名前をコピー（例 `Add`）→ 手順 2 の規則でサイズ・バリアントを付ける。
+
+### アイコン選定のガイド
+
+| 用途 | 候補（英語キーワード） |
+|---|---|
+| 追加・新規 | `Add` |
+| 編集 | `Edit` |
+| 削除 | `Delete` |
+| 検索 | `Search` |
+| 更新・再読込 | `ArrowClockwise` |
+| 設定 | `Settings` |
+| ユーザー | `Person` / `People` |
+| ホーム | `Home` |
+| ダッシュボード | `Board` / `DataBarVertical` |
+| ドキュメント | `Document` |
+| 通知 | `Alert` |
+| フィルタ | `Filter` |
+| メニュー | `Navigation`（ハンバーガー） |
+
+迷ったら **方法 A のスクリプトでキーワード検索**して、実在する名前から選ぶ。
+
+---
+
+## 5. 注意点
+
+- **shadcn 内部を Fluent に置換しない**: `src/components/ui/*` の lucide import はそのまま。壊すとコンポーネントが動かない。
+- **import は個別指定のみ**（`import * as` 禁止）。バンドルサイズと CSP（外部通信なし）の両面で重要。
+- **色は currentColor 基調**: `--primary` 等のパレット変数と `text-*` で色を当て、[カラーパレット集](color-palettes.md) と整合させる。
+- **サイズを揃える**: lucide（既定 24、`size-4` 等）と混在するときは `className="size-4"` 等で見た目を統一する。

--- a/.github/skills/code-apps/references/new-theme-checklist.md
+++ b/.github/skills/code-apps/references/new-theme-checklist.md
@@ -50,7 +50,7 @@ cp .github/skills/standard/references/gitignore-template .gitignore
 ```
 0. テンプレート scaffold        ← vite.config.ts / plugins/ / styles/ / src/ 一式（@GeekPowerCode が scaffold）
 1. .env 設定（.env.example をコピーして新テーマの値を入れる）
-2. デザインテンプレート選択（design-templates.md → apply_design_template.py）
+2. デザインテンプレート選択（レイアウト: design-templates.md → カラー: color-palettes.md → apply_design_template.py）
 3. pac code init                  ← power.config.json / .power/ を生成（手で作らない）
 4. pac code add-data-source ...   ← src/generated/ が生成される
 5. 設計フェーズ（design-system.md）→ ユーザー承認 → 実装
@@ -63,4 +63,4 @@ cp .github/skills/standard/references/gitignore-template .gitignore
 | `.power/` / `src/generated/` / `power.config.json` | 削除 → 手順 3〜4 で SDK に再生成させる |
 | 前テーマの業務画面（`src/pages/*.tsx`） | 削除し、@GeekPowerCode に新規テーマとして scaffold し直すよう依頼 |
 | 前テーマのテーブル参照（dataSourcesInfo / services / types） | 削除。**コメントアウトで残さない**（ビルドエラー・接続エラーの温床） |
-| 前テーマの配色 | `apply_design_template.py 1 --project .` で Ocean Blue に戻すか、新テーマのテンプレートを適用 |
+| 前テーマの配色 | `apply_design_template.py 1 --project .` で Ocean Blue に戻すか、新テーマのカラーパレット（color-palettes.md）を適用 |

--- a/.github/skills/code-apps/references/previews/layout-dashboard.html
+++ b/.github/skills/code-apps/references/previews/layout-dashboard.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dashboard レイアウト プレビュー — Code Apps</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  font-family:system-ui,Avenir,Helvetica,Arial,sans-serif;
+  --radius:.625rem;--background:#f0f7ff;--foreground:#0c2d5e;--card:#fff;
+  --primary:#3b82f6;--primary-foreground:#fff;--secondary:#dbeafe;
+  --muted:#e0f2fe;--muted-foreground:#475569;--border:#bfdbfe;--header-bg:#fff;
+  --chart-1:#3b82f6;--chart-2:#60a5fa;--chart-3:#93c5fd;--chart-4:#bfdbfe;
+}
+body{background:var(--background);color:var(--foreground);min-height:100vh;font-size:13px;line-height:1.5}
+.hdr{background:var(--header-bg);border-bottom:1px solid var(--border);height:52px;display:flex;align-items:center;padding:0 24px;gap:12px}
+.logo{background:var(--primary);color:var(--primary-foreground);width:30px;height:30px;border-radius:var(--radius);display:flex;align-items:center;justify-content:center;font-weight:700}
+.hdr-title{font-weight:600;font-size:14px}
+.mode{margin-left:auto;width:30px;height:30px;border:1px solid var(--border);border-radius:var(--radius);display:grid;place-items:center;background:var(--card)}
+.wrap{max-width:1120px;margin:0 auto;padding:24px}
+.kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-bottom:20px}
+.kpi{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:16px}
+.kpi .lbl{color:var(--muted-foreground);font-size:12px}
+.kpi .num{font-size:24px;font-weight:700;margin-top:6px}
+.grid2{display:grid;grid-template-columns:2fr 1fr;gap:20px}
+.card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:16px}
+.bars{display:flex;align-items:flex-end;gap:10px;height:130px;margin-top:12px}
+.bar{flex:1;border-radius:6px 6px 0 0}
+.row{height:10px;background:var(--muted);border-radius:5px;margin:10px 0}
+.row.s{width:50%}
+.tag{position:fixed;bottom:10px;right:12px;font-size:11px;color:var(--muted-foreground)}
+@media(max-width:640px){.kpis{grid-template-columns:repeat(2,1fr)}.grid2{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+<div class="hdr"><div class="logo">A</div><div class="hdr-title">Dashboard レイアウト</div><div class="mode">◐</div></div>
+<div class="wrap">
+  <div class="kpis">
+    <div class="kpi"><div class="lbl">売上</div><div class="num">¥12.4M</div></div>
+    <div class="kpi"><div class="lbl">商談数</div><div class="num">148</div></div>
+    <div class="kpi"><div class="lbl">受注率</div><div class="num">32%</div></div>
+    <div class="kpi"><div class="lbl">活動</div><div class="num">512</div></div>
+  </div>
+  <div class="grid2">
+    <div class="card">
+      <div class="row s"></div>
+      <div class="bars">
+        <div class="bar" style="height:60%;background:var(--chart-1)"></div>
+        <div class="bar" style="height:85%;background:var(--chart-2)"></div>
+        <div class="bar" style="height:45%;background:var(--chart-3)"></div>
+        <div class="bar" style="height:95%;background:var(--chart-1)"></div>
+        <div class="bar" style="height:70%;background:var(--chart-2)"></div>
+        <div class="bar" style="height:55%;background:var(--chart-4)"></div>
+      </div>
+    </div>
+    <div class="card"><div class="row s"></div><div class="row"></div><div class="row"></div><div class="row"></div><div class="row"></div></div>
+  </div>
+</div>
+<div class="tag">KPI スタットカード + メイン/サブ</div>
+</body>
+</html>

--- a/.github/skills/code-apps/references/previews/layout-hero-cards.html
+++ b/.github/skills/code-apps/references/previews/layout-hero-cards.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hero Cards レイアウト プレビュー — Code Apps</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  font-family:system-ui,Avenir,Helvetica,Arial,sans-serif;
+  --radius:.625rem;--background:#f0f7ff;--foreground:#0c2d5e;--card:#fff;
+  --primary:#3b82f6;--primary-foreground:#fff;--secondary:#dbeafe;
+  --muted:#e0f2fe;--muted-foreground:#475569;--border:#bfdbfe;--header-bg:#fff;
+}
+body{background:var(--background);color:var(--foreground);min-height:100vh;font-size:13px;line-height:1.5}
+.hdr{background:var(--header-bg);border-bottom:1px solid var(--border);height:52px;display:flex;align-items:center;padding:0 24px;gap:12px}
+.logo{background:var(--primary);color:var(--primary-foreground);width:30px;height:30px;border-radius:var(--radius);display:flex;align-items:center;justify-content:center;font-weight:700}
+.hdr-title{font-weight:600;font-size:14px}
+.mode{margin-left:auto;width:30px;height:30px;border:1px solid var(--border);border-radius:var(--radius);display:grid;place-items:center;background:var(--card)}
+.wrap{max-width:960px;margin:0 auto;padding:24px}
+.hero{text-align:center;padding:40px 20px}
+.hero h1{font-size:28px;font-weight:800}
+.hero p{color:var(--muted-foreground);margin:10px 0 18px}
+.cta{display:inline-block;padding:10px 24px;border-radius:var(--radius);background:var(--primary);color:var(--primary-foreground);font-weight:600}
+.cards{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:20px}
+.fcard{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:20px;transition:transform .15s}
+.fcard:hover{transform:translateY(-4px)}
+.ic{width:38px;height:38px;border-radius:var(--radius);background:var(--secondary);margin-bottom:12px}
+.row{height:10px;background:var(--muted);border-radius:5px;margin:8px 0}
+.row.s{width:55%}
+.sec{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:20px;margin-top:24px}
+.tag{position:fixed;bottom:10px;right:12px;font-size:11px;color:var(--muted-foreground)}
+@media(max-width:640px){.cards{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+<div class="hdr"><div class="logo">A</div><div class="hdr-title">Hero Cards レイアウト</div><div class="mode">◐</div></div>
+<div class="wrap">
+  <section class="hero">
+    <h1>営業支援ポータル</h1>
+    <p>顧客・商談・活動をひとつの入口から</p>
+    <span class="cta">はじめる</span>
+  </section>
+  <section class="cards">
+    <div class="fcard"><div class="ic"></div><div class="row s"></div><div class="row"></div><div class="row"></div></div>
+    <div class="fcard"><div class="ic"></div><div class="row s"></div><div class="row"></div><div class="row"></div></div>
+    <div class="fcard"><div class="ic"></div><div class="row s"></div><div class="row"></div><div class="row"></div></div>
+  </section>
+  <section class="sec"><div class="row s"></div><div class="row"></div><div class="row"></div></section>
+</div>
+<div class="tag">ヒーロー + 特徴カード + セクション</div>
+</body>
+</html>

--- a/.github/skills/code-apps/references/previews/layout-minimal.html
+++ b/.github/skills/code-apps/references/previews/layout-minimal.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Minimal レイアウト プレビュー — Code Apps</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  font-family:system-ui,Avenir,Helvetica,Arial,sans-serif;
+  --radius:.625rem;--background:#f0f7ff;--foreground:#0c2d5e;--card:#fff;
+  --primary:#3b82f6;--primary-foreground:#fff;--secondary:#dbeafe;
+  --muted:#e0f2fe;--muted-foreground:#475569;--border:#bfdbfe;--header-bg:#fff;
+}
+body{background:var(--background);color:var(--foreground);min-height:100vh;font-size:13px;line-height:1.5}
+.hdr{background:var(--header-bg);border-bottom:1px solid var(--border);height:52px;display:flex;align-items:center;justify-content:center;position:relative}
+.hdr-title{font-weight:600;font-size:14px}
+.mode{position:absolute;right:24px;width:30px;height:30px;border:1px solid var(--border);border-radius:var(--radius);display:grid;place-items:center;background:var(--card)}
+.wrap{max-width:520px;margin:0 auto;padding:32px 24px}
+.card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:24px}
+.card h2{font-size:16px;margin-bottom:4px}
+.card .sub{color:var(--muted-foreground);margin-bottom:18px}
+.lbl{font-size:12px;color:var(--muted-foreground);margin:12px 0 6px}
+.field{height:36px;border:1px solid var(--border);border-radius:var(--radius);background:var(--background)}
+.area{height:80px;border:1px solid var(--border);border-radius:var(--radius);background:var(--background)}
+.btn{height:38px;border-radius:var(--radius);background:var(--primary);color:var(--primary-foreground);display:grid;place-items:center;font-weight:600;margin-top:20px}
+.tag{position:fixed;bottom:10px;right:12px;font-size:11px;color:var(--muted-foreground)}
+</style>
+</head>
+<body>
+<div class="hdr"><div class="hdr-title">Minimal レイアウト</div><div class="mode">◐</div></div>
+<div class="wrap">
+  <div class="card">
+    <h2>お問い合わせ登録</h2>
+    <div class="sub">必要事項を入力して送信してください</div>
+    <div class="lbl">件名</div><div class="field"></div>
+    <div class="lbl">カテゴリ</div><div class="field"></div>
+    <div class="lbl">内容</div><div class="area"></div>
+    <div class="btn">送信</div>
+  </div>
+</div>
+<div class="tag">中央 1 カラム（最大幅制限）</div>
+</body>
+</html>

--- a/.github/skills/code-apps/references/previews/layout-sidebar.html
+++ b/.github/skills/code-apps/references/previews/layout-sidebar.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sidebar レイアウト プレビュー — Code Apps</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  font-family:system-ui,Avenir,Helvetica,Arial,sans-serif;
+  --radius:.625rem;--background:#f0f7ff;--foreground:#0c2d5e;--card:#fff;
+  --primary:#3b82f6;--primary-foreground:#fff;--secondary:#dbeafe;
+  --muted:#e0f2fe;--muted-foreground:#475569;--border:#bfdbfe;
+  --sidebar:#f8fafc;--sidebar-accent:#dbeafe;--header-bg:#fff;
+}
+body{background:var(--background);color:var(--foreground);height:100vh;display:flex;flex-direction:column;font-size:13px;line-height:1.5}
+.hdr{background:var(--header-bg);border-bottom:1px solid var(--border);height:52px;display:flex;align-items:center;padding:0 16px;gap:12px;flex-shrink:0}
+.logo{background:var(--primary);color:var(--primary-foreground);width:30px;height:30px;border-radius:var(--radius);display:flex;align-items:center;justify-content:center;font-weight:700}
+.hdr-title{font-weight:600;font-size:14px}
+.mode{margin-left:auto;width:30px;height:30px;border:1px solid var(--border);border-radius:var(--radius);display:grid;place-items:center;background:var(--card)}
+.layout{display:flex;flex:1;overflow:hidden}
+.side{width:190px;background:var(--sidebar);border-right:1px solid var(--border);padding:12px 8px;display:flex;flex-direction:column;gap:2px;flex-shrink:0}
+.nav{padding:8px 12px;border-radius:var(--radius);color:var(--muted-foreground)}
+.nav.active{background:var(--sidebar-accent);color:var(--foreground);font-weight:600}
+.main{flex:1;padding:20px;overflow:auto}
+.card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:16px;margin-bottom:14px}
+.row{height:12px;background:var(--muted);border-radius:6px;margin:8px 0}
+.row.s{width:40%}.row.m{width:70%}
+.tbl{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);overflow:hidden}
+.tr{display:flex;gap:16px;padding:12px 16px;border-bottom:1px solid var(--border)}
+.tr:last-child{border-bottom:0}.tr>div{flex:1;height:10px;background:var(--muted);border-radius:5px}
+.tag{position:fixed;bottom:10px;right:12px;font-size:11px;color:var(--muted-foreground)}
+</style>
+</head>
+<body>
+<div class="hdr"><div class="logo">A</div><div class="hdr-title">Sidebar レイアウト（標準）</div><div class="mode">◐</div></div>
+<div class="layout">
+  <nav class="side">
+    <div class="nav active">ダッシュボード</div>
+    <div class="nav">顧客</div>
+    <div class="nav">商談</div>
+    <div class="nav">パイプライン</div>
+    <div class="nav">活動履歴</div>
+    <div class="nav">設定</div>
+  </nav>
+  <main class="main">
+    <div class="card"><div class="row m"></div><div class="row s"></div></div>
+    <div class="tbl"><div class="tr"><div></div><div></div><div></div></div><div class="tr"><div></div><div></div><div></div></div><div class="tr"><div></div><div></div><div></div></div><div class="tr"><div></div><div></div><div></div></div></div>
+  </main>
+</div>
+<div class="tag">固定左ナビ + フル高さコンテンツ</div>
+</body>
+</html>

--- a/.github/skills/code-apps/references/previews/layout-workspace.html
+++ b/.github/skills/code-apps/references/previews/layout-workspace.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Workspace レイアウト プレビュー — Code Apps</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  font-family:system-ui,Avenir,Helvetica,Arial,sans-serif;
+  --radius:.625rem;--background:#f0f7ff;--foreground:#0c2d5e;--card:#fff;
+  --primary:#3b82f6;--primary-foreground:#fff;--secondary:#dbeafe;
+  --muted:#e0f2fe;--muted-foreground:#475569;--border:#bfdbfe;--header-bg:#fff;
+}
+body{background:var(--background);color:var(--foreground);min-height:100vh;font-size:13px;line-height:1.5}
+.hdr{background:var(--header-bg);border-bottom:1px solid var(--border);height:52px;display:flex;align-items:center;padding:0 24px;gap:12px}
+.logo{background:var(--primary);color:var(--primary-foreground);width:30px;height:30px;border-radius:var(--radius);display:flex;align-items:center;justify-content:center;font-weight:700}
+.hdr-title{font-weight:600;font-size:14px}
+.mode{margin-left:auto;width:30px;height:30px;border:1px solid var(--border);border-radius:var(--radius);display:grid;place-items:center;background:var(--card)}
+.wrap{max-width:1120px;margin:0 auto;padding:24px;display:grid;grid-template-columns:300px 1fr;gap:20px}
+.aside{display:flex;flex-direction:column;gap:12px}
+.panel{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:14px}
+.panel .h{font-weight:600;margin-bottom:8px;font-size:12px;color:var(--muted-foreground)}
+.chip{display:inline-block;padding:6px 12px;border-radius:999px;background:var(--secondary);margin:3px 3px 0 0;font-size:12px}
+.field{height:32px;border:1px solid var(--border);border-radius:var(--radius);background:var(--background);margin-bottom:8px}
+.btn{height:34px;border-radius:var(--radius);background:var(--primary);color:var(--primary-foreground);display:grid;place-items:center;font-weight:600}
+.main .card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:16px;margin-bottom:14px}
+.tr{display:flex;gap:16px;padding:10px 0;border-bottom:1px solid var(--border)}
+.tr>div{flex:1;height:10px;background:var(--muted);border-radius:5px}
+.tag{position:fixed;bottom:10px;right:12px;font-size:11px;color:var(--muted-foreground)}
+@media(max-width:640px){.wrap{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+<div class="hdr"><div class="logo">A</div><div class="hdr-title">Workspace レイアウト</div><div class="mode">◐</div></div>
+<div class="wrap">
+  <aside class="aside">
+    <div class="panel"><div class="h">フィルタ</div><div class="field"></div><div class="field"></div><div class="btn">適用</div></div>
+    <div class="panel"><div class="h">カテゴリ</div><span class="chip">未対応</span><span class="chip">進行中</span><span class="chip">完了</span><span class="chip">保留</span></div>
+  </aside>
+  <main class="main">
+    <div class="card">
+      <div class="tr"><div></div><div></div><div></div></div>
+      <div class="tr"><div></div><div></div><div></div></div>
+      <div class="tr"><div></div><div></div><div></div></div>
+      <div class="tr"><div></div><div></div><div></div></div>
+      <div class="tr"><div></div><div></div><div></div></div>
+    </div>
+  </main>
+</div>
+<div class="tag">左作業パネル（lg:sticky）+ 右メイン</div>
+</body>
+</html>

--- a/.github/skills/code-apps/samples/geek-sales/README.md
+++ b/.github/skills/code-apps/samples/geek-sales/README.md
@@ -68,7 +68,7 @@ Code Apps サンプル実装。Power Automate AI フロー連携と Copilot Stud
 | `src/config.ts` の `NAV_SECTIONS` | ページ構成を変更（コードで直接編集） |
 | `VITE_FEATURE_COPILOT=true`（.env） | Copilot Analytics ページを有効化 |
 | `VITE_FEATURE_AI_FLOW=true`（.env） | AI フロー連携を有効化 |
-| `styles/index.pcss` | カラーテーマを変更（design-templates.md 参照） |
+| `styles/index.pcss` | カラーテーマを変更（color-palettes.md 参照）。レイアウトの骨格は design-templates.md 参照 |
 
 ### プレフィックス変更時の作業
 

--- a/.github/skills/code-apps/scripts/find_fluent_icon.mjs
+++ b/.github/skills/code-apps/scripts/find_fluent_icon.mjs
@@ -1,0 +1,95 @@
+/**
+ * find_fluent_icon.mjs — @fluentui/react-icons から適切なアイコンを検索する
+ *
+ * キーワード（英語）にマッチするアイコンを、インストール済みの
+ * @fluentui/react-icons から探し、そのまま貼れる import 文を出力する。
+ * インストール済みバージョンを走査するため、存在しない名前を選ぶ事故を防げる。
+ *
+ * Usage:
+ *   node .github/skills/code-apps/scripts/find_fluent_icon.mjs <keyword> [--size 24] [--variant Regular|Filled] [--limit 40]
+ *
+ * 例:
+ *   node .github/skills/code-apps/scripts/find_fluent_icon.mjs add
+ *   node .github/skills/code-apps/scripts/find_fluent_icon.mjs delete --size 20 --variant Regular
+ *   node .github/skills/code-apps/scripts/find_fluent_icon.mjs person
+ *
+ * 前提: プロジェクトに @fluentui/react-icons がインストール済み
+ *   npm i @fluentui/react-icons
+ */
+import process from "node:process";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+
+const args = process.argv.slice(2);
+if (args.length === 0 || args[0].startsWith("--")) {
+  console.error(
+    "Usage: node find_fluent_icon.mjs <keyword> [--size 24] [--variant Regular|Filled] [--limit 40]"
+  );
+  process.exit(1);
+}
+
+const keyword = args[0].toLowerCase();
+const getOpt = (name) => {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const size = getOpt("--size");
+const variant = getOpt("--variant");
+const limit = Number.parseInt(getOpt("--limit") ?? "40", 10);
+
+let mod;
+try {
+  // プロジェクトルート（npm i を実行した場所 = cwd）から解決する
+  const req = createRequire(pathToFileURL(path.join(process.cwd(), "package.json")).href);
+  const resolved = req.resolve("@fluentui/react-icons");
+  mod = await import(pathToFileURL(resolved).href);
+} catch {
+  console.error(
+    "@fluentui/react-icons が見つかりません。プロジェクトルートで先に `npm i @fluentui/react-icons` を実行してください。"
+  );
+  process.exit(1);
+}
+
+// アイコン名は {Name}{Size}{Variant} 形式（Variant: Regular|Filled、Size: 数値）
+const ICON_RE = /^([A-Za-z0-9]+?)(\d+)(Regular|Filled)$/;
+const rows = [];
+for (const name of Object.keys(mod)) {
+  const m = name.match(ICON_RE);
+  if (!m) continue;
+  const [, base, sz, vr] = m;
+  if (!base.toLowerCase().includes(keyword)) continue;
+  if (size && sz !== String(size)) continue;
+  if (variant && vr.toLowerCase() !== variant.toLowerCase()) continue;
+  rows.push({ name, base, size: Number(sz), variant: vr });
+}
+
+if (rows.length === 0) {
+  console.log(
+    `"${keyword}" に一致するアイコンはありません。別の英語キーワードを試してください。`
+  );
+  process.exit(0);
+}
+
+// base 名でグルーピング
+const byBase = new Map();
+for (const r of rows) {
+  if (!byBase.has(r.base)) byBase.set(r.base, []);
+  byBase.get(r.base).push(r);
+}
+
+console.log(`"${keyword}" にマッチするアイコン（${byBase.size} 種）:\n`);
+let shown = 0;
+for (const [base, list] of [...byBase.entries()].sort()) {
+  const sizes = [...new Set(list.map((r) => r.size))].sort((a, b) => a - b).join(", ");
+  const variants = [...new Set(list.map((r) => r.variant))].join("/");
+  // 代表 import 例（24 Regular があれば優先）
+  const rep = list.find((r) => r.size === 24 && r.variant === "Regular") ?? list[0];
+  console.log(`● ${base}  (size: ${sizes} / ${variants})`);
+  console.log(`   import { ${rep.name} } from "@fluentui/react-icons";`);
+  shown++;
+  if (shown >= limit) {
+    console.log(`\n... 他 ${byBase.size - shown} 種を省略（--limit で調整）`);
+    break;
+  }
+}


### PR DESCRIPTION
## 概要
code-apps スキルのデザイン提案を「レイアウト軸」と「配色軸」の2軸に再構成し、Fluent UI v2 アイコン対応を追加します。

## 変更内容
### 1. レイアウトと配色の分離
- `references/design-templates.md` を **配色専用の `color-palettes.md` にリネーム**（6配色はそのまま維持）
- **新 `design-templates.md` を作成**（レイアウト軸）: Sidebar / Dashboard / Workspace / Hero Cards / Minimal の5種。copilot-studio の WebChat ライトテンプレートを Code Apps のアプリシェル（React + Tailwind + shadcn/ui）に変換
- `references/previews/layout-*.html` 5枚を追加（骨格プレビュー、ローカル検証済み）
- `design-system.md` / `new-theme-checklist.md` / `SKILL.md` / `samples/geek-sales/README.md` を「レイアウト選択→配色選択」の2軸に更新
- samples は機能実装済みのため変更なし（標準レイアウト = Sidebar と明記）

### 2. Fluent UI v2 アイコン対応
- **`references/fluent-icons.md`**（新規）: @fluentui/react-icons の導入・命名規則・使用例・CSP 安全性・選定ガイド。shadcn（lucide 依存）と共存する方針
- **`scripts/find_fluent_icon.mjs`**（新規）: キーワードからインストール済みバージョンに実在するアイコン名を検索（--size / --variant / --limit 対応）。実インストールで動作確認済み

## 検証
- validate_skill.py: 合格（triggers 数の WARN は既存）
- レイアウトプレビュー5種を localhost で表示確認
- find_fluent_icon.mjs を実パッケージで検索実行し出力確認
