### PR TITLE
feat(agent365): Foundry エージェントを Agent 365 経由で Teams / M365 Copilot に公開するスキルを追加

### DIFF
--- a/.github/agents/GeekPowerCode.agent.md
+++ b/.github/agents/GeekPowerCode.agent.md
@@ -58,5 +58,6 @@ Power Platform コードファースト開発エキスパート。
 | アーキテクチャ判断 | .github/skills/architecture/SKILL.md |
 | 要件理解・仕様書変換 | .github/skills/spec-builder/SKILL.md |
 | Cowork / MCP クライアント登録 | .github/skills/cowork/SKILL.md |
+| Agent 365 / Foundry エージェント公開 | .github/skills/agent365/SKILL.md |
 | スキル作成・更新 | .github/skills/update-skills/SKILL.md |
 | Azure リファレンスアーキテクチャ（セキュア構成） | .github/skills/azure/SKILL.md |

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -112,7 +112,7 @@ triggers:                      # スキル発動条件キーワード（必須�
 
 ---
 
-## スキル一覧（16 スキル）
+## スキル一覧（17 スキル）
 
 ### architecture — アーキテクチャ・基盤
 
@@ -146,6 +146,7 @@ triggers:                      # スキル発動条件キーワード（必須�
 | [copilot-studio-v2](copilot-studio-v2/SKILL.md) | Copilot Studio の新アーキテクチャ（cliagent）エージェントを Dataverse API だけで UI 操作なし完全自動構築する。フラット Python スキル添付まで対応。MCP サーバー等のツール追加は Copilot Studio UI での手動作業。 |
 | [power-automate](power-automate/SKILL.md) | Power Automate クラウドフローをソリューション対応で作成・デプロイする。 |
 | [cowork](cowork/SKILL.md) | 目的特化型の Copilot Cowork プラグイン（Agent Skills + Dataverse MCP）を開発し、Entra ID SSO を構成して M365 管理センターのエージェント画面から公開・更新する。 |
+| [agent365](agent365/SKILL.md) | Microsoft Foundry のエージェントを SDK/REST ベースで作成・バージョン管理し、Agent 365 のエージェント ID ブループリントと Teams アプリパッケージを介して Teams / Microsoft 365 Copilot に公開する。 |
 
 ### ai — AI / プロンプト
 
@@ -192,4 +193,6 @@ Track C（設計承認と同時に着手）:
 ── 全トラック完了後 ──
   8. cowork             → Cowork プラグイン化（Agent Skills + Dataverse MCP）・公開・更新
                            ※ 会社環境で Cowork の利用が許可されている場合のみ推奨
