### PR TITLE
skill(spec-to-markdown): アーキテクチャ優先の参照原則を明記し設計・テスト要件の重複を解消

### DIFF
--- a/.github/skills/spec-to-markdown/SKILL.md
+++ b/.github/skills/spec-to-markdown/SKILL.md
@@ -100,8 +100,8 @@ staging の変換完了後、以下の手順で docs を更新する。
 3. 全 staging ファイルを横断し、各 docs の `要確認` を実際の要件に書き換える：
    - `business-requirements.md` → ステークホルダー・ユーザーストーリー・業務フロー
    - `functional-requirements.md` → 機能一覧(MoSCoW)・データモデル・非機能要件
-   - `design-requirements.md` → 全体構成・コンポーネント・リスク・実装タスク分解
-   - `test-requirements.md` → テストシナリオ・受け入れ条件（functional の機能一覧 # と対応）
+   - `design-requirements.md` → 全体構成・コンポーネント・リスク・実装タスク分解（★全体構成・コンポーネント選定は [architecture スキル](../architecture/SKILL.md) の判断を正として転記する）
+   - `test-requirements.md` → テストシナリオ・受け入れ条件（functional の機能一覧 # と対応。条件本文の正は functional 側）
 4. `index.md` の処理状況テーブルも合わせて更新する
 5. 推測で埋めず、情報不足は `要確認` として残す
 
@@ -143,29 +143,33 @@ staging の変換完了後、以下の手順で docs を更新する。
 - 要件変更履歴（変更理由を必ず併記）
 
 ### functional-requirements.md
-- 機能一覧（MoSCoW 優先度・受け入れ条件の表）
+- 機能一覧（MoSCoW 優先度・受け入れ条件の表 — **受け入れ条件の正はここ**）
 - Dataverse テーブル候補（テーブル名・主な列・リレーション）
-- Code Apps / Model-Driven Apps の UI 要件
+- UI 要件（Code Apps / Model-Driven Apps / Cowork プラグイン — 選定の確定は [architecture スキル](../architecture/SKILL.md) を優先）
 - Power Automate の自動化要件
-- Copilot Studio / AI Builder の利用余地
+- Copilot Studio / AI Builder の利用余地（採用可否・v1/v2 判断は architecture スキルに従う）
 - 外部連携
-- 非機能要件（パフォーマンス・セキュリティ・可用性・スケーラビリティ）
+- 非機能要件（パフォーマンス・セキュリティ・可用性・スケーラビリティ・ユーザビリティ — test-requirements の非機能テストと区分を一致させる）
 - 要件変更履歴（変更理由を必ず併記）
 
 ### design-requirements.md
