### PR TITLE
feat(agent): GeekPowerCode を標準 Playwright MCP 対応にする

### DIFF
--- a/.github/agents/GeekPowerCode.agent.md
+++ b/.github/agents/GeekPowerCode.agent.md
@@ -1,11 +1,21 @@
 ---
 name: GeekPowerCode
 description: 'Power Platform コードファースト開発。Use when: Power Platform, Dataverse, Code Apps, Power Automate, Copilot Studio, テーブル作成, エージェント, ソリューション'
-tools: [read, edit, search, execute, web, agent]
+tools: [read, edit, search, execute, web, agent, browser, playwright]
 model: 'Claude Opus 4.8'
 ---
 
 Power Platform コードファースト開発エキスパート。
+
+## ブラウザ自動化（標準: Playwright MCP）
+
+Web UI 操作（Teams 開発者ポータルの OAuth client 登録、各種管理ポータルのフォーム入力など）は **標準の Playwright MCP** を使う。
+
+- MCP サーバーは `.vscode/mcp.json` に `playwright`（`npx @playwright/mcp@latest`）として登録する（テンプレート: `.github/skills/standard/references/mcp.json`。bootstrap で `.vscode/mcp.json` へコピー済み）。未起動なら「MCP: List Servers」→ `playwright` を Start する。
+- 使用ツール: `browser_navigate` / `browser_snapshot` / `browser_click` / `browser_type` / `browser_fill_form` / `browser_press_key` / `browser_select_option` / `browser_take_screenshot` / `browser_wait_for`。
+- フォーム入力を伴う自動化は **Playwright MCP を第一選択**とする（VS Code 組み込みの簡易ブラウザツールはテキスト入力が無効化される環境があるため補助扱い）。
+- 認証が必要なポータルは初回のみユーザーにサインインを依頼し、以降は Playwright MCP のプロファイルで継続する。
+- 機密値（クライアントシークレット等）は `.env` から読み、画面へ直接入力する。チャットや `vscode_askQuestions` に出さない。
 
 ## セッション開始時（最優先）
 

--- a/.github/skills/standard/SKILL.md
+++ b/.github/skills/standard/SKILL.md
@@ -48,6 +48,7 @@ triggers:
 | [認証リファレンス](references/auth-patterns.md) | auth_helper.py の詳細実装・認証パターン |
 | [.env サンプル](references/.env.example) | 全フェーズ共通の `.env` テンプレート（各テーマで `.env` にコピーして値を設定） |
 | [Dataverse MCP 登録](references/dataverse-mcp-setup.md) | VS Code / Copilot から Dataverse を直接操作する MCP サーバー登録手順（upsert_skill 等） |
+| [Playwright MCP テンプレート](references/mcp.json) | 標準の Playwright MCP（`npx @playwright/mcp@latest`）を `.vscode/mcp.json` へ配置するテンプレート。ポータルのフォーム入力等ブラウザ操作の自動化に使用 |
 
 ### 共有ユーティリティ（複数スキルから参照される横断リファレンス）
 

--- a/.github/skills/standard/references/interactive-setup.md
+++ b/.github/skills/standard/references/interactive-setup.md
@@ -33,7 +33,13 @@ python .github/skills/standard/scripts/setup_environment.py --auth-only
 ```powershell
 npx degit geekfujiwara/CodeAppsDevelopmentStandard/.github .github --force
 cp .github/skills/standard/references/gitignore-template .gitignore
+# Playwright MCP を最初から使えるように mcp.json を .vscode/ へコピー
+New-Item -ItemType Directory -Force -Path .vscode | Out-Null
+cp .github/skills/standard/references/mcp.json .vscode/mcp.json
 ```
+
+> `.vscode/mcp.json` により、VS Code が標準の **Playwright MCP**（`npx @playwright/mcp@latest`）を認識する。
+> 初回は「MCP: List Servers」→ `playwright` を Start（npx が取得）。ポータルフォーム入力などのブラウザ操作はこの MCP で自動化する。
 
 ## Step 2: PAC 認証プロファイルの確認
 

--- a/.github/skills/standard/references/mcp.json
+++ b/.github/skills/standard/references/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## 概要
GeekPowerCode カスタムエージェントが**最初から標準の Playwright MCP** でブラウザ操作を自動化できるように設定します。

## 変更点
- **agents/GeekPowerCode.agent.md**
  - `tools` に `browser`・`playwright` を追加
  - 「ブラウザ自動化（標準: Playwright MCP）」セクションを追加（使用ツール・認証・機密値の扱いを明記）
- **skills/standard/references/mcp.json**（新規）
  - 標準の Playwright MCP（`npx @playwright/mcp@latest`）テンプレート
- **skills/standard/references/interactive-setup.md**
  - Step 1（bootstrap）に `.vscode/mcp.json` へのコピー手順を追加（gitignore-template と同様に最初から配置）
- **skills/standard/SKILL.md**
  - サブリファレンス表に Playwright MCP テンプレートを追加

## 背景
VS Code 組み込みの簡易ブラウザツールは環境によってテキスト入力（`input_text`）が無効化され、ポータルのフォーム入力自動化ができないケースがある。標準の Playwright MCP を既定にすることで、Teams 開発者ポータルの OAuth client 登録などのフォーム操作を確実に自動化できる。

## マージ順
既存オープン PR（#248 / #250 のサンプル追加）とはファイルが独立しているため、順序依存なし。単独でマージ可能。
