### PR TITLE
fix(update-skills): gh CLI 出力の文字化けでPR検出が誤判定される問題を修正

### DIFF
--- a/.github/skills/update-skills/references/troubleshooting.md
+++ b/.github/skills/update-skills/references/troubleshooting.md
@@ -61,3 +61,12 @@
 - 主オプション: `--skill <name>`（必須）/ `--extra <path>`（README・agents 等の集約ファイルを同時反映、複数可）/
   `--branch`（既定 `skill/<name>`）/ `--dry-run`（push・PR をスキップして検証のみ）。
 - 既存の同名ブランチ/PR があれば自動で更新（新規 PR を作らない）。
+
+## 13. `manage_skill_pr.py` が既存のオープン PR を検出できず「新規 PR で OK」と誤判定する
+- 原因: 日本語タイトル・本文を含む PR で `gh pr list --json ...` の出力を読む際、Windows の既定コンソール
+  コードページ（cp932）で `subprocess.run` がデコードしようとして `UnicodeDecodeError` になり、
+  該当 PR がリストから抜け落ちる（バックグラウンドスレッドの例外のためスクリプト自体は落ちず、
+  「オープン PR: 0 件」のように**サイレントに誤った結果**を返す）。
+- 対処: `gh()` 呼び出しに `encoding="utf-8", errors="replace"` を明示する（本スキルの `manage_skill_pr.py` は
+  対応済み）。念のため、スクリプトの判定結果が「関連 PR なし」でも、対象スキルに触れていそうな PR がないか
+  `gh pr list --repo <owner/repo> --state open` で目視確認してから新規 PR を作成する。

--- a/.github/skills/update-skills/scripts/manage_skill_pr.py
+++ b/.github/skills/update-skills/scripts/manage_skill_pr.py
@@ -45,7 +45,7 @@ def gh(args: list[str]) -> str:
     exe = shutil.which("gh")
     if not exe:
         sys.exit("GitHub CLI(gh) が見つかりません。インストールと 'gh auth login' を確認してください。")
-    res = subprocess.run([exe, *args], capture_output=True, text=True)
+    res = subprocess.run([exe, *args], capture_output=True, text=True, encoding="utf-8", errors="replace")
     if res.returncode != 0:
         sys.exit(f"gh 失敗: {' '.join(args)}\n{res.stderr.strip()}")
     return res.stdout

--- a/.github/skills/update-skills/scripts/publish_skill.py
+++ b/.github/skills/update-skills/scripts/publish_skill.py
@@ -54,7 +54,7 @@ def load_env(start: Path) -> None:
 
 
 def run(args: list[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess:
-    res = subprocess.run(args, cwd=cwd, capture_output=True, text=True, encoding="utf-8")
+    res = subprocess.run(args, cwd=cwd, capture_output=True, text=True, encoding="utf-8", errors="replace")
     if check and res.returncode != 0:
         sys.exit(f"コマンド失敗: {' '.join(args)}\n{res.stderr.strip() or res.stdout.strip()}")
     return res


### PR DESCRIPTION
manage_skill_pr.py が既存のオープンPRを検出できず「関連PRなし→新規PRでOK」と誤判定するバグを修正。

## 原因
gh pr list --json ... の出力（日本語タイトル/本文を含む）を subprocess.run で読む際、
Windows既定のコンソールコードページ(cp932)でデコードしようとして UnicodeDecodeError が
バックグラウンドスレッドで発生。スクリプト自体は落ちずに握りつぶされ、
「オープンPR: 0件」のようにサイレントに誤った結果を返していた。
実際にこのセッション中、既存のオープンPR #227（code-apps: reactflow-visualization-design）を
検出できず新規PR作成を推奨する誤判定が発生し、手動で気づいて回避した。

## 変更内容
- manage_skill_pr.py の gh() 呼び出しに encoding="utf-8", errors="replace" を明示
- publish_skill.py の run() にも同様に errors="replace" を追加（同じクラッシュパターンの予防）
- references/troubleshooting.md に事象と対処（目視での二重確認を推奨）を追記

- validate_skill.py PASS
- マージ順: 依存なし。他のオープンPR（#227, #228）とは別ファイルのため単独でマージ可能
