### PR TITLE
fix: npx禁止警告・Playwright自動化強化・SimpleブラウザZoom設定

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -201,7 +201,14 @@ pac code add-data-source -a dataverse -t ${PUBLISHER_PREFIX}_{table_basename}
 python scripts/toggle_table_lang.py jp   # 日本語に復元
 ```
 
-> **日本語 DisplayName で `Failed to sanitize string` エラーが出る場合**、および `npx power-apps add-data-source` をフォールバックで使う場合（`patch-nameutils.cjs` 適用）の判断フロー・詳細手順は [日本語サニタイズリファレンス](references/japanese-sanitize.md) を参照。
+> [!CAUTION]
+> **`npx power-apps add-data-source` は絶対に使わない**。`npx` 経由で実行すると対話プロンプト
+> （「このパッケージを install してよいか？」等）が発生し、**AI エージェント実行時にターミナルが
+> 無限にハングする**（入力待ちのまま停止し、タイムアウトするまで復帰しない）。
+> 必ず **`pac code add-data-source`**（PAC CLI サブコマンド）を使う。
+> `pac code add-data-source -a dataverse -t {table}` が正しいコマンド。
+
+> **日本語 DisplayName で `Failed to sanitize string` エラーが出る場合**の判断フロー・詳細手順は [日本語サニタイズリファレンス](references/japanese-sanitize.md) を参照。
 
 ## 4. 改善デプロイ
 

--- a/.github/skills/cowork/SKILL.md
+++ b/.github/skills/cowork/SKILL.md
@@ -211,12 +211,16 @@ python .github/skills/cowork/scripts/register_mcp_client.py --app-id <CLIENT_ID>
 
 ### Step 5: Teams 開発者ポータルで OAuth client 登録 → registrationId 取得（ブラウザ）
 
-> **ブラウザ操作は AI 自動化を優先**: このポータル手順は **Playwright MCP**（`browser_navigate` /
-> `browser_snapshot` / `browser_type` / `browser_click`）で自動化することを第一候補とする。
+> **ブラウザ操作は AI 自動化を必ず実行する**（手動案内にフォールバックしない）:
+> このポータル手順は **Playwright MCP**（`browser_navigate` /
+> `browser_snapshot` / `browser_type` / `browser_click`）で自動化する。
 > AI がフォーム入力〜Save〜registrationId の読み取りまで行い、値を `.env` の
 > `COWORK_OAUTH_REGISTRATION_ID` に書き込む。**クライアントシークレットだけは機密**のため、
-> `browser_type` で `.env` の値をそのまま入力し、チャットには出力しない。Playwright MCP が
-> 使えない環境でのみ、下表を人手で入力するフォールバックに切り替える。
+> `browser_type` で `.env` の値をそのまま入力し、チャットには出力しない。
+>
+> **VS Code Simple Browser のズーム設定**: 操作前に
+> `page.evaluate(() => document.body.style.zoom = '0.8')` でページを 80% に縮小し、
+> ポータルの全 UI 要素が視認可能な状態にしてから操作を開始する。
 
 [dev.teams.microsoft.com/tools](https://dev.teams.microsoft.com/tools) → Tools →
 **OAuth client registration** → New（**SSO client registration ではない**）。
@@ -257,13 +261,23 @@ ZIP 検証: ルートに `manifest.json` / `dataverse-mcp-tools.json`、`skills/
 > からアップロードする（UI 変更済み）。Integrated apps 画面は「Agents > All agents へ移動」の案内のみで
 > カスタムアプリのアップロード導線は**廃止**された。
 
-> **ブラウザ操作は AI 自動化を優先**: このアップロード〜Publish も **Playwright MCP** で自動化する
-> ことを第一候補とする（`browser_navigate` で `#/agents/all` へ→ファイル選択→ウィザードを
-> `browser_click` で進める）。`Add agent` の **More actions（…）はページ中段の Registry ツールバー**
-> にあり、**画面が狭いと折り畳まれて見えない**ため viewport を広げる（例: 1600×900）。
-> ファイル選択は `<input type=file>` に `setInputFiles` で直接投入すると確実。検証エラーが出た場合は
+> **ブラウザ操作は AI 自動化を必ず実行する**（手動案内にフォールバックしない）:
+> このアップロード〜Publish は **Playwright MCP** で自動化する。
+> 手順: `browser_navigate` で `https://admin.cloud.microsoft/#/agents/all` へ →
+> SSO 完了待ち（`page.waitForURL('**/admin.cloud.microsoft/**')` — 最大 30 秒）→
+> Registry ツールバーの **More actions（…）** → **Add agent** → `<input type=file>` に
+> `setInputFiles` で zip を投入 → 検証待ち → **Publish to users**（All users + Install None を
+> **radio の `.evaluate(el => el.click())` で選択** — `click()` は overlay に遮られるため）→
+> Apply template → Accept permissions → Review & finish → Publish → Close。
+>
+> **VS Code Simple Browser のズーム設定**: 既定の `Match Window` だと管理センターの UI 要素が
+> 画面外にはみ出し、**More actions ボタンが不可視になる**ことがある。
+> **操作前に `page.evaluate(() => document.body.style.zoom = '0.8')` でページを 80% に縮小**し、
+> 全 UI 要素が視認可能な状態にする。それでも不足なら `0.67`（67%）まで下げる。
+>
+> `Add agent` の **More actions（…）はページ中段の Registry ツールバー** にあり、
+> **画面が狭いと折り畳まれて見えない**。検証エラーが出た場合は
 > `browser_snapshot` で内容を読み取り troubleshooting と突き合わせて修正→再アップロードする。