-- Power Platform 全体構成案
-- コンポーネント設計（種別・役割・依存の表）
+
+> ★ 全体構成・コンポーネント選定・構築フェーズは [architecture スキル](../architecture/SKILL.md) を正とする。
+> 本ドキュメントには architecture スキルの判断フロー・[設計アウトプットテンプレート](../architecture/references/design-patterns.md#2-設計アウトプットテンプレート)で確定した結果を転記する。
+
+- Power Platform 全体構成案（architecture スキルのテンプレート準拠、Mermaid 構成図）
+- コンポーネント設計（種別・役割・依存の表 — architecture スキルの「コンポーネント構成」表と整合させる）
 - セキュリティ / 権限 / 監査（区分・内容・対応方針の表）
 - 設計上のリスク（リスク・影響度・発生確率・対応方針の表）
-- Phase 1 で確認が必要な論点
-- 実装タスク分解（タスク・依存・優先度・見積の表）
+- Phase 1 確認事項
+- 実装タスク分解（タスク・依存・優先度・見積の表 — フェーズ順序は architecture スキルの「構築フェーズ」に沿う）
 - 要件変更履歴（変更理由を必ず併記）
 
 ### test-requirements.md
 - テスト戦略（テスト方針・環境・自動化範囲）
 - テストシナリオ（シナリオ名・前提条件・操作手順・期待結果・優先度の表）
-- 受け入れ条件（functional-requirements の機能 # と対応させた表）
-- 非機能テスト（区分・テスト内容・合格基準の表）
+- 受け入れ条件（functional-requirements の機能 # を参照し確認方法を定義 — **条件本文の正は functional 側、二重管理しない**）
+- 非機能テスト（区分・テスト内容・合格基準の表 — 区分は functional の非機能要件と一致させる）
 - 要件変更履歴（変更理由を必ず併記）
 
 ## 実行例
@@ -178,3 +182,4 @@ python convert_documents.py
 ## 参照
 
 - [変換ガイド](references/conversion-guide.md)
+- [architecture スキル](../architecture/SKILL.md) — 全体構成・コンポーネント選定の正（design-requirements / UI・AI 連携要件はこちらを優先して参照）

--- a/.github/skills/spec-to-markdown/references/conversion-guide.md
+++ b/.github/skills/spec-to-markdown/references/conversion-guide.md
@@ -115,26 +115,30 @@ python convert_documents.py \
 - 要件変更履歴（理由を併記）
 
 ### functional-requirements.md
-- 機能一覧（MoSCoW 優先度・受け入れ条件の表）
+- 機能一覧（MoSCoW 優先度・受け入れ条件の表 — 受け入れ条件の正はここ）
 - Dataverse テーブル候補（表）
-- UI 要件 / 自動化要件 / AI 連携要件
-- 非機能要件（パフォーマンス・セキュリティ・可用性・スケーラビリティの表）
+- UI 要件 / 自動化要件 / AI 連携要件（コンポーネント選定は `.github/skills/architecture/SKILL.md` の判断フローを優先。Cowork プラグイン第一候補・Canvas Apps は常に対象外・外部ユーザー向けは Azure 既定）
+- 非機能要件（パフォーマンス・セキュリティ・可用性・スケーラビリティ・ユーザビリティの表 — test の非機能テストと区分を一致させる）
 - 要件変更履歴（理由を併記）
 
 ### design-requirements.md
-- Power Platform 全体構成案
-- コンポーネント設計（表）
+
+> ★ 全体構成・コンポーネント選定・構築フェーズは `.github/skills/architecture/SKILL.md` を正とし、
+> architecture スキルの判断フロー・設計アウトプットテンプレート（`references/design-patterns.md` §2）で確定した結果を転記する。
+
+- Power Platform 全体構成案（architecture スキルのテンプレート準拠、Mermaid 構成図）
+- コンポーネント設計（表 — architecture スキルの「コンポーネント構成」表と整合させる）
 - セキュリティ / 権限 / 監査（表）
 - 設計上のリスク（影響度・発生確率・対応方針の表）
 - Phase 1 確認事項
-- 実装タスク分解（タスク・依存・優先度・見積の表）
+- 実装タスク分解（タスク・依存・優先度・見積の表 — フェーズ順序は architecture スキルの「構築フェーズ」に沿う）
 - 要件変更履歴（理由を併記）
 
 ### test-requirements.md
 - テスト戦略
 - テストシナリオ（前提条件・操作手順・期待結果・優先度の表）
-- 受け入れ条件（functional の機能 # と対応させた表）
-- 非機能テスト（合格基準の表）
+- 受け入れ条件（functional の機能 # を参照し確認方法を定義 — 条件本文の正は functional 側、二重管理しない）
+- 非機能テスト（合格基準の表 — 区分は functional の非機能要件と一致させる）
 - 要件変更履歴（理由を併記）
 
 ## 7. conversion-checklist の運用
@@ -159,7 +163,7 @@ staging が全件完了したら、以下の流れで開発に入る。
 
 1. **要件合意**: `business-requirements.md` の未確定事項を PO / BA と確認し、`要確認` を解消する
 2. **優先度合意**: `functional-requirements.md` の MoSCoW 優先度を PO と合意する
-3. **設計確定**: `design-requirements.md` の実装タスク分解を確定させる
+3. **設計確定**: `.github/skills/architecture/SKILL.md` の判断フローで全体構成・コンポーネント選定を確定し、結果を `design-requirements.md` に転記して実装タスク分解を確定させる
 4. **テスト設計**: `test-requirements.md` の受け入れ条件を `functional-requirements.md` の機能 # と紐付ける
 5. **開発着手**: `design-requirements.md` の実装タスク表を元にタスクを割り当てる
 6. **変更管理**: 仕様変更時は各 docs の「要件変更履歴」に変更内容と理由を記録する

--- a/.github/skills/spec-to-markdown/scripts/convert_documents.py
+++ b/.github/skills/spec-to-markdown/scripts/convert_documents.py
@@ -341,7 +341,14 @@ def build_functional_requirements_doc(batch_started_at: str, results: list[Conve
 
 ## 4. UI 要件
 
+<!-- コンポーネント選定は architecture スキル（.github/skills/architecture/SKILL.md）の判断フローを優先する -->
+<!-- ここでは要件の列挙にとどめ、選定の確定は architecture スキルで行う（Cowork プラグイン第一候補・Canvas Apps は常に対象外・外部ユーザー向けは Azure 既定） -->
+
 ### Code Apps / Model-Driven Apps
+
+- 要確認
+
+### Copilot Cowork プラグイン（データ入力の接点）
 
 - 要確認
 
@@ -353,6 +360,8 @@ def build_functional_requirements_doc(batch_started_at: str, results: list[Conve
 
 ## 6. AI / 連携要件
 
+<!-- Copilot Studio の採用可否・v1/v2 の選択、AI Builder（AI プロンプト優先）は architecture スキルの判断フローに従う -->
+
 ### Copilot Studio / AI Builder
 
 - 要確認
@@ -363,12 +372,15 @@ def build_functional_requirements_doc(batch_started_at: str, results: list[Conve
 
 ## 7. 非機能要件
 
+<!-- 区分は test-requirements.md の非機能テストと一致させる -->
+
 | 区分 | 内容 | 指標 |
 | --- | --- | --- |
 | パフォーマンス | 要確認 | 要確認 |
 | セキュリティ | 要確認 | 要確認 |
 | 可用性 | 要確認 | 要確認 |
 | スケーラビリティ | 要確認 | 要確認 |
+| ユーザビリティ | 要確認 | 要確認 |
 
 ## 8. 備考
 
@@ -385,17 +397,22 @@ def build_design_requirements_doc(batch_started_at: str, results: list[Conversio
     date_prefix = batch_started_at[:10]
     return f"""# 設計要件
 
+<!-- 全体構成・コンポーネント選定・構築フェーズは architecture スキル（.github/skills/architecture/SKILL.md）を正とする -->
+<!-- 本ドキュメントには architecture スキルの判断フロー・設計アウトプットテンプレートで確定した結果を転記する -->
+
 ## 1. 変換対象ファイル
 
 {_file_table_header(batch_started_at, results)}
 
 ## 2. Power Platform 全体構成案
 
-<!-- アーキテクチャ図（mermaid / テキスト）や構成の説明を記載 -->
+<!-- architecture スキルの設計アウトプットテンプレート（references/design-patterns.md §2）に従い、Mermaid 構成図（複数カラム形式の subgraph）で記載する -->
 
 要確認
 
 ## 3. コンポーネント設計
+
+<!-- architecture スキルの「コンポーネント構成」表と整合させる（Cowork プラグイン第一候補・Canvas Apps は常に対象外） -->
 
 | コンポーネント | 種別 | 役割 | 依存 | 備考 |
 | --- | --- | --- | --- | --- |
@@ -415,13 +432,13 @@ def build_design_requirements_doc(batch_started_at: str, results: list[Conversio
 | --- | --- | --- | --- | --- |
 | 1 | 要確認 | 高/中/低 | 高/中/低 | 要確認 |
 
-## 6. Phase 0 確認事項
+## 6. Phase 1 確認事項
 
 - 要確認
 
 ## 7. 実装タスク分解
 
-<!-- 開発着手前に確認・合意する粒度で記載 -->
+<!-- 開発着手前に確認・合意する粒度で記載。フェーズ順序は architecture スキルの「構築フェーズ」（Phase 2〜7）に沿って分解する -->
 
 | # | タスク | 依存タスク | 優先度 | 見積 (h) | 担当 |
 | --- | --- | --- | --- | --- | --- |
@@ -462,20 +479,23 @@ def build_test_requirements_doc(batch_started_at: str, results: list[ConversionR
 
 ## 4. 受け入れ条件
 
-<!-- functional-requirements.md の機能一覧 #N に対応させて記載 -->
+<!-- 受け入れ条件の正（Source of Truth）は functional-requirements.md の機能一覧。条件本文をここへ転記せず、機能 # を参照して確認方法のみを定義する -->
 
-| # | 機能名 | 受け入れ条件 | 確認方法 |
+| # | 機能 #（functional 参照） | 機能名 | 確認方法 |
 | --- | --- | --- | --- |
 | 1 | 要確認 | 要確認 | 要確認 |
 
 ## 5. 非機能テスト
 
+<!-- 区分は functional-requirements.md の非機能要件と一致させる -->
+
 | 区分 | テスト内容 | 合格基準 |
 | --- | --- | --- |
 | パフォーマンス | 要確認 | 要確認 |
 | セキュリティ | 要確認 | 要確認 |
-| ユーザビリティ | 要確認 | 要確認 |
 | 可用性 | 要確認 | 要確認 |
+| スケーラビリティ | 要確認 | 要確認 |
+| ユーザビリティ | 要確認 | 要確認 |
 
 ## 6. 備考
 


### PR DESCRIPTION
- design-requirements: 全体構成・コンポーネント選定・構築フェーズは architecture スキルを正とし、確定結果を転記する方針を SKILL.md / conversion-guide / 生成テンプレートに明記
- functional-requirements: UI 要件・AI 連携要件にコンポーネント選定は architecture スキル優先（Cowork 第一候補・Canvas Apps 対象外・外部は Azure 既定）の注記を追加、Cowork プラグインのセクションを追加
- test-requirements: 受け入れ条件の正を functional 側に一本化（機能 # 参照 + 確認方法のみ定義）
- 非機能の区分を functional / test で統一（パフォーマンス・セキュリティ・可用性・スケーラビリティ・ユーザビリティ）
- 生成テンプレートの「Phase 0 確認事項」を「Phase 1 確認事項」に統一（SKILL.md / conversion-guide と整合）

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FLjvjGySmTu9pT3ss2yE3k