### PR TITLE
skill(dataverse): メタデータロック競合対策と501回避パターンを反映

### DIFF
--- a/.github/skills/dataverse/SKILL.md
+++ b/.github/skills/dataverse/SKILL.md
@@ -133,7 +133,10 @@ python -u .github/skills/dataverse/scripts/scan_environment.py --tables account,
 existing_sol = api_get(f"solutions?$filter=uniquename eq '{SOLUTION_NAME}'&$select=solutionid,friendlyname")
 
 # テーブルスキーマ名の重複チェック
-existing_tables = api_get(f"EntityDefinitions?$filter=startswith(SchemaName,'{PREFIX}_')&$select=SchemaName,DisplayName")
+# ⚠️ 環境によっては EntityDefinitions への $filter=startswith(...) が 501 Not Implemented になる。
+#    $select のみで全件取得し、プレフィックス一致は Python 側でフィルタする（詳細は Dataverse 統合ガイド参照）。
+all_tables = api_get("EntityDefinitions?$select=LogicalName,SchemaName,DisplayName")
+existing_tables = [t for t in all_tables["value"] if t["LogicalName"].startswith(f"{PREFIX}_")]
 ```
 
 衝突がある場合はユーザーに報告し、名前を変更してから設計を確定する。
@@ -172,10 +175,18 @@ existing_tables = api_get(f"EntityDefinitions?$filter=startswith(SchemaName,'{PR
 > `-u` を付けて Step ごとの進捗（`=== Step 2: テーブル作成 ===` など）を確実にリアルタイム
 > 表示させる。スクリプト側でも `sys.stdout.reconfigure(line_buffering=True)` を有効化済み。
 
-> **テーブルが複数ある場合は並行作成**: `setup_dataverse.py` の Step 2 では、`TABLES` に
-> 2 つ以上のテーブルが定義されている場合、`ThreadPoolExecutor`（最大 5 並行）で**全テーブル
-> を並行作成**する。各テーブルの「本体作成 → sleep 10s → カスタム列追加」は 1 スレッドで
-> 完結するため、テーブル間の競合は発生しない。
+> **テーブルが複数ある場合は並行作成（環境の混雑度に応じて並行数を調整）**: `setup_dataverse.py` の
+> Step 2 では、`TABLES` に 2 つ以上のテーブルが定義されている場合、`ThreadPoolExecutor`
+> （デフォルト最大 3 並行）で**全テーブルを並行作成**する。
+>
+> ⚠️ **Dataverse のメタデータロックはテナント全体で共有される**ため、既存カスタムテーブルが
+> 大量にある（100 件超）環境や、同一環境で他セッションが並行してメタデータ操作をしている環境では
+> 並行数が高いほど競合が増える。実測では 10 テーブルを 5 並行で作成したところ 7 テーブルが
+> `max retries (5) exceeded` で失敗し、並行数を 2 に落として再実行したところ全て成功した。
+> 失敗が多発する場合は `create_tables()` の `ThreadPoolExecutor(max_workers=...)` を 2 まで
+> 下げて再実行する。**スクリプトはべき等**（成功済みテーブル・列は `already exists, skipping`
+> で自動スキップ）なので、同じコマンドを再実行するだけで失敗分だけがリトライされ、安全に復旧する。
+>
 > **Lookup（Step 3）は全テーブルと列が揃ってから**作成するので、このスクリプトでの呼び出し順は
 > 変わらない（`create_tables()` が全スレッドの完了を待ってから return する）。
 
@@ -231,6 +242,7 @@ existing_tables = api_get(f"EntityDefinitions?$filter=startswith(SchemaName,'{PR
 | **EntitySetName は API で取得** | 複数形の推測は誤る場合がある（例: `equipmentcategorys` vs `em_equipmentcategories`） |
 | **ソリューション表示名を `.env` に自動保存** | `_save_env_value("SOLUTION_DISPLAY_NAME", name)` で永続化。他スクリプトから参照可能 |
 | **メタデータロックで最大リトライ超過時は再実行** | `retry_metadata()` の max retries (5) を超えた列は、スクリプト再実行時に「既存。スキップ」で回復 |
+| **失敗が多発する環境では並行数を下げる** | 既存カスタムテーブルが多い環境では `max_workers` を 5→2〜3 に下げると失敗率が大幅に下がる（実測） |
 | **429 レート制限は時間を置いて再実行** | `PublishAllXml`・`EntityDefinitions` PUT で 429 が頻発。べき等設計でスクリプト再実行で回復 |
 
 ### Lookup と NavProp

--- a/.github/skills/dataverse/references/dataverse-guide.md
+++ b/.github/skills/dataverse/references/dataverse-guide.md
@@ -369,3 +369,36 @@ pac auth create --environment {environment-id}
 - `$select` に対象フィールドが含まれているか確認
 - Lookup フィールドの場合は `$expand` を使用
 - フィールドのスキーマ名（論理名）が正しいか確認
+
+### EntityDefinitions の `$filter=startswith(...)` が 501 になる
+
+```
+501 Server Error: Not Implemented for url: .../EntityDefinitions?$filter=startswith(SchemaName,'geek_')...
+```
+
+環境によっては `EntityDefinitions` に対する `startswith` フィルタが未実装（`LogicalName` /
+`SchemaName` どちらでも発生）。`$select` のみで全件取得し、プレフィックス一致は Python 側で
+フィルタする。
+
+```python
+all_tables = api_get("EntityDefinitions?$select=LogicalName,SchemaName")
+matches = [t for t in all_tables["value"] if t["LogicalName"].startswith(f"{PREFIX}_")]
+```
+
+### 並行テーブル作成の失敗率が高い（メタデータロック競合）
+
+既存カスタムテーブルが多い（100件超）環境、または同一環境で他セッション/他ユーザーが並行して
+メタデータ操作をしている環境では、`ThreadPoolExecutor` の並行数が高いほど `0x80040237`
+（メタデータロック競合）が `retry_metadata` の再試行上限（5回、10s〜50s の累進バックオフ）を
+超えて失敗するテーブルが増える。実測では 10 テーブルを 5 並行で作成したところ 7 テーブルが
+`max retries (5) exceeded` で失敗し、並行数を 2 に落として再実行したところ全テーブルが成功した。
+
+対処:
+
+- `setup_dataverse.py` の `create_tables()` にある `ThreadPoolExecutor(max_workers=...)` を
+  2〜3 に下げる（テンプレートのデフォルトは 3）。
+- スクリプトはべき等（既存テーブル・列は `already exists, skipping` でスキップ）なので、
+  失敗が出ても**同じコマンドで再実行するだけで復旧する**。失敗したテーブル・列だけが
+  再作成対象になる。
+- それでも失敗が続く場合は、さらに並行数を下げる（1 = 完全逐次実行）か、`TABLES` を
+  分割して複数回に分けて実行する。

--- a/.github/skills/dataverse/scripts/setup_dataverse.py
+++ b/.github/skills/dataverse/scripts/setup_dataverse.py
@@ -397,7 +397,12 @@ def create_tables():
 
     print(f"  {len(TABLES)} テーブルを並行作成します…")
     errors: list[str] = []
-    with ThreadPoolExecutor(max_workers=min(len(TABLES), 5)) as executor:
+    # 並行数はデフォルト 3。既存カスタムテーブルが多い（100件超）環境や他セッションが
+    # 同時にメタデータ操作をしている環境では、並行数が高いほど 0x80040237（メタデータ
+    # ロック競合）の retry_metadata 上限（5回）を超えて失敗しやすい（実測: 5並行で
+    # 10テーブル中7テーブルが失敗、2並行で全成功）。失敗が多発する場合は 2 まで下げる。
+    # スクリプトはべき等なので、失敗した分だけを対象に何度でも安全に再実行できる。
+    with ThreadPoolExecutor(max_workers=min(len(TABLES), 3)) as executor:
         futures = {executor.submit(_create_single_table, tbl): tbl["logical"] for tbl in TABLES}
         for future in as_completed(futures):
             logical = futures[future]

--- a/.github/skills/standard/references/auth-patterns.md
+++ b/.github/skills/standard/references/auth-patterns.md
@@ -47,6 +47,16 @@ flow_api_call("GET", f"/providers/Microsoft.ProcessSimple/environments/{env_id}/
 python -c "import sys; sys.path.insert(0, '.github/skills/standard/scripts'); from auth_helper import get_token; print(get_token()[:20] + '...')"
 ```
 