-> Playwright MCP が使えない環境でのみ下記を人手で操作する。
 
 1. [Microsoft 365 管理センター](https://admin.cloud.microsoft/) → 左ナビ **エージェント（Agents）** (`#/agents/all`)
 2. **Registry** タブ → グリッド中段ツールバーの **Export の右隣「…」(More actions)** → **Add agent** → **Upload agent** ウィザード起動

--- a/.github/skills/cowork/SKILL.md
+++ b/.github/skills/cowork/SKILL.md
@@ -219,8 +219,9 @@ python .github/skills/cowork/scripts/register_mcp_client.py --app-id <CLIENT_ID>
 > `browser_type` で `.env` の値をそのまま入力し、チャットには出力しない。
 >
 > **VS Code Simple Browser のズーム設定**: 操作前に
-> `page.evaluate(() => document.body.style.zoom = '0.8')` でページを 80% に縮小し、
+> `page.evaluate(() => document.body.style.zoom = '0.5')` でページを 50% に縮小し、
 > ポータルの全 UI 要素が視認可能な状態にしてから操作を開始する。
+> それでも必要な要素が見えないときはさらに縮小する。
 
 [dev.teams.microsoft.com/tools](https://dev.teams.microsoft.com/tools) → Tools →
 **OAuth client registration** → New（**SSO client registration ではない**）。
@@ -272,8 +273,8 @@ ZIP 検証: ルートに `manifest.json` / `dataverse-mcp-tools.json`、`skills/
 >
 > **VS Code Simple Browser のズーム設定**: 既定の `Match Window` だと管理センターの UI 要素が
 > 画面外にはみ出し、**More actions ボタンが不可視になる**ことがある。
-> **操作前に `page.evaluate(() => document.body.style.zoom = '0.8')` でページを 80% に縮小**し、
-> 全 UI 要素が視認可能な状態にする。それでも不足なら `0.67`（67%）まで下げる。
+> **操作前に `page.evaluate(() => document.body.style.zoom = '0.5')` でページを 50% に縮小**し、
+> 全 UI 要素が視認可能な状態にする。それでも必要な要素が見えないときはさらに縮小する。
 >
 > `Add agent` の **More actions（…）はページ中段の Registry ツールバー** にあり、
 > **画面が狭いと折り畳まれて見えない**。検証エラーが出た場合は

--- a/.github/skills/update-skills/SKILL.md
+++ b/.github/skills/update-skills/SKILL.md
@@ -127,7 +127,8 @@ python .github/skills/update-skills/scripts/validate_skill.py --all
    その場合も画面パスとセレクタの目印を明記する。
    **VS Code Simple Browser のズーム**: 既定の `Match Window` だと管理ポータル等の
    UI 要素が画面外にはみ出す。スキル本文に **操作前に
-   `page.evaluate(() => document.body.style.zoom = '0.8')` でページを 80% に縮小する**指示を含める。
+   `page.evaluate(() => document.body.style.zoom = '0.5')` でページを 50% に縮小する**指示を含める。
+   それでも必要な要素が見えないときはさらに縮小する。
 3. **CLI 化**: 繰り返す操作は `scripts/` に追加し、本文からはスクリプト呼び出しで参照する。
 
 ### Step 5: PR 戦略を決める（更新 / 新規 + マージ順）

--- a/.github/skills/update-skills/SKILL.md
+++ b/.github/skills/update-skills/SKILL.md
@@ -125,6 +125,9 @@ python .github/skills/update-skills/scripts/validate_skill.py --all
 2. **ブラウザ操作の自動化**: ポータル操作が必要な手順は **Playwright MCP**（`browser_navigate` /
    `browser_click` / `browser_snapshot` 等）で自動化できる形に書く。手動 UI 操作は最終手段とし、
    その場合も画面パスとセレクタの目印を明記する。
+   **VS Code Simple Browser のズーム**: 既定の `Match Window` だと管理ポータル等の
+   UI 要素が画面外にはみ出す。スキル本文に **操作前に
+   `page.evaluate(() => document.body.style.zoom = '0.8')` でページを 80% に縮小する**指示を含める。
 3. **CLI 化**: 繰り返す操作は `scripts/` に追加し、本文からはスクリプト呼び出しで参照する。
 
 ### Step 5: PR 戦略を決める（更新 / 新規 + マージ順）


### PR DESCRIPTION
## セッション教訓に基づくスキル改善

### 変更概要

| スキル | 変更内容 |
|---|---|
| **code-apps** | `npx power-apps add-data-source` の禁止警告（CAUTION）を追加 |
| **cowork** | Step 5/8 の Playwright MCP 自動化を「必ず実行」に強化 + Simple Browser ズーム設定 |
| **update-skills** | Step 4 にブラウザズーム設定ガイドラインを追加 |

### 背景（教訓）

1. **`npx power-apps add-data-source` で AI エージェントがハングする問題**
   `pac code add-data-source -a dataverse -t {table}` の代わりに `npx power-apps add-data-source` を使うと、npx がパッケージインストールの対話プロンプトを出し、AI エージェントのターミナルが無限にハングする。`pac` サブコマンドなら対話なしで即座に実行される。

2. **Cowork プラグインアップロートの手動案内フォールバック問題**
   「Playwright MCP を優先」という書き方だと、AI が手動案内にフォールバックしてしまうことがあった。「必ず実行する」に変更し、手動案内は行わない方針に統一。

3. **VS Code Simple Browser のズーム問題**
   既定の `Match Window` 設定だと M365 管理センター等の複雑な UI がはみ出し、More actions ボタン等が不可視になる。`document.body.style.zoom = '0.8'` で 80% に縮小してから操作する指示を追加。

4. **radio ボタンの overlay 遮蔽問題**
   M365 管理センターの Publish to users ウィザードで、radio ボタンが overlay パネルに遮られて通常の `click()` が失敗する。`.evaluate(el => el.click())` で JS レベルのクリックを使う回避策を明記。