+  9. agent365           → Foundry エージェントを Agent 365 経由で Teams / M365 Copilot に公開
+                           ※ Foundry プロジェクトと Agent 365 ライセンスがある場合
 ```

--- a/.github/skills/agent365/SKILL.md
+++ b/.github/skills/agent365/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: agent365
+description: "Microsoft Foundry のエージェントを SDK/REST ベースで作成・バージョン管理し、Agent 365 のエージェント ID ブループリントと Teams アプリパッケージを介して Teams / Microsoft 365 Copilot に公開する。秘匿値は .env と GitHub Secrets に隔離し、テンプレートの汎用化を CI で機械検証する。"
+category: automation
+triggers:
+  - "Agent 365"
+  - "a365"
+  - "Foundry エージェント"
+  - "Microsoft Foundry"
+  - "エージェントを Teams に公開"
+  - "custom engine agent"
+  - "agentic user"
+  - "Agent Identity Blueprint"
+  - "エージェントテンプレート"
+  - "AI 秘書エージェント"
+---
+
+# Foundry エージェント × Agent 365 公開スキル
+
+Microsoft Foundry 上のエージェントを**コードファースト**（SDK / REST のみ、ポータル自動操作なし）で
+定義・デプロイし、**Agent 365 のエージェント ID ブループリント**と Teams アプリパッケージを通じて
+Teams / Microsoft 365 Copilot に公開するまでを一貫して行う。
+
+| 原則 | 内容 |
+|---|---|
+| SDK / REST のみ | すべて `azure-ai-projects` SDK と Agent 365 CLI（`a365`）で完結。ポータルのブラウザ自動操作は行わない |
+| テンプレート駆動 | コミットするのは `${VAR}` 入りテンプレートだけ。実値は `.env` / GitHub Secrets のみ |
+| 機械検証 | 秘匿化・汎用化は `review_sanitization.py` が CI で Pass/Fail 判定。人手のレビューに依存しない |
+| インスタンス化 | インストールごとに専用の Entra Agent ID を持たせるには Agent 365 ブループリント + `agenticUserTemplates` が必須 |
+| 自動配信 | Foundry の「常に最新を使用」により、新バージョンは Teams / M365 Copilot へ自動配信される |
+
+> 前提ツール: Python 3.10+、Azure CLI（`az`、ログイン済み）、GitHub CLI（`gh`、認証済み）、
+> Agent 365 CLI（`a365`）、Git。
+> 参考: [アーキテクチャ（2 種類のブループリント）](references/architecture.md) /
+> [Agent 365 CLI 運用](references/a365-cli.md) /
+> [リポジトリ scaffold](references/repo-scaffold.md) /
+> [異常系・トラブルシュート](references/troubleshooting.md)
+
+## スキル同梱スクリプト（再利用）
+
+すべて汎用化済み。値は引数または `.env`（[references/.env.example](references/.env.example)）から取得する。
+
+| スクリプト | 用途 | Step |
+|---|---|---|
+| [scripts/render.py](scripts/render.py) | テンプレートの `${VAR}` を環境変数で解決して実ファイルを生成 | 4 |
+| [scripts/create_blueprint.py](scripts/create_blueprint.py) | Foundry のマネージド ID ブループリントを作成／一覧／表示（REST 直呼び） | 3 |
+| [scripts/create_instance.py](scripts/create_instance.py) | manifest / definition / blueprint の 3 モードでエージェントを作成 | 4 |
+| [scripts/deploy.py](scripts/deploy.py) | レンダリング済み manifest から新バージョンを `create_version` | 4, 9 |
+| [scripts/build_teams_package.py](scripts/build_teams_package.py) | Teams manifest + アイコン + agenticUser を ZIP 化 | 7 |
+| [scripts/sanitize.py](scripts/sanitize.py) | 実値入り manifest を `${VAR}` 化し GitHub Secrets へ同期 | 9 |
+| [scripts/check_secrets.py](scripts/check_secrets.py) | ステージ済み差分への実値混入を検査（pre-commit） | 9 |
+| [scripts/review_sanitization.py](scripts/review_sanitization.py) | 秘匿化・汎用化の決定論レビューゲート（CI 必須チェック） | 9, 10 |
+
+## 標準フォルダ構成（生成されるテーマ側）
+
+```
+<repo-root>/
+├── .env                          # 実値（.gitignore 済み）
+├── .env.example                  # プレースホルダーのみ（コミット対象）
+├── .githooks/pre-commit          # 汎用化 → Secrets 同期 → 漏洩検査
+├── .github/workflows/
+│   ├── review.yml                # sanitization-review（必須チェック）
+│   └── deploy.yml                # render → 承認 → create_version
+├── agents/<agent-name>/
+│   ├── agent.template.yaml       # コミット対象（${VAR} 入り）
+│   └── agent.yaml                # レンダリング結果（.gitignore 済み）
+├── teams/
+│   ├── manifest.template.json    # コミット対象
+│   ├── agenticUser.template.json # コミット対象
+│   └── <agent-name>-teams-app.zip# ビルド結果（.gitignore 済み）
+├── assets/agent-icon.png         # アイコン元画像（正方形・背景透過）
+└── scripts/                      # 本スキルの scripts/ をコピー
+```
+
+## ワークフロー（正常系）
+
+### Step 0: 公開形態を決める
+
+1. **共有エージェント**（全ユーザーが同じ 1 体を使う）か、
+   **インスタンス化エージェント**（インストールごとに専用の Entra Agent ID を持つ）かを確認する。
+2. インスタンス化する場合のみ Agent 365 ブループリント（Step 5）と `agenticUserTemplates` が必要になる。
+   → 詳細は [references/architecture.md](references/architecture.md)。
+3. エージェント名（kebab-case、Teams 表示名とは別）を決める。
+   **商標・著作権に触れる名称やキャラクターを流用しない**（後から改称すると識別子の総入れ替えになる）。
+
+### Step 1: リポジトリを scaffold する
+
+[references/repo-scaffold.md](references/repo-scaffold.md) の内容をそのまま配置する。
+
+```powershell
+# 本スキルの scripts/ とテンプレートをテーマリポジトリへコピー
+Copy-Item .github/skills/agent365/scripts -Destination scripts -Recurse
+Copy-Item .github/skills/agent365/references/templates/agent.template.yaml agents/<agent-name>/
+Copy-Item .github/skills/agent365/references/templates/manifest.template.json teams/
+Copy-Item .github/skills/agent365/references/templates/agenticUser.template.json teams/
+Copy-Item .github/skills/agent365/references/.env.example .env.example
+git config core.hooksPath .githooks
+pip install -r requirements.txt   # azure-ai-projects / azure-identity / PyYAML / Pillow
+```
+
+`.gitignore` には最低限 `.env` / `agents/**/agent.yaml` / `teams/*.zip` / `a365.generated.config.json`
+/ `*token-cache*` を追加する（[references/repo-scaffold.md](references/repo-scaffold.md) に完全版）。
+
+### Step 2: Foundry プロジェクトと `.env` を用意する
+
+1. Foundry プロジェクトのエンドポイント（`https://<account>.services.ai.azure.com/api/projects/<project>`）を
+   プロジェクト概要から取得する。
+2. `.env.example` を `.env` にコピーし、実値を設定する。**`.env` は絶対にコミットしない**。
+3. `az login` 済みであることを確認する（`DefaultAzureCredential` が使用する）。
+
+```powershell
+Copy-Item .env.example .env
+az account set --subscription $env:AZURE_SUBSCRIPTION_ID
+```
+
+### Step 3: Foundry のマネージド ID ブループリントを作成する
+
+エージェントのマネージド ID の設計図。**`lifecycle=Manual` で作れば複数エージェントから共有できる**
+（エージェントが暗黙に作る `Auto` は所有者専用で共有不可）。
+
+```powershell
+python scripts/create_blueprint.py --name <blueprint-name>          # lifecycle=Manual
+python scripts/create_blueprint.py --list
+python scripts/create_blueprint.py --name <blueprint-name> --show
+```
+
+出力された `blueprintId` / `principalId` / `clientId` を `.env` の
+`BLUEPRINT_ID` / `BLUEPRINT_PRINCIPAL_ID` / `BLUEPRINT_CLIENT_ID` に設定する。
+
+### Step 4: エージェントを定義してデプロイする
+
+1. `agents/<agent-name>/agent.template.yaml` の `definition`（`model` / `instructions` / `tools`）を編集する。
+   ARM リソース参照は必ず `${AZURE_SUBSCRIPTION_ID}` 等のプレースホルダーで書く。
+2. レンダリングしてデプロイする。
+
+```powershell
+python scripts/render.py --agent <agent-name>
+python scripts/create_instance.py --name <agent-name> --mode blueprint --blueprint-id <blueprint-name>
+# 2 回目以降のバージョン更新
+python scripts/deploy.py --agent <agent-name>
+```
+
+| モード | SDK API | 用途 |
+|---|---|---|
+| `manifest` | `agents.create_version_from_manifest` | 公開済みテンプレート ID + パラメーター値で作成 |
+| `definition` | `agents.create_version` | テンプレート定義を複製して独立エージェント化 |
+| `blueprint` | `agents.create_version(blueprint_reference=...)` | ブループリント共有（`lifecycle=Manual` 必須） |
+
+作成後、`INSTANCE_IDENTITY_PRINCIPAL_ID` / `INSTANCE_IDENTITY_CLIENT_ID` / `AGENT_GUID` を `.env` へ反映する。
+
+### Step 5: Agent 365 のエージェント ID ブループリントを作成する
+
+インストールごとの専用 Entra Agent ID が必要な場合のみ実施する（Step 0 の判断）。
+**Foundry のブループリントとは別物**なので混同しない。
+
+```powershell
+a365 setup blueprint -n <agent-name> --no-endpoint
+```
+
+- 生成された `a365.generated.config.json` の `agentBlueprintId` を `.env` の
+  `A365_AGENT_BLUEPRINT_ID` に設定する（このファイル自体は `.gitignore` 済み）。
+- 実行のたびに**クライアントシークレットが平文で標準出力される**。ログに残さない。
+- 初回はディレクトリ伝播の遅延で失敗することがあるが、**同じコマンドを再実行すれば冪等に修復される**。
+- Windows での認証（WAM）まわりのハマりどころは [references/a365-cli.md](references/a365-cli.md)。
+
+### Step 6: Azure Bot Service と Teams チャネルを作成する
+
+Bot の `msaAppId` には**エージェントのインスタンス ID の client id** を使う。
+
+```powershell
+az bot create --resource-group $env:AZURE_RESOURCE_GROUP --name $env:AZURE_BOT_NAME `
+  --app-type SingleTenant --appid $env:INSTANCE_IDENTITY_CLIENT_ID --tenant-id $env:AZURE_TENANT_ID `
+  --endpoint "$env:FOUNDRY_PROJECT_ENDPOINT/agents/$env:AGENT_NAME/endpoint/protocols/activityprotocol?api-version=2025-11-15-preview" `
+  --sku S1
+az bot msteams create --resource-group $env:AZURE_RESOURCE_GROUP --name $env:AZURE_BOT_NAME
+```
+
+### Step 7: Teams アプリパッケージをビルドする
+
+```powershell
+python scripts/build_teams_package.py
+```
+
+- `assets/agent-icon.png` から `color.png`（192x192）と `outline.png`（32x32・白シルエット）を自動生成する。
+  元画像は**アルファチャンネル付きの正方形 PNG**にする（背景が不透明だと outline が塗り潰しになる）。
+- `A365_AGENT_BLUEPRINT_ID` が設定されていれば `agenticUser.json` を同梱し、
+  `manifestVersion: devPreview` のインスタンス化パッケージを生成する。
+  未設定なら GA スキーマ（1.22）の**共有エージェント**パッケージに自動ダウングレードして警告を出す。
+- **再アップロードのたびに `.env` の `TEAMS_APP_VERSION` を上げる**（同一バージョンはアップロード時に拒否される）。
+
+### Step 8: アップロードして公開する
+
+1. Microsoft 365 管理センター（Agent 365 の Agents 画面）または Teams 管理センター >
+   アプリを管理 > アップロード で、生成された ZIP を登録する。
+2. 組織向けのアクセス許可・公開範囲を設定する。
+3. Teams でエージェントを開き、利用者ごとのセッション（インスタンス）が開始されることを確認する。
+
+### Step 9: CI/CD と秘匿化ゲートを有効化する
+
+1. **pre-commit**: `sanitize.py`（実値 → `${VAR}` 化 + GitHub Secrets 同期 + ステージ）→
+   `check_secrets.py`（ステージ差分の漏洩検査）を実行する。
+2. **`review.yml`**: PR と main で `review_sanitization.py` を実行し、必須ステータスチェックにする。
+3. **`deploy.yml`**: main マージで `render.py` → OIDC ログイン（`azure/login@v2`）→ `deploy.py`。
+   `environment: production` の承認ゲートを付ける。
+4. GitHub Secrets には `.env` の秘匿値一式に加え、OIDC 用の `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` を登録する。
+
+```mermaid
+flowchart TD
+    A[ローカル編集] --> B[git commit]
+    B -->|pre-commit| C[汎用化 + Secrets 同期 + 漏洩検査]
+    C --> D[PR]
+    D --> E[sanitization-review]
+    E -->|Pass| F[main マージ]
+    F --> G[deploy.yml: 承認後 create_version]
+    G --> H[常に最新を使用 → Teams / M365 Copilot へ自動配信]
+```
+
+### Step 10: 検証する
+
+```powershell
+python scripts/review_sanitization.py       # Pass であること
+python scripts/create_blueprint.py --list   # ブループリントの存在確認
+git status --short                          # .env / agent.yaml / *.zip が未追跡であること
+```
+
+[検証チェックリスト](#検証チェックリスト) を上から確認する。
+
+## 検証チェックリスト
+
+- [ ] `.env` / `agents/**/agent.yaml` / `teams/*.zip` / `a365.generated.config.json` が追跡されていない
+- [ ] `agent.template.yaml` / `*.template.json` に実 GUID・ARM パス・接続文字列が無い（`${VAR}` 化済み）
+- [ ] `.env.example` にすべての変数がプレースホルダー付きで定義されている
+- [ ] `AGENT_NAME` / `BLUEPRINT_ID` 等の公開識別子が `NON_SECRET_VARS` に入っている
+- [ ] Foundry ブループリントと Agent 365 ブループリントを取り違えていない
+- [ ] インスタンス化する場合、manifest に `agenticUserTemplates` と `functionsAs: agenticUserOnly` がある
+- [ ] Teams 再アップロード前に `TEAMS_APP_VERSION` を上げた
+- [ ] アイコン元画像がアルファチャンネル付きの正方形 PNG
+- [ ] `review_sanitization.py` が Pass、`deploy.yml` に承認ゲートがある
+- [ ] Teams / M365 Copilot での動作確認が済んでいる
+
+## 参考リンク
+
+- [アーキテクチャ（2 種類のブループリント・スキーマ選択）](references/architecture.md)
+- [Agent 365 CLI 運用（Windows / WAM / 権限）](references/a365-cli.md)
+- [リポジトリ scaffold（.gitignore / hook / workflows）](references/repo-scaffold.md)
+- [異常系・トラブルシュート](references/troubleshooting.md)
+- [環境変数サンプル](references/.env.example)

--- a/.github/skills/agent365/references/.env.example
+++ b/.github/skills/agent365/references/.env.example
@@ -1,0 +1,75 @@
+# agent365 — 環境変数サンプル
+
+このファイルはプレースホルダーのみ。実値はテーマリポジトリのルートの `.env` に置く（`.gitignore` 済み）。
+値は `scripts/*.py` が引数未指定時のデフォルトとして参照する。
+
+```dotenv
+# === Azure / Foundry プロジェクト（秘匿）===
+# 取得元: az account show --query id / Foundry プロジェクトの概要ページ
+AZURE_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000
+AZURE_RESOURCE_GROUP=rg-your-group
+AZURE_AI_ACCOUNT=your-foundry-account
+AZURE_AI_PROJECT=your-project
+AZURE_TENANT_ID=00000000-0000-0000-0000-000000000000
+
+# 取得元: Foundry プロジェクト概要ページの "Project endpoint"
+FOUNDRY_PROJECT_ENDPOINT=https://your-account.services.ai.azure.com/api/projects/your-project
+
+# === エージェント識別子（公開識別子・秘匿対象外）===
+# kebab-case。フォルダ名 agents/<AGENT_NAME>/ と一致させる
+AGENT_NAME=your-agent
+# 取得元: scripts/create_blueprint.py --name <name> の blueprintName
+BLUEPRINT_ID=your-agent
+
+# === Foundry のマネージド ID（秘匿）===
+# 取得元: scripts/create_blueprint.py --name <name> --show
+BLUEPRINT_PRINCIPAL_ID=00000000-0000-0000-0000-000000000000
+BLUEPRINT_CLIENT_ID=00000000-0000-0000-0000-000000000000
+# 取得元: エージェント作成後の agents.get / Foundry ポータルのエージェント詳細
+INSTANCE_IDENTITY_PRINCIPAL_ID=00000000-0000-0000-0000-000000000000
+INSTANCE_IDENTITY_CLIENT_ID=00000000-0000-0000-0000-000000000000
+AGENT_GUID=00000000-0000-0000-0000-000000000000
+
+# === Agent 365（秘匿）===
+# 取得元: a365 setup blueprint -n <name> --no-endpoint → a365.generated.config.json の agentBlueprintId
+# 未設定の場合 build_teams_package.py は共有エージェント用パッケージにダウングレードする
+A365_AGENT_BLUEPRINT_ID=00000000-0000-0000-0000-000000000000
+
+# === Azure Bot Service（秘匿）===
+# 取得元: az bot create で作成した Bot リソース名
+AZURE_BOT_NAME=your-agent-bot
+
+# === Teams アプリ manifest（公開メタデータ・秘匿対象外）===
+# 再アップロードのたびに必ず上げる（同一バージョンは拒否される）
+TEAMS_APP_VERSION=1.0.0
+# 30 文字以内 / 100 文字以内
+AGENT_DISPLAY_NAME=Your Agent
+AGENT_FULL_NAME=Your Agent - team assistant
+# 80 文字以内 / 4000 文字以内
+AGENT_DESCRIPTION_SHORT=Short description shown in the Teams app catalog.
+AGENT_DESCRIPTION_FULL=Full description of what this agent does for the user.
+DEVELOPER_NAME=Your Organization
+DEVELOPER_WEBSITE_URL=https://www.example.com
+DEVELOPER_PRIVACY_URL=https://www.example.com/privacy
+DEVELOPER_TERMS_URL=https://www.example.com/terms
+# webApplicationInfo.resource。所有ドメインの api:// URI
+TEAMS_APP_RESOURCE_URI=api://www.example.com
+
+# === 任意 ===
+# create_instance.py の manifest モードで使うテンプレート ID
+# AGENT_TEMPLATE_ID=your-agent-template-id
+
+# === CI の Azure OIDC ログイン（GitHub Secrets 専用 / .env では未使用）===
+# フェデレーション資格情報を設定したアプリ登録
+# AZURE_CLIENT_ID=00000000-0000-0000-0000-000000000000
+```
+
+## 秘匿区分
+
+| 区分 | 変数 | 扱い |
+|---|---|---|
+| 秘匿 | `AZURE_*` / `FOUNDRY_PROJECT_ENDPOINT` / `*_PRINCIPAL_ID` / `*_CLIENT_ID` / `AGENT_GUID` / `A365_AGENT_BLUEPRINT_ID` / `AZURE_BOT_NAME` | `.env` と GitHub Secrets のみ。テンプレートでは `${VAR}` |
+| 非秘匿 | `AGENT_NAME` / `BLUEPRINT_ID` / `TEAMS_APP_VERSION` / `AGENT_DISPLAY_NAME` / `AGENT_FULL_NAME` / `AGENT_DESCRIPTION_*` / `DEVELOPER_*` / `TEAMS_APP_RESOURCE_URI` | `scripts/sanitize.py` と `check_secrets.py` の `NON_SECRET_VARS` に登録し、置換対象から除外する |
+
+非秘匿値を置換対象に含めると、`AGENT_NAME` のような短い文字列が
+manifest の散文中で誤って `${AGENT_NAME}` に置き換わり、テンプレートが壊れる。

--- a/.github/skills/agent365/references/a365-cli.md
+++ b/.github/skills/agent365/references/a365-cli.md
@@ -1,0 +1,88 @@
+# Agent 365 CLI（`a365`）運用ガイド
+
+`a365` は Agent 365 のエージェント ID ブループリントを作成・構成するための CLI。
+Windows での実行にクセがあるため、以下を守る。
+
+## 1. クライアントアプリ登録が先に要る
+
+**「Agent 365 CLI」は Microsoft のファーストパーティ アプリではない。**
+公開の固定 appId は存在せず、**テナントごとにその表示名でアプリ登録を自前で作る**必要がある
+（CLI は表示名でアプリを解決する）。
+
+作成するアプリ登録の要件:
+
+- シングルテナント / パブリック クライアント フォールバックを有効
+- リダイレクト URI: `http://localhost:8400/`、`http://localhost`、
+  `ms-appx-web://Microsoft.AAD.BrokerPlugin/<appId>`
+- オプションの要求に `wids` を追加
+
+> **注意**: 作成後に Entra ポータルで「管理者の同意を与える」を押すと、
+> CLI が必要とする beta 権限が消えることがある。CLI 側の同意フローに任せる。
+
+参考: Microsoft Learn「custom client app registration」（Agent 365 開発者向けドキュメント）
+
+## 2. ライセンス
+
+Agent 365 のライセンス SKU が割り当てられている必要がある。
+CLI にハードコードされた SKU ID が実際に割り当て可能な SKU と異なることがあるため、
+`Get-MgSubscribedSku` 等で自テナントの `skuId` を確認して割り当てる。
+割り当て時は `usageLocation` が必須。
+
+## 3. 出力をパイプしない
+
+認証は WAM（ネイティブ ダイアログ）を使う。
+
+- **`| Out-String` や `| Tee-Object` でパイプすると対話プロンプトが飲み込まれ、固まったように見える。**
+- ログが必要なときだけパイプし、プロンプト待ちが疑われたらパイプ無しで再実行する。
+- CLI に `--device-code` オプションは無い。デバイスコードは WAM / ブラウザ失敗時の自動フォールバックのみ。
+
+## 4. 埋め込みターミナルでは WAM ダイアログが出せない
+
+VS Code の統合ターミナルからは WAM のダイアログを表示できない。可視ウィンドウで起動する。
+
+```powershell
+$b64 = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes('a365 setup blueprint -n <name> --no-endpoint'))
+Start-Process powershell -ArgumentList '-NoExit','-EncodedCommand',$b64
+```
+
+`-Command` を `-ArgumentList` で渡すと引用符が壊れるため、**必ず `-EncodedCommand`** を使う。
+
+## 5. ブラウザのプロファイル問題
+
+CLI はブラウザを `ProcessStartInfo` + `UseShellExecute=true`（= OS 既定ハンドラー）で開く。
+**プロファイルを指定するオプションも環境変数も無い。**
+Edge は外部リンクを「最後にアクティブだったプロファイルのウィンドウ」に流すため、
+`a365` 実行の**直前に**対象アカウントのプロファイルでウィンドウを開いておく。
+
+```powershell
+Start-Process msedge.exe -ArgumentList '--profile-directory="Profile N"','https://portal.azure.com'
+```
+
+恒久策は `edge://settings/profiles/multiProfileSettings` の「自動プロファイル切り替え」。
+
+## 6. 冪等性と再実行
+
+- 初回の `a365 setup blueprint` はディレクトリ伝播の遅延で
+  inheritable permissions が 404 になり失敗しがち。
+  **同じコマンドをもう一度流せば冪等に修復される**（追加スコープの付与も同様）。
+- `a365 setup permissions mcp|bot` は **`--agent-name <name>` が必須**（無いと即エラー終了）。
+
+## 7. シークレットの取り扱い
+
+- 実行のたびに**新しいクライアント シークレットが平文でコンソール出力される**。
+- ログファイルに残すと平文で残るため、実行後に削除する。
+  `.gitignore` に `a365-*.log` と `a365.generated.config.json` を必ず入れる。
+
+## 8. 生成される設定ファイル
+
+`a365.generated.config.json` の主なキー（値は環境固有 = 秘匿）:
+
+| キー | 内容 |
+|---|---|
+| `agentBlueprintId` | `.env` の `A365_AGENT_BLUEPRINT_ID` に設定する GUID |
+| `agentBlueprintServicePrincipalObjectId` | ブループリントのサービス プリンシパル |
+| `agentBlueprintClientSecretProtected` | シークレット保護状態 |
+| `resourceConsents[]` | 付与済み API 同意（`resourceName` / `scopes` / `consentGranted` 等） |
+| `completed` / `lastUpdated` / `cliVersion` | セットアップ状態 |
+
+このファイルは**コミットしない**。必要な値は `.env` 経由で参照する。

--- a/.github/skills/agent365/references/architecture.md
+++ b/.github/skills/agent365/references/architecture.md
@@ -1,0 +1,90 @@
+# アーキテクチャ — 2 種類のブループリントと公開経路
+
+## 1. 「ブループリント」は 2 種類ある（最頻出の混同）
+
+| | Foundry マネージド ID ブループリント | Agent 365 エージェント ID ブループリント |
+|---|---|---|
+| 何の設計図か | エージェントが Azure リソースへアクセスするための**マネージド ID** | インストールごとに払い出す**Entra Agent ID** |
+| 識別子 | 名前（例: `your-agent`）。`.env` の `BLUEPRINT_ID` | GUID。`.env` の `A365_AGENT_BLUEPRINT_ID` |
+| 作成方法 | `python scripts/create_blueprint.py --name <name>` | `a365 setup blueprint -n <name> --no-endpoint` |
+| API | Foundry データプレーン REST `/managedAgentIdentityBlueprints`（`api-version=v1`） | Agent 365 CLI（Entra + Agent 365 サービス） |
+| 参照先 | `agent.yaml` の `blueprint_reference` | `teams/agenticUser.template.json` の `agentIdentityBlueprintId` |
+| 共有可否 | `lifecycle=Manual` なら複数エージェントで共有可。`Auto` は所有エージェント専用 | インストール単位でインスタンスを払い出す |
+
+**両者は無関係**。Foundry 側のブループリントを作っても Agent 365 のインスタンス化は起きないし、
+その逆も成立しない。名前が似ているだけなので、変数名でも常に区別する。
+
+## 2. インスタンスが作られない典型原因
+
+`copilotAgents.customEngineAgents[]` の `functionsAs` の既定値は `agentOnly`
+（= 通常のエージェントとしてインストールされるだけ = 全員が同じ 1 体を共有）。
+インストールごとに専用の Entra Agent ID を持たせるには、manifest に次の 2 つが**両方**必要。
+
+```jsonc
+"copilotAgents": {
+  "customEngineAgents": [
+    {
+      "id": "${INSTANCE_IDENTITY_CLIENT_ID}",
+      "type": "bot",
+      "functionsAs": "agenticUserOnly",          // ← devPreview のみ
+      "agenticUserTemplateId": "${AGENT_NAME}-agentic-user"
+    }
+  ]
+},
+"agenticUserTemplates": [                         // ← GA 1.25+ / devPreview
+  { "id": "${AGENT_NAME}-agentic-user", "file": "agenticUser.json" }
+]
+```
+
+## 3. manifest スキーマの選び方
+
+| 目的 | `manifestVersion` | `$schema` | 備考 |
+|---|---|---|---|
+| インスタンス化エージェント | `devPreview` | `.../teams/vDevPreview/MicrosoftTeams.schema.json` | `functionsAs` / `agenticUserTemplateId` は **devPreview にしか無い**（GA 1.25〜1.29 には存在しない） |
+| 共有エージェント | `1.22` | `.../teams/v1.22/MicrosoftTeams.schema.json` | `agenticUserTemplates` と agentic-user 系プロパティを削除する |
+
+`scripts/build_teams_package.py` は `A365_AGENT_BLUEPRINT_ID` の有無でこの 2 つを自動で切り替える。
+
+### agenticUser.json のスキーマ（検証済み）
+
+`https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.AgenticUser.schema.json`
+
+- 必須: `id` / `schemaVersion`（`"0.1.0-preview"`）/ `agentIdentityBlueprintId`（GUID）
+- 任意: `communicationProtocol`（`"activityProtocol"`）
+- `additionalProperties: false`（余計なキーを足すと検証エラー）
+
+## 4. 公開経路の全体像
+
+```mermaid
+flowchart LR
+    A["Foundry ブループリント<br/>lifecycle=Manual"] --> B["Foundry エージェント<br/>create_version"]
+    B --> C["Azure Bot Service<br/>msaAppId = instance identity client id"]
+    C --> D["MSTeams チャネル"]
+    D --> E["Teams アプリ manifest<br/>botId = msaAppId"]
+    F["Agent 365 ブループリント<br/>agentBlueprintId"] --> G["agenticUser.json"]
+    G --> E
+    E --> H["管理センターへアップロード"]
+    H --> I["Teams / M365 Copilot"]
+```
+
+Bot のエンドポイントは Foundry のエージェント エンドポイント。
+
+```
+{FOUNDRY_PROJECT_ENDPOINT}/agents/{AGENT_NAME}/endpoint/protocols/activityprotocol?api-version=2025-11-15-preview
+```
+
+## 5. バージョニングと配信
+
+- `deploy.py`（= `agents.create_version`）で作った新バージョンは、
+  エージェント エンドポイントの既定「**常に最新を使用**」により Teams / M365 Copilot へ自動配信される。
+  ポータルでの有効化操作は不要。
+- 一方 **Teams アプリ manifest の内容（名前・説明・アイコン・スコープ）を変えた場合は
+  ZIP を再アップロードする必要がある**。この際 `version` を必ず上げる。
+- 挙動・プロンプトだけの変更なら Foundry へのデプロイのみでよく、再アップロードは不要。
+
+## 6. なぜポータル自動操作をしないか
+
+- Foundry のエージェント操作は `azure-ai-projects` SDK で完結する。
+- SDK の操作グループに無い API（ブループリント）も、認証済みクライアントの
+  `AIProjectClient.send_request(HttpRequest(...))` で REST を直接叩ける。
+- ブラウザ自動化は壊れやすく CI で再現できないため、最終手段としても採用しない。

--- a/.github/skills/agent365/references/repo-scaffold.md
+++ b/.github/skills/agent365/references/repo-scaffold.md
@@ -1,0 +1,167 @@
+# リポジトリ scaffold
+
+Step 1 で配置するファイル一式。テーマ固有の値はすべて `.env` から解決する。
+
+## requirements.txt
+
+```
+azure-ai-projects>=2.2.0
+azure-identity>=1.19.0
+PyYAML>=6.0
+Pillow>=10.0
+```
+
+## .gitignore
+
+```gitignore
+# Environment / secrets
+.env
+*.env
+!.env.example
+
+# Rendered manifests (contain resolved secrets — never commit)
+agents/**/agent.yaml
+
+# Built Teams app packages (contain resolved identifiers — never commit)
+teams/*.zip
+
+# Agent 365 CLI (a365) — token caches, credentials and generated config
+.a365/
+a365.config.json
+a365.generated.config.json
+auth-token.json
+*token-cache*
+*.token.json
+a365*.log
+
+# Python
+.venv/
+__pycache__/
+*.pyc
+
+# OS
+.DS_Store
+Thumbs.db
+```
+
+## .githooks/pre-commit
+
+`git config core.hooksPath .githooks` で有効化する。
+
+```sh
+#!/bin/sh
+set -e
+
+# 1. 実値入り manifest を汎用化し、GitHub Secrets へ同期してテンプレートをステージ
+python scripts/sanitize.py --env .env --set-secrets --stage
+
+# 2. ステージ済み差分に実値が残っていないか検査（残っていればコミット中止）
+python scripts/check_secrets.py --env .env
+```
+
+## .github/workflows/review.yml
+
+```yaml
+name: review
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  sanitization-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Sanitization / generalization gate
+        run: python scripts/review_sanitization.py
+```
+
+このジョブを**必須ステータスチェック**に設定して merge をブロックする。
+
+## .github/workflows/deploy.yml
+
+```yaml
+name: deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'agents/**'
+      - 'scripts/render.py'
+      - 'scripts/deploy.py'
+      - 'requirements.txt'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-agent
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production   # 承認ゲート
+    env:
+      AGENT_NAME: ${{ secrets.AGENT_NAME }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+      AZURE_AI_ACCOUNT: ${{ secrets.AZURE_AI_ACCOUNT }}
+      AZURE_AI_PROJECT: ${{ secrets.AZURE_AI_PROJECT }}
+      INSTANCE_IDENTITY_PRINCIPAL_ID: ${{ secrets.INSTANCE_IDENTITY_PRINCIPAL_ID }}
+      INSTANCE_IDENTITY_CLIENT_ID: ${{ secrets.INSTANCE_IDENTITY_CLIENT_ID }}
+      BLUEPRINT_PRINCIPAL_ID: ${{ secrets.BLUEPRINT_PRINCIPAL_ID }}
+      BLUEPRINT_CLIENT_ID: ${{ secrets.BLUEPRINT_CLIENT_ID }}
+      AGENT_GUID: ${{ secrets.AGENT_GUID }}
+      FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt
+      - name: Render agent manifest
+        run: python scripts/render.py --agent "$AGENT_NAME"
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Create new agent version
+        run: python scripts/deploy.py --agent "$AGENT_NAME"
+```
+
+`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` は OIDC 用アプリ登録（フェデレーション資格情報）。
+そのアプリ登録に Foundry プロジェクトへのロール（Azure AI Developer / Cognitive Services User 等）を付与する。
+
+## .github/copilot-instructions.md（レビュー観点）
+
+PR で Copilot コードレビューに秘匿化・汎用化を確認させる。決定論チェック
+`sanitization-review` の Pass を承認の前提にする。
+
+```markdown
+プルリクエストでは **秘匿化** と **汎用化** を最優先でレビューする。
+
+1. 実値の非混入: 追跡ファイルにサブスクリプション ID / テナント ID / principal_id /
+   client_id などの実 GUID、`/subscriptions/<guid>/...` の ARM パス、接続文字列、
+   API キー、シークレットが含まれないこと。
+2. 汎用化: `agents/**/agent.template.yaml` と `teams/*.template.json` は
+   環境依存値をすべて `${VAR}` プレースホルダー化していること。
+3. 未コミット確認: `.env`、`agents/**/agent.yaml`、`teams/*.zip`、
+   `a365.generated.config.json` がコミットされていないこと。
+4. Secrets 整合: 新しい秘匿値には `.env.example` のプレースホルダーと
+   GitHub Secrets 名が対応していること。
+5. 公開メタデータ: Teams / M365 に公開される名前・説明・URL に秘密情報が無いこと。
+```

--- a/.github/skills/agent365/references/templates/agent.template.yaml
+++ b/.github/skills/agent365/references/templates/agent.template.yaml
@@ -1,0 +1,37 @@
+metadata: {}
+object: agent.version
+name: ${AGENT_NAME}
+description: Agent published to Teams / Microsoft 365 Copilot
+definition:
+  kind: prompt
+  model: model-router
+  instructions: |-
+    # <Agent role> システムプロンプト
+
+    あなたは <役割> です。利用者の指示に基づき、<扱う業務> を支援します。
+
+    ## 原則
+    - 事実に基づいて回答し、推測が含まれる場合は明示する。
+    - 破壊的な操作（送信・削除・予定確定など）は必ず利用者の承認を得てから実行する。
+    - 参照した情報源を提示する。
+
+    ## 利用できる情報源
+    - 組織のメール・予定表・ファイル・チャット（WorkIQ ツール経由）
+    - Web 検索
+  tools:
+    # 組織データ（Microsoft 365）への接続。接続名はプロジェクトの接続に合わせる
+    - type: work_iq_preview
+      project_connection_id: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.CognitiveServices/accounts/${AZURE_AI_ACCOUNT}/projects/${AZURE_AI_PROJECT}/connections/WorkIQ
+    - type: web_search
+  draft: false
+  status: active
+instance_identity:
+  principal_id: ${INSTANCE_IDENTITY_PRINCIPAL_ID}
+  client_id: ${INSTANCE_IDENTITY_CLIENT_ID}
+blueprint:
+  principal_id: ${BLUEPRINT_PRINCIPAL_ID}
+  client_id: ${BLUEPRINT_CLIENT_ID}
+blueprint_reference:
+  type: ManagedAgentIdentityBlueprint
+  blueprint_id: ${BLUEPRINT_ID}
+agent_guid: ${AGENT_GUID}

--- a/.github/skills/agent365/references/templates/agenticUser.template.json
+++ b/.github/skills/agent365/references/templates/agenticUser.template.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.AgenticUser.schema.json",
+  "id": "${AGENT_NAME}-agentic-user",
+  "schemaVersion": "0.1.0-preview",
+  "agentIdentityBlueprintId": "${A365_AGENT_BLUEPRINT_ID}",
+  "communicationProtocol": "activityProtocol"
+}

--- a/.github/skills/agent365/references/templates/manifest.template.json
+++ b/.github/skills/agent365/references/templates/manifest.template.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
+  "manifestVersion": "devPreview",
+  "version": "${TEAMS_APP_VERSION}",
+  "id": "${INSTANCE_IDENTITY_CLIENT_ID}",
+  "developer": {
+    "name": "${DEVELOPER_NAME}",
+    "websiteUrl": "${DEVELOPER_WEBSITE_URL}",
+    "privacyUrl": "${DEVELOPER_PRIVACY_URL}",
+    "termsOfUseUrl": "${DEVELOPER_TERMS_URL}"
+  },
+  "name": {
+    "short": "${AGENT_DISPLAY_NAME}",
+    "full": "${AGENT_FULL_NAME}"
+  },
+  "description": {
+    "short": "${AGENT_DESCRIPTION_SHORT}",
+    "full": "${AGENT_DESCRIPTION_FULL}"
+  },
+  "icons": {
+    "color": "color.png",
+    "outline": "outline.png"
+  },
+  "accentColor": "#2F6FEB",
+  "validDomains": [],
+  "webApplicationInfo": {
+    "id": "${INSTANCE_IDENTITY_CLIENT_ID}",
+    "resource": "${TEAMS_APP_RESOURCE_URI}"
+  },
+  "bots": [
+    {
+      "botId": "${INSTANCE_IDENTITY_CLIENT_ID}",
+      "scopes": [
+        "personal",
+        "team",
+        "groupChat",
+        "copilot"
+      ],
+      "supportsFiles": true,
+      "isNotificationOnly": false,
+      "commandLists": [
+        {
+          "scopes": [
+            "personal"
+          ],
+          "commands": [
+            {
+              "title": "はじめる",
+              "description": "自分専用のエージェントセッションを開始する"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "copilotAgents": {
+    "customEngineAgents": [
+      {
+        "id": "${INSTANCE_IDENTITY_CLIENT_ID}",
+        "type": "bot",
+        "functionsAs": "agenticUserOnly",
+        "agenticUserTemplateId": "${AGENT_NAME}-agentic-user",
+        "disclaimer": {
+          "text": "This agent uses AI. Please verify important information."
+        }
+      }
+    ]
+  },
+  "agenticUserTemplates": [
+    {
+      "id": "${AGENT_NAME}-agentic-user",
+      "file": "agenticUser.json"
+    }
+  ]
+}

--- a/.github/skills/agent365/references/troubleshooting.md
+++ b/.github/skills/agent365/references/troubleshooting.md
@@ -1,0 +1,84 @@
+# agent365 — 異常系・トラブルシュート
+
+## 1. Teams アップロードで「Must upload a newer version of the title than what is already present.」
+
+- 原因: manifest の `version` が既にアップロード済みのバージョンと同じ。
+- 対処: `.env` の `TEAMS_APP_VERSION` を上げて `python scripts/build_teams_package.py` を再実行する。
+  同じアプリ ID を更新するときは**毎回**上げる必要がある。
+
+## 2. インストールしてもエージェント インスタンスが作られない（全員が同じ 1 体を共有してしまう）
+
+- 原因: `functionsAs` 未指定（既定 `agentOnly`）、または `agenticUserTemplates` ノードが無い。
+- 対処: manifest に `functionsAs: agenticUserOnly` + `agenticUserTemplateId` + `agenticUserTemplates` を入れる。
+  これらは **`manifestVersion: devPreview` でのみ有効**（GA 1.25〜1.29 には `functionsAs` が無い）。
+- `A365_AGENT_BLUEPRINT_ID` が未設定だと `build_teams_package.py` が
+  共有エージェント用（GA 1.22）へ自動ダウングレードし、警告を出す。警告を見落とさない。
+
+## 3. `build_teams_package.py` が `Missing environment variables: ...` で失敗する
+
+- 原因: `.env` に manifest の `${VAR}` に対応する値が無い、または空。
+- 対処: `references/.env.example` と突き合わせて不足分を追加する。
+  空文字も「未設定」として扱われる。
+
+## 4. outline アイコンが真っ白な四角になる
+
+- 原因: 元画像にアルファチャンネルが無い（背景が不透明）。outline は元画像のアルファから生成される。
+- 対処: 背景を透過させた正方形 PNG を用意する。円形イラストなら円マスクでアルファを作る。
+
+```python
+from PIL import Image, ImageDraw
+src = Image.open("source.png").convert("RGBA")
+w, h = src.size
+mask = Image.new("L", (w * 4, h * 4), 0)
+ImageDraw.Draw(mask).ellipse((0, 0, w * 4 - 1, h * 4 - 1), fill=255)
+src.putalpha(mask.resize((w, h), Image.LANCZOS))
+src.save("assets/agent-icon.png")
+```
+
+## 5. `create_instance.py --mode blueprint` が「blueprint cannot be shared」で失敗する
+
+- 原因: 参照したブループリントが `lifecycle=Auto`（エージェントが暗黙に作った所有者専用のもの）。
+- 対処: `python scripts/create_blueprint.py --name <name>` で `lifecycle=Manual` のブループリントを
+  作り直し、そちらを参照する。既存の `Auto` は共有できないので `--mode definition` で複製する。
+
+## 6. `FOUNDRY_PROJECT_ENDPOINT is not set` / 認証エラー
+
+- 原因: `.env` が読み込まれていない、または `DefaultAzureCredential` が資格情報を解決できない。
+- 対処: ローカルは `az login` + `az account set --subscription <id>`。
+  CI は `azure/login@v2` の OIDC（`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID`）。
+  対象アプリ登録に Foundry プロジェクトへのロール（Azure AI Developer 等）が必要。
+
+## 7. `sanitize.py` がテンプレートを壊す（散文中の語まで `${VAR}` になる）
+
+- 原因: `AGENT_NAME` のような短い公開識別子が置換対象に入っている。
+- 対処: `NON_SECRET_VARS` に追加する（または `--non-secret <NAME>` を渡す）。
+  置換は**長い値から順に**実行される（部分文字列による取り違え防止）。
+
+## 8. `review_sanitization.py` が Fail する
+
+| メッセージ | 対処 |
+|---|---|
+| `.env is tracked` | `git rm --cached .env` し `.gitignore` に追加 |
+| `Rendered manifest is tracked` | `git rm --cached agents/**/agent.yaml` |
+| `Built Teams package is tracked` | `git rm --cached teams/*.zip` |
+| `contains a real GUID` | 該当箇所を `${VAR}` へ置換し `.env.example` にプレースホルダーを追加 |
+| `no ${VAR} placeholders found` | テンプレートが汎用化されていない。`sanitize.py` を実行する |
+
+すべてゼロ GUID（`00000000-...`）はプレースホルダーとして許可される。
+
+## 9. `a365` コマンドが固まる / ダイアログが出ない
+
+→ [a365-cli.md](a365-cli.md) の 3〜5 節（パイプ禁止・`-EncodedCommand` での可視ウィンドウ起動・
+Edge プロファイル）を参照。初回失敗時は同じコマンドを再実行すると冪等に修復されることが多い。
+
+## 10. Windows PowerShell 5.1 で `&&` が使えない
+
+- 対処: `;` で区切るか `; if ($?) { ... }` を使う。PowerShell 7（`pwsh`）なら `&&` が使える。
+
+## 11. エージェント名を後から変えたくなった
+
+識別子が広範囲に波及する（`.env` の変数名・フォルダ名 `agents/<name>/`・
+`agenticUserTemplates[].id`・ZIP 名・Bot リソース名・Foundry のエージェント名）。
+**Step 0 の時点で商標・著作権に配慮した名前を確定させる**。
+既存の Foundry エージェントは削除せず残しても害はないが、Teams 側は同じアプリ ID の
+バージョン更新として扱うため `TEAMS_APP_VERSION` の引き上げを忘れない。

--- a/.github/skills/agent365/scripts/build_teams_package.py
+++ b/.github/skills/agent365/scripts/build_teams_package.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Build the Teams app package for a Foundry agent.
+
+Renders ``teams/manifest.template.json`` and ``teams/agenticUser.template.json``
+(``${VAR}`` placeholders resolved from environment variables / ``.env``) and
+generates the Teams icons from a square source image:
+
+  - color icon:   192x192 PNG (full color)
+  - outline icon: 32x32 PNG, white silhouette on transparency (Teams spec)
+
+The resulting ZIP is uploaded once in the Microsoft 365 / Teams admin center so
+an instance of the agent can be created for the org. The package contains real
+identifiers, so it must stay git-ignored.
+
+The manifest ``version`` comes from ``TEAMS_APP_VERSION`` and MUST be increased
+for every re-upload; the admin center rejects an already present version.
+
+Usage:
+    python scripts/build_teams_package.py
+    python scripts/build_teams_package.py --output teams/my-agent-teams-app.zip
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+from PIL import Image
+
+COLOR_SIZE = 192
+OUTLINE_SIZE = 32
+PLACEHOLDER = re.compile(r"\$\{([A-Z0-9_]+)\}")
+
+# Per-install agent instances (each with their own Entra Agent ID) require an
+# Agent 365 blueprint. Without it the package can only be published as a single
+# shared agent, which needs the GA schema because the agentic-user properties
+# exist in devPreview only.
+A365_BLUEPRINT_VAR = "A365_AGENT_BLUEPRINT_ID"
+SHARED_MANIFEST_VERSION = "1.22"
+SHARED_MANIFEST_SCHEMA = (
+    "https://developer.microsoft.com/json-schemas/teams/v1.22/MicrosoftTeams.schema.json"
+)
+
+
+def load_env(path: Path) -> None:
+    """Load KEY=VALUE pairs from a .env file without overriding real env vars."""
+    if not path.is_file():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+def render(template: str) -> str:
+    missing: list[str] = []
+
+    def substitute(match: re.Match[str]) -> str:
+        name = match.group(1)
+        value = os.environ.get(name)
+        if not value:
+            missing.append(name)
+            return match.group(0)
+        return value
+
+    result = PLACEHOLDER.sub(substitute, template)
+    if missing:
+        raise SystemExit("Missing environment variables: " + ", ".join(sorted(set(missing))))
+    return result
+
+
+def make_color_icon(icon_path: Path, size: int = COLOR_SIZE) -> bytes:
+    img = Image.open(icon_path).convert("RGBA").resize((size, size), Image.LANCZOS)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def make_outline_icon(icon_path: Path, size: int = OUTLINE_SIZE) -> bytes:
+    """White silhouette on a transparent background, as Teams requires."""
+    img = Image.open(icon_path).convert("RGBA").resize((size, size), Image.LANCZOS)
+    white = Image.new("RGBA", (size, size), (255, 255, 255, 255))
+    white.putalpha(img.getchannel("A"))
+    buf = io.BytesIO()
+    white.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def downgrade_to_shared_agent(manifest: dict) -> None:
+    """Strip the Agent 365 instantiation nodes so the app installs as one shared agent."""
+    manifest["$schema"] = SHARED_MANIFEST_SCHEMA
+    manifest["manifestVersion"] = SHARED_MANIFEST_VERSION
+    manifest.pop("agenticUserTemplates", None)
+    for agent in manifest.get("copilotAgents", {}).get("customEngineAgents", []):
+        agent.pop("functionsAs", None)
+        agent.pop("agenticUserTemplateId", None)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--template", default="teams/manifest.template.json")
+    parser.add_argument("--agentic-user-template", default="teams/agenticUser.template.json")
+    parser.add_argument("--icon", default="assets/agent-icon.png")
+    parser.add_argument("--output", help="Output ZIP (default: teams/<agent>-teams-app.zip).")
+    parser.add_argument("--env", default=".env")
+    args = parser.parse_args()
+
+    load_env(Path(args.env))
+
+    template_path = Path(args.template)
+    icon = Path(args.icon)
+    agent = os.environ.get("AGENT_NAME", "agent")
+    output = Path(args.output or f"teams/{agent}-teams-app.zip")
+
+    if not template_path.is_file():
+        raise SystemExit(f"Manifest template not found: {template_path}")
+    if not icon.is_file():
+        raise SystemExit(f"Icon not found: {icon}")
+
+    manifest_text = render(template_path.read_text(encoding="utf-8"))
+    manifest = json.loads(manifest_text)
+
+    color_name = manifest["icons"]["color"]
+    outline_name = manifest["icons"]["outline"]
+
+    # Agent 365 provisions a per-install agent instance (its own Entra Agent ID)
+    # only when the package carries the agentic user template referenced here.
+    extra_files: dict[str, bytes] = {}
+    if not os.environ.get(A365_BLUEPRINT_VAR):
+        print(
+            f"WARNING: {A365_BLUEPRINT_VAR} is not set - building a SHARED agent "
+            "package. Installing it does not create a per-install agent instance.\n"
+            "         Run 'a365 setup blueprint' to obtain the Agent 365 blueprint "
+            f"GUID, then set {A365_BLUEPRINT_VAR}.",
+            file=sys.stderr,
+        )
+        downgrade_to_shared_agent(manifest)
+        manifest_text = json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
+
+    for ref in manifest.get("agenticUserTemplates", []):
+        agentic_path = Path(args.agentic_user_template)
+        if not agentic_path.is_file():
+            raise SystemExit(f"Agentic user template not found: {agentic_path}")
+        agentic_text = render(agentic_path.read_text(encoding="utf-8"))
+        agentic = json.loads(agentic_text)
+        if agentic["id"] != ref["id"]:
+            raise SystemExit(
+                f"agenticUserTemplates id '{ref['id']}' does not match "
+                f"{agentic_path} id '{agentic['id']}'."
+            )
+        extra_files[ref["file"]] = agentic_text.encode("utf-8")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("manifest.json", manifest_text)
+        zf.writestr(color_name, make_color_icon(icon))
+        zf.writestr(outline_name, make_outline_icon(icon))
+        for name, data in extra_files.items():
+            zf.writestr(name, data)
+
+    print(f"Built Teams package: {output}")
+    print(f"  app name     : {manifest['name']['short']} (v{manifest['version']})")
+    print(f"  manifest ver : {manifest['manifestVersion']}")
+    print(f"  color  icon  : {color_name} ({COLOR_SIZE}x{COLOR_SIZE}) from {icon}")
+    print(f"  outline icon : {outline_name} ({OUTLINE_SIZE}x{OUTLINE_SIZE}) from {icon}")
+    for name in extra_files:
+        print(f"  agentic user : {name}")
+    print("  mode         : " + ("per-install agent instance" if extra_files else "shared agent"))
+    print("Bump TEAMS_APP_VERSION in .env before every re-upload.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills/agent365/scripts/check_secrets.py
+++ b/.github/skills/agent365/scripts/check_secrets.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Fail if any secret value from .env appears in staged (to-be-committed) content.
+
+Runs as part of the pre-commit hook after ``sanitize.py``, as a safety net so
+that real secret values can never be committed even if generalization was
+skipped.
+
+Usage:
+    python scripts/check_secrets.py --env .env
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+# Public identifiers and human-readable metadata that legitimately appear in
+# tracked files. Keep in sync with sanitize.py.
+NON_SECRET_VARS = {
+    "AGENT_NAME",
+    "BLUEPRINT_ID",
+    "TEAMS_APP_VERSION",
+    "AGENT_DISPLAY_NAME",
+    "AGENT_FULL_NAME",
+    "AGENT_DESCRIPTION_SHORT",
+    "AGENT_DESCRIPTION_FULL",
+    "DEVELOPER_NAME",
+    "DEVELOPER_WEBSITE_URL",
+    "DEVELOPER_PRIVACY_URL",
+    "DEVELOPER_TERMS_URL",
+    "TEAMS_APP_RESOURCE_URI",
+}
+
+# Obvious placeholder values shipped in .env.example.
+PLACEHOLDER_HINTS = ("0000-0000", "your-", "example.com", "<")
+
+
+def load_env_values(env_path: Path, non_secret: set[str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not env_path.is_file():
+        return values
+    for raw in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        key, val = key.strip(), val.strip().strip('"').strip("'")
+        if not key or not val or key in non_secret:
+            continue
+        if any(hint in val for hint in PLACEHOLDER_HINTS):
+            continue
+        values[key] = val
+    return values
+
+
+def staged_diff() -> str:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--no-color"], check=True, capture_output=True
+    )
+    return result.stdout.decode("utf-8", errors="replace")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env", default=".env")
+    parser.add_argument("--non-secret", action="append", default=[], metavar="NAME",
+                        help="Additional variable to treat as public; repeatable.")
+    args = parser.parse_args()
+
+    values = load_env_values(Path(args.env), NON_SECRET_VARS | set(args.non_secret))
+    if not values:
+        return 0
+
+    diff = staged_diff()
+    leaked = sorted({name for name, value in values.items() if value in diff})
+    if leaked:
+        sys.stderr.write(
+            "[pre-commit] Blocked: secret value(s) present in staged changes: "
+            + ", ".join(leaked)
+            + "\nRun sanitize before committing, or remove the value.\n"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills/agent365/scripts/create_blueprint.py
+++ b/.github/skills/agent365/scripts/create_blueprint.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Create or inspect Foundry managed agent identity blueprints.
+
+Blueprints are not exposed through the ``azure-ai-projects`` operation groups,
+so this script calls the project data-plane REST API through the authenticated
+client (``AIProjectClient.send_request``) — still SDK-based, no portal
+automation.
+
+A blueprint created here uses ``lifecycle: Manual`` so it can be shared across
+multiple agents. Auto-lifecycle blueprints (created implicitly by an agent) are
+owned by that agent and cannot be referenced by another one.
+
+NOTE: this is the *Foundry managed identity* blueprint. It is unrelated to the
+Agent 365 agent identity blueprint created with ``a365 setup blueprint``.
+
+Usage:
+    python scripts/create_blueprint.py --name my-agent
+    python scripts/create_blueprint.py --list
+    python scripts/create_blueprint.py --name my-agent --show
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from azure.ai.projects import AIProjectClient
+from azure.core.exceptions import AzureError
+from azure.core.rest import HttpRequest
+from azure.identity import DefaultAzureCredential
+
+ROUTE = "/managedAgentIdentityBlueprints"
+API_VERSION = "v1"
+
+
+def load_env(path: Path) -> None:
+    """Load KEY=VALUE pairs from a .env file without overriding real env vars."""
+    if not path.is_file():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+def summarize(blueprint: dict) -> str:
+    identity = blueprint.get("agentIdentityBlueprint", {})
+    return (
+        f"{blueprint.get('blueprintName')}  "
+        f"lifecycle={blueprint.get('lifecycle')}  "
+        f"state={identity.get('provisioningState')}  "
+        f"owner={blueprint.get('owningAgentId', '-')}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", help="Blueprint name to create or show (default: $BLUEPRINT_ID).")
+    parser.add_argument("--list", action="store_true", help="List existing blueprints.")
+    parser.add_argument("--show", action="store_true", help="Show the blueprint instead of creating it.")
+    parser.add_argument("--lifecycle", choices=("Manual", "Auto"), default="Manual")
+    parser.add_argument("--env", default=".env")
+    args = parser.parse_args()
+
+    load_env(Path(args.env))
+
+    name = args.name or os.environ.get("BLUEPRINT_ID")
+    if not name and not args.list:
+        parser.error("Provide --name, set BLUEPRINT_ID, or use --list.")
+
+    endpoint = os.environ.get("FOUNDRY_PROJECT_ENDPOINT")
+    if not endpoint:
+        raise SystemExit("FOUNDRY_PROJECT_ENDPOINT is not set (see references/.env.example).")
+
+    params = {"api-version": API_VERSION}
+
+    try:
+        with (
+            DefaultAzureCredential() as credential,
+            AIProjectClient(endpoint=endpoint, credential=credential, allow_preview=True) as client,
+        ):
+            if args.list:
+                response = client.send_request(HttpRequest("GET", ROUTE, params=params))
+                response.raise_for_status()
+                for blueprint in response.json().get("value", []):
+                    print(summarize(blueprint))
+                return 0
+
+            path = f"{ROUTE}/{name}"
+
+            if args.show:
+                response = client.send_request(HttpRequest("GET", path, params=params))
+                response.raise_for_status()
+                print(json.dumps(response.json(), indent=2, ensure_ascii=False))
+                return 0
+
+            body = {
+                "agentIdentityBlueprint": {"kind": "AgentBlueprint", "type": "System"},
+                "lifecycle": args.lifecycle,
+            }
+            response = client.send_request(HttpRequest("PUT", path, params=params, json=body))
+            response.raise_for_status()
+            blueprint = response.json()
+            print(f"Created blueprint: {summarize(blueprint)}")
+            print(f"  blueprintId: {blueprint.get('blueprintId')}")
+            print(
+                "Reference it with: python scripts/create_instance.py "
+                f"--name <agent> --mode blueprint --blueprint-id {blueprint.get('blueprintName')}"
+            )
+    except AzureError as exc:
+        sys.stderr.write(f"Foundry request failed: {exc}\n")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills/agent365/scripts/create_instance.py
+++ b/.github/skills/agent365/scripts/create_instance.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Create an agent instance from an Agent Template using the Foundry SDK.
+
+Foundry exposes three ways to instantiate an agent from a template:
+
+  manifest   Instantiate a published agent manifest (template) by id, passing
+             template parameter values.
+             -> ``agents.create_version_from_manifest``
+
+  definition Create a standalone agent from the template definition. Use this
+             when the source blueprint has ``Lifecycle=Auto`` and therefore
+             cannot be shared across agents.
+             -> ``agents.create_version``
+
+  blueprint  Create a version bound to a managed-identity blueprint. Requires
+             the blueprint to have ``Lifecycle=Manual``.
+             -> ``agents.create_version(..., blueprint_reference=...)``
+
+All identifiers come from arguments or ``.env`` — nothing is hardcoded.
+
+Usage:
+    python scripts/create_instance.py --name my-agent --mode blueprint --blueprint-id my-agent
+    python scripts/create_instance.py --name my-agent-sales --template-id <manifest-id> \
+        --parameter region=japaneast
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import yaml
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import ManagedAgentIdentityBlueprintReference
+from azure.core.exceptions import AzureError
+from azure.identity import DefaultAzureCredential
+
+
+def load_env(path: Path) -> None:
+    """Load KEY=VALUE pairs from a .env file without overriding real env vars."""
+    if not path.is_file():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+def parse_parameters(pairs: list[str]) -> dict[str, object]:
+    """Parse ``key=value`` pairs; values are JSON-decoded when possible."""
+    values: dict[str, object] = {}
+    for pair in pairs:
+        key, sep, raw = pair.partition("=")
+        if not sep:
+            raise SystemExit(f"Invalid --parameter '{pair}' (expected key=value).")
+        try:
+            values[key.strip()] = json.loads(raw)
+        except json.JSONDecodeError:
+            values[key.strip()] = raw
+    return values
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", help="Name of the agent instance (default: $AGENT_NAME).")
+    parser.add_argument("--mode", choices=("manifest", "definition", "blueprint"), default="blueprint")
+    parser.add_argument("--template-id", help="Template/manifest id (default: $AGENT_TEMPLATE_ID).")
+    parser.add_argument("--blueprint-id", help="Blueprint id (default: $BLUEPRINT_ID).")
+    parser.add_argument("--definition", help="Rendered manifest (default: agents/<name>/agent.yaml).")
+    parser.add_argument("--description")
+    parser.add_argument("--parameter", action="append", default=[], metavar="KEY=VALUE",
+                        help="Template parameter value; repeatable.")
+    parser.add_argument("--env", default=".env")
+    args = parser.parse_args()
+
+    load_env(Path(args.env))
+
+    name = args.name or os.environ.get("AGENT_NAME")
+    if not name:
+        raise SystemExit("Provide --name or set AGENT_NAME.")
+
+    endpoint = os.environ.get("FOUNDRY_PROJECT_ENDPOINT")
+    if not endpoint:
+        raise SystemExit("FOUNDRY_PROJECT_ENDPOINT is not set (see references/.env.example).")
+
+    try:
+        with (
+            DefaultAzureCredential() as credential,
+            AIProjectClient(endpoint=endpoint, credential=credential, allow_preview=True) as client,
+        ):
+            if args.mode == "manifest":
+                template_id = args.template_id or os.environ.get("AGENT_TEMPLATE_ID")
+                if not template_id:
+                    raise SystemExit("Provide --template-id or set AGENT_TEMPLATE_ID.")
+                version = client.agents.create_version_from_manifest(
+                    agent_name=name,
+                    manifest_id=template_id,
+                    parameter_values=parse_parameters(args.parameter),
+                    description=args.description,
+                )
+            else:
+                definition_path = Path(args.definition or f"agents/{name}/agent.yaml")
+                if not definition_path.is_file():
+                    raise SystemExit(
+                        f"Definition manifest not found: {definition_path}\n"
+                        "Run scripts/render.py first to produce it from the template."
+                    )
+                manifest = yaml.safe_load(definition_path.read_text(encoding="utf-8"))
+                definition = manifest.get("definition")
+                if not definition:
+                    raise SystemExit(f"{definition_path}: missing top-level 'definition'.")
+
+                create_kwargs: dict[str, object] = {
+                    "agent_name": name,
+                    "definition": definition,
+                    "description": args.description or manifest.get("description"),
+                }
+                if args.mode == "blueprint":
+                    blueprint_id = args.blueprint_id or os.environ.get("BLUEPRINT_ID")
+                    if not blueprint_id:
+                        raise SystemExit("Provide --blueprint-id or set BLUEPRINT_ID.")
+                    create_kwargs["blueprint_reference"] = ManagedAgentIdentityBlueprintReference(
+                        blueprint_id=blueprint_id
+                    )
+                version = client.agents.create_version(**create_kwargs)
+
+            print(f"Created agent instance '{version.name}' version '{version.version}' (id: {version.id})")
+
+            agent = client.agents.get(agent_name=version.name)
+            print(f"  name  : {agent.name}")
+            print(f"  status: {getattr(agent, 'status', 'n/a')}")
+            print("Copy the instance identity principal/client id into .env before rendering again.")
+    except AzureError as exc:
+        sys.stderr.write(f"Foundry request failed: {exc}\n")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills/agent365/scripts/deploy.py
+++ b/.github/skills/agent365/scripts/deploy.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Deploy a new Foundry agent version from a rendered manifest.
+
+Reads a rendered agent manifest (see ``render.py``) and creates a new agent
+version in the target Microsoft Foundry project using the ``azure-ai-projects``
+SDK. On success the new version becomes the "latest" (unless the manifest marks
+it as a draft), which the "always use latest" endpoint selector serves to Teams
+and Microsoft 365 Copilot automatically — no portal step required.
+
+Environment:
+    FOUNDRY_PROJECT_ENDPOINT  Foundry project endpoint from the project
+                              Overview page, e.g.
+                              https://<account>.services.ai.azure.com/api/projects/<project>
+
+Auth: ``DefaultAzureCredential`` — supports azure/login (OIDC) in CI, Azure CLI
+locally, managed identity and environment credentials.
+
+Usage:
+    python scripts/deploy.py --agent my-agent
+    python scripts/deploy.py --manifest agents/my-agent/agent.yaml
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import yaml
+from azure.ai.projects import AIProjectClient
+from azure.core.exceptions import AzureError
+from azure.identity import DefaultAzureCredential
+
+
+def load_env(path: Path) -> None:
+    """Load KEY=VALUE pairs from a .env file without overriding real env vars."""
+    if not path.is_file():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent", help="Agent name (default: $AGENT_NAME).")
+    parser.add_argument("--manifest", help="Rendered manifest (default: agents/<agent>/agent.yaml).")
+    parser.add_argument("--env", default=".env")
+    args = parser.parse_args()
+
+    load_env(Path(args.env))
+
+    agent = args.agent or os.environ.get("AGENT_NAME")
+    if not agent and not args.manifest:
+        raise SystemExit("Provide --agent, set AGENT_NAME, or pass --manifest.")
+
+    manifest_path = Path(args.manifest or f"agents/{agent}/agent.yaml")
+    if not manifest_path.is_file():
+        raise SystemExit(
+            f"Manifest not found: {manifest_path}\n"
+            "Run scripts/render.py first to produce it from the template."
+        )
+
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+
+    agent_name = manifest.get("name")
+    definition = manifest.get("definition")
+    if not agent_name or not definition:
+        raise SystemExit("Manifest must contain top-level 'name' and 'definition'.")
+
+    endpoint = os.environ.get("FOUNDRY_PROJECT_ENDPOINT")
+    if not endpoint:
+        raise SystemExit("FOUNDRY_PROJECT_ENDPOINT is not set (see references/.env.example).")
+
+    create_kwargs: dict[str, object] = {
+        "agent_name": agent_name,
+        "definition": definition,
+        "description": manifest.get("description") or "",
+        "draft": bool(manifest.get("draft", False)),
+    }
+    blueprint_reference = manifest.get("blueprint_reference")
+    if blueprint_reference:
+        create_kwargs["blueprint_reference"] = blueprint_reference
+
+    try:
+        with (
+            DefaultAzureCredential() as credential,
+            AIProjectClient(endpoint=endpoint, credential=credential, allow_preview=True) as client,
+        ):
+            version = client.agents.create_version(**create_kwargs)
+            print(f"Deployed agent '{version.name}' version '{version.version}' (id: {version.id})")
+            print("Active version selector 'always use latest' serves this version to Teams / M365.")
+    except AzureError as exc:
+        sys.stderr.write(f"Foundry request failed: {exc}\n")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills/agent365/scripts/render.py
+++ b/.github/skills/agent365/scripts/render.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Render an agent template into a concrete manifest by substituting ``${VAR}``.
+
+Placeholders use ``${VAR}`` syntax and are resolved from environment variables
+(and, for convenience, from a ``.env`` file). Fails fast if any variable is
+missing so that secrets are never left as literal placeholders in a manifest
+that is about to be deployed.
+
+Usage:
+    python scripts/render.py --agent my-agent
+    python scripts/render.py --template agents/my-agent/agent.template.yaml \
+        --output agents/my-agent/agent.yaml
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+PLACEHOLDER = re.compile(r"\$\{([A-Z0-9_]+)\}")
+
+
+def load_env(path: Path) -> None:
+    """Load KEY=VALUE pairs from a .env file without overriding real env vars."""
+    if not path.is_file():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+def render(template_text: str) -> str:
+    missing: list[str] = []
+
+    def _sub(match: re.Match[str]) -> str:
+        name = match.group(1)
+        value = os.environ.get(name)
+        if not value:
+            missing.append(name)
+            return match.group(0)
+        return value
+
+    result = PLACEHOLDER.sub(_sub, template_text)
+    if missing:
+        raise SystemExit(
+            "Missing required environment variables: " + ", ".join(sorted(set(missing)))
+        )
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent", help="Agent name (default: $AGENT_NAME). Drives default paths.")
+    parser.add_argument("--template", help="Template YAML (default: agents/<agent>/agent.template.yaml).")
+    parser.add_argument("--output", help="Rendered YAML (default: agents/<agent>/agent.yaml).")
+    parser.add_argument("--env", default=".env")
+    args = parser.parse_args()
+
+    load_env(Path(args.env))
+
+    agent = args.agent or os.environ.get("AGENT_NAME")
+    if not agent and not (args.template and args.output):
+        raise SystemExit("Provide --agent, set AGENT_NAME, or pass both --template and --output.")
+
+    template_path = Path(args.template or f"agents/{agent}/agent.template.yaml")
+    output_path = Path(args.output or f"agents/{agent}/agent.yaml")
+
+    if not template_path.is_file():
+        raise SystemExit(f"Template not found: {template_path}")
+
+    rendered = render(template_path.read_text(encoding="utf-8"))
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(rendered, encoding="utf-8")
+    print(f"Rendered {template_path} -> {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills/agent365/scripts/review_sanitization.py
+++ b/.github/skills/agent365/scripts/review_sanitization.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Deterministic sanitization / generalization review gate.
+
+This is the automated reviewer that backs the review process. It inspects
+Git-tracked files and fails (exit 1) if secret-hiding or generalization rules
+are violated, so the review can only Pass when the repo is clean.
+
+Rules enforced:
+  1. `.env` and Agent 365 generated config must not be tracked.
+  2. Rendered manifests `agents/**/agent.yaml` and built Teams packages
+     `teams/*.zip` must not be tracked.
+  3. Agent templates, Teams templates and `.env.example` must not contain real
+     GUIDs or `/subscriptions/<guid>/...` ARM paths (all-zero placeholder GUIDs
+     are allowed).
+  4. `agents/**/agent.template.yaml` and `teams/*.template.json` must be
+     generalized: they must use `${VAR}` placeholders.
+
+The script never hardcodes real secret values; it matches by pattern only.
+
+Usage:
+    python scripts/review_sanitization.py
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+GUID = re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b")
+ZERO_GUID = re.compile(r"^0+(-0+)*$")
+SUBSCRIPTION_PATH = re.compile(r"/subscriptions/[0-9a-fA-F-]{36}/resourceGroups/", re.IGNORECASE)
+TEAMS_TEMPLATE = re.compile(r"teams/.+\.template\.json")
+AGENT_MANIFEST = re.compile(r"agents/.+/agent\.yaml")
+AGENT_TEMPLATE = re.compile(r"agents/.+/agent\.template\.yaml")
+AGENT_ANY_YAML = re.compile(r"agents/.+/agent(\.template)?\.yaml")
+FORBIDDEN_TRACKED = {".env", "a365.config.json", "a365.generated.config.json", "auth-token.json"}
+
+
+def tracked_files() -> list[str]:
+    out = subprocess.run(["git", "ls-files"], check=True, capture_output=True, text=True).stdout
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def is_real_guid(value: str) -> bool:
+    return not ZERO_GUID.match(value)
+
+
+def main() -> int:
+    failures: list[str] = []
+    files = tracked_files()
+
+    # Rule 1: secret-bearing files must not be tracked.
+    for name in sorted(FORBIDDEN_TRACKED):
+        if name in files:
+            failures.append(f"{name} is tracked; it must be git-ignored.")
+
+    # Rule 2: rendered manifests / built packages must not be tracked.
+    for f in files:
+        if AGENT_MANIFEST.fullmatch(f):
+            failures.append(f"Rendered manifest is tracked: {f} (must be git-ignored).")
+        if re.fullmatch(r"teams/.+\.zip", f):
+            failures.append(f"Built Teams package is tracked: {f} (must be git-ignored).")
+
+    # Rule 3: scan sensitive text files for real identifiers.
+    scan_targets = [
+        f for f in files
+        if f.endswith(".env.example") or AGENT_ANY_YAML.fullmatch(f) or TEAMS_TEMPLATE.fullmatch(f)
+    ]
+    for f in scan_targets:
+        text = Path(f).read_text(encoding="utf-8", errors="replace")
+
+        if SUBSCRIPTION_PATH.search(text):
+            failures.append(
+                f"{f}: contains a real /subscriptions/<guid>/resourceGroups ARM path (must be ${{...}})."
+            )
+
+        for m in GUID.finditer(text):
+            if is_real_guid(m.group(0)):
+                failures.append(
+                    f"{f}: contains a real GUID '{m.group(0)}' (generalize to a ${{VAR}} placeholder)."
+                )
+                break
+
+    # Rule 4: templates must be generalized.
+    for f in files:
+        if AGENT_TEMPLATE.fullmatch(f) or TEAMS_TEMPLATE.fullmatch(f):
+            text = Path(f).read_text(encoding="utf-8", errors="replace")
+            if "${" not in text:
+                failures.append(f"{f}: no ${{VAR}} placeholders found; template is not generalized.")
+
+    if failures:
+        sys.stderr.write("Sanitization review FAILED:\n")
+        for msg in failures:
+            sys.stderr.write(f"  - {msg}\n")
+        return 1
+
+    print("Sanitization review PASSED: no real secrets, templates generalized.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills/agent365/scripts/sanitize.py
+++ b/.github/skills/agent365/scripts/sanitize.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Generalize + hide secrets in an agent manifest, then sync GitHub secrets.
+
+1. Read a source manifest that still contains real values
+   (default: ``agents/<agent>/agent.yaml`` — kept local, git-ignored).
+2. For every NAME=VALUE pair in ``.env`` (excluding public identifiers), replace
+   occurrences of VALUE in the manifest text with the ``${NAME}`` placeholder.
+3. Optionally push each VALUE to GitHub Actions secrets via ``gh secret set``.
+4. Write the generalized result to the template and optionally ``git add`` it.
+
+Intended to run from the pre-commit hook so that only the generalized,
+secret-free template is ever committed.
+
+Usage:
+    python scripts/sanitize.py --env .env --set-secrets --stage
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Public identifiers and human-readable metadata. Substituting them would
+# corrupt prose that legitimately mentions the agent, so they stay literal.
+NON_SECRET_VARS = {
+    "AGENT_NAME",
+    "BLUEPRINT_ID",
+    "TEAMS_APP_VERSION",
+    "AGENT_DISPLAY_NAME",
+    "AGENT_FULL_NAME",
+    "AGENT_DESCRIPTION_SHORT",
+    "AGENT_DESCRIPTION_FULL",
+    "DEVELOPER_NAME",
+    "DEVELOPER_WEBSITE_URL",
+    "DEVELOPER_PRIVACY_URL",
+    "DEVELOPER_TERMS_URL",
+    "TEAMS_APP_RESOURCE_URI",
+}
+
+
+def load_env(env_path: Path, non_secret: set[str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not env_path.is_file():
+        return values
+    for raw in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        key, val = key.strip(), val.strip().strip('"').strip("'")
+        if key and val and key not in non_secret:
+            values[key] = val
+    return values
+
+
+def set_github_secret(name: str, value: str, repo: str | None) -> None:
+    cmd = ["gh", "secret", "set", name, "--body", value]
+    if repo:
+        cmd += ["--repo", repo]
+    subprocess.run(cmd, check=True, shell=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent", help="Agent name (default: $AGENT_NAME from --env).")
+    parser.add_argument("--source", help="Manifest with real values (default: agents/<agent>/agent.yaml).")
+    parser.add_argument("--template", help="Generalized output (default: agents/<agent>/agent.template.yaml).")
+    parser.add_argument("--env", default=".env")
+    parser.add_argument("--repo", default=None, help="owner/repo for gh secret set")
+    parser.add_argument("--non-secret", action="append", default=[], metavar="NAME",
+                        help="Additional variable to exclude from substitution; repeatable.")
+    parser.add_argument("--set-secrets", action="store_true", help="push values to GitHub secrets")
+    parser.add_argument("--stage", action="store_true", help="git add the generated template")
+    args = parser.parse_args()
+
+    non_secret = NON_SECRET_VARS | set(args.non_secret)
+    env_path = Path(args.env)
+
+    agent = args.agent
+    if not agent:
+        for raw in env_path.read_text(encoding="utf-8").splitlines() if env_path.is_file() else []:
+            if raw.strip().startswith("AGENT_NAME="):
+                agent = raw.split("=", 1)[1].strip().strip('"').strip("'")
+                break
+    agent = agent or os.environ.get("AGENT_NAME")
+
+    if not agent and not (args.source and args.template):
+        print("sanitize: AGENT_NAME not resolved and no --source/--template given; skipping.")
+        return 0
+
+    source_path = Path(args.source or f"agents/{agent}/agent.yaml")
+    template_path = Path(args.template or f"agents/{agent}/agent.template.yaml")
+
+    if not source_path.is_file():
+        # Nothing to sanitize (no local manifest with real values) — no-op.
+        print(f"sanitize: source not found ({source_path}); skipping.")
+        return 0
+
+    env_values = load_env(env_path, non_secret)
+    if not env_values:
+        raise SystemExit(f"sanitize: no values found in {args.env}; cannot generalize/hide secrets.")
+
+    text = source_path.read_text(encoding="utf-8")
+
+    # Replace longer values first so nested substrings do not clobber longer ones.
+    replaced: list[str] = []
+    for name in sorted(env_values, key=lambda n: len(env_values[n]), reverse=True):
+        value = env_values[name]
+        if value and value in text:
+            text = text.replace(value, "${" + name + "}")
+            replaced.append(name)
+
+    template_path.parent.mkdir(parents=True, exist_ok=True)
+    template_path.write_text(text, encoding="utf-8")
+    print(f"sanitize: wrote generalized template -> {template_path}")
+    if replaced:
+        print("sanitize: generalized values -> " + ", ".join(sorted(replaced)))
+
+    if args.set_secrets:
+        for name in sorted(env_values):
+            set_github_secret(name, env_values[name], args.repo)
+        print("sanitize: synced GitHub secrets -> " + ", ".join(sorted(env_values)))
+
+    if args.stage:
+        subprocess.run(["git", "add", str(template_path)], check=True, shell=False)
+        print(f"sanitize: staged {template_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Python と pip が利用可能な場合は、`spec-builder` 用 `.venv` の作�
 .
 ├── .github/
 │   ├── agents/                      # Copilot カスタムエージェント定義
-│   └── skills/                      # 製品単位で統合された 16 スキル
+│   └── skills/                      # 製品単位で統合された 17 スキル
 │       ├── architecture/            # アーキテクチャ設計
 │       ├── standard/                # 共通基盤（認証・アイコン・メールテンプレート）
 │       ├── update-skills/           # スキル作成・更新・PR 提出
@@ -311,6 +311,7 @@ Python と pip が利用可能な場合は、`spec-builder` 用 `.venv` の作�
 │       ├── copilot-studio-v2/       # 新アーキテクチャ（cliagent）エージェント完全自動構築
 │       ├── power-automate/          # クラウドフロー作成・デプロイ
 │       ├── cowork/                  # Copilot Cowork プラグイン開発・公開
+│       ├── agent365/                # Foundry エージェントを Agent 365 経由で Teams / M365 に公開
 │       ├── ai-builder/              # AI プロンプト作成
 │       ├── spec-builder/            # 一次情報→要件定義書（仕様書）作成
 │       ├── package-sample/          # サンプルのパブリック公開パッケージング


### PR DESCRIPTION
## 概要

Microsoft Foundry のエージェントを **SDK / REST ベース**（ポータル自動操作なし）で定義・デプロイし、
**Agent 365 のエージェント ID ブループリント**と Teams アプリパッケージを通じて
Teams / Microsoft 365 Copilot に公開するまでを一貫して扱う `agent365` スキルを追加します。

実案件で一通り動作確認した内容（正常系）と、実際に踏んだ落とし穴（異常系）を分離して収録しています。

## 追加・変更

| ファイル | 内容 |
|---|---|
| `.github/skills/agent365/SKILL.md` | **正常系**のみ。Step 0〜10（公開形態決定 → scaffold → Foundry ブループリント → デプロイ → Agent 365 ブループリント → Bot Service → Teams パッケージ → 公開 → CI/CD → 検証） |
| `references/troubleshooting.md` | **異常系** 11 件 |
| `references/architecture.md` | 2 種類のブループリントの違い、manifest スキーマ選択、公開経路図 |
| `references/a365-cli.md` | `a365` CLI の Windows / WAM 運用 |
| `references/repo-scaffold.md` | `.gitignore` / pre-commit / `review.yml` / `deploy.yml` / レビュー指示 |
| `references/.env.example` | 全パラメーターをプレースホルダーで定義（取得元コメント付き） |
| `references/templates/` | `agent.template.yaml` / `manifest.template.json` / `agenticUser.template.json` |
| `scripts/` (8 本) | `render` / `create_blueprint` / `create_instance` / `deploy` / `build_teams_package` / `sanitize` / `check_secrets` / `review_sanitization` |
| `.github/skills/README.md` | カタログに 1 行追加（16 → 17 スキル）、推奨開発フローに 9 を追加 |
| `.github/agents/GeekPowerCode.agent.md` | スキル表に 1 行追加 |
| `README.md` | リポジトリ構成ツリーとスキル数を更新 |

## このスキルが解決すること

- **「ブループリント」の混同**: Foundry のマネージド ID ブループリントと Agent 365 のエージェント ID ブループリントは別物。取り違えるとインスタンス化されない
- **インスタンスが作られない**: `functionsAs` の既定は `agentOnly`。`agenticUserTemplates` + `functionsAs: agenticUserOnly` が両方必要で、これらは `devPreview` スキーマにしか無い
- **再アップロード失敗**: `Must upload a newer version of the title than what is already present.` → `TEAMS_APP_VERSION` を毎回上げる
- **outline アイコンが白い四角になる**: 元画像にアルファチャンネルが必要
- **秘匿化の担保**: `review_sanitization.py` が実 GUID・ARM パス・未汎用化テンプレート・追跡してはいけないファイルを機械判定し、CI の必須チェックとして merge をブロック

## 汎用化・秘匿化

- 会社名・個別プロジェクト名・実 GUID・実 URL・メールアドレス・シークレットは含まれていません
- 環境依存値はすべて `${VAR}` プレースホルダー化し、`references/.env.example` に定義（実値は `.env`）
- 公開識別子（`AGENT_NAME` 等）と表示メタデータは `NON_SECRET_VARS` として置換対象から除外

## 検証

- `python .github/skills/update-skills/scripts/validate_skill.py --all` → 全 17 スキル ✅
- スクリプト 8 本の `py_compile`、テンプレート 3 種の JSON / YAML パース ✅
- staged diff に対する GUID スキャンで実値の混入なし ✅

## マージ順

既存のオープン PR #285（power-pages）とはファイルが重複せず、依存関係もありません。**どちらを先にマージしても問題ありません。**