+#### PowerShell で `python -c "..."` に OData クエリを渡すと壊れる
+
+`$select` / `$filter` などの `$` を含む Python コードを `python -c "..."` として
+PowerShell の二重引用符内に書くと、ネストした Python 文字列の中であっても PowerShell が
+`$select` / `$filter` を**変数展開**しようとして空文字列に置き換えてしまう
+（`EntityDefinitions?=uniquename,...` のように `$` 以降が消えた URL になる）。
+
+**対策**: `$` を含む OData クエリを扱うコードは `-c` のワンライナーにせず、一時的な
+`.py` ファイルに書いて `python <file>.py` で実行する。実行後は忘れずに削除する。
+
 #### MSAL Python 3.14 互換性問題
 
 Python 3.14 では MSAL 内部トークンキャッシュ (`msal/token_cache.py`) が壊れる問題がある。


### PR DESCRIPTION
実案件（10テーブル・並行構築）で得られた教訓を dataverse スキルに反映。

- Step2 の名前衝突チェックで EntityDefinitions?$filter=startswith(...) が環境により 501 Not Implemented になる問題を検知。$select 全件取得 + クライアント側フィルタに変更
- setup_dataverse.py テンプレートの並行テーブル作成 max_workers を既存カスタムテーブルが多い環境での実測（5並行→10件中7件失敗 / 2並行→全成功）に基づき 5→3 に変更し、troubleshooting に対処法を追記
- SKILL.md の『テーブル間の競合は発生しない』という誤った記述を修正し、並行数調整・べき等再実行のガイダンスを追加
- standard スキルに、PowerShell で python -c に $select/$filter を渡すと変数展開されて壊れる問題の回避策（一時 .py ファイル方式）を追記

validate_skill.py PASS（dataverse / standard）。マージ順: 単独 PR（他のオープン PR なし）。