### PR TITLE
skill(agent365/architecture): ライト実装(PoC)ルートを追加し、本格実装を GitHub 以外の Git にも対応

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -118,7 +118,7 @@ triggers:                      # スキル発動条件キーワード（必須�
 
 | スキル | 説明 |
 |--------|------|
-| [architecture](architecture/SKILL.md) | Power Platform 全体の構成方針を設計し、最適なコンポーネント構成を決定する。 |
+| [architecture](architecture/SKILL.md) | Power Platform 全体の構成方針を設計し、最適なコンポーネント構成を決定する。Agent 365 採用時はライト実装 / 本格実装と Git ホスティングを確定する。 |
 | [standard](standard/SKILL.md) | 共通認証・環境変数・ソリューション運用など、全スキル共通の開発基盤を提供する。 |
 | [update-skills](update-skills/SKILL.md) | スキル（SKILL.md/references/scripts）を作成・更新し、汎用化・秘匿化した上でリモートへ PR を作成・更新する。 |
 | [azure](azure/SKILL.md) | Azure のリファレンスアーキテクチャを選定し、テナントのセキュリティガバナンス（公衆アクセス禁止・共有キー禁止・MFA 必須等）に準拠した構成で構築・デプロイ・検証する。 |
@@ -146,7 +146,7 @@ triggers:                      # スキル発動条件キーワード（必須�
 | [copilot-studio-v2](copilot-studio-v2/SKILL.md) | Copilot Studio の新アーキテクチャ（cliagent）エージェントを Dataverse API だけで UI 操作なし完全自動構築する。フラット Python スキル添付まで対応。MCP サーバー等のツール追加は Copilot Studio UI での手動作業。 |
 | [power-automate](power-automate/SKILL.md) | Power Automate クラウドフローをソリューション対応で作成・デプロイする。 |
 | [cowork](cowork/SKILL.md) | 目的特化型の Copilot Cowork プラグイン（Agent Skills + Dataverse MCP）を開発し、Entra ID SSO を構成して M365 管理センターのエージェント画面から公開・更新する。 |
-| [agent365](agent365/SKILL.md) | Microsoft Foundry のエージェントを SDK/REST ベースで作成・バージョン管理し、Agent 365 のエージェント ID ブループリントと Teams アプリパッケージを介して Teams / Microsoft 365 Copilot に公開する。 |
+| [agent365](agent365/SKILL.md) | Microsoft Foundry のエージェン トを SDK/REST ベースで作成・バージョン管理し、Agent 365 のエージェント ID ブループリントと Teams アプリパッケージを介して Teams / Microsoft 365 Copilot に公開する。ライト実装（PoC）と本格実装（private リポジトリ + CI/CD）の 2 ルートに対応。 |
 
 ### ai — AI / プロンプト
 

--- a/.github/skills/agent365/SKILL.md
+++ b/.github/skills/agent365/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent365
-description: "Microsoft Foundry のエージェントを SDK/REST ベースで作成・バージョン管理し、Agent 365 のエージェント ID ブループリントと Teams アプリパッケージを介して Teams / Microsoft 365 Copilot に公開する。秘匿値は .env と GitHub Secrets に隔離し、テンプレートの汎用化を CI で機械検証する。"
+description: "Microsoft Foundry のエージェントを SDK/REST ベースで作成・バージョン管理し、Agent 365 のエージェント ID ブループリントと Teams アプリパッケージを介して Teams / Microsoft 365 Copilot に公開する。ライト実装（PoC）と本格実装（CI/CD + Agent Evals）の 2 ルートを選択でき、本格実装は GitHub / Azure DevOps Repos / その他 Git の private リポジトリに対応する。秘匿値は .env と CI のシークレットストアに隔離し、テンプレートの汎用化を CI で機械検証する。"
 category: automation
 triggers:
   - "Agent 365"
@@ -13,6 +13,10 @@ triggers:
   - "Agent Identity Blueprint"
   - "エージェントテンプレート"
   - "AI 秘書エージェント"
+  - "エージェントの PoC"
+  - "ライト実装"
+  - "本格実装"
+  - "Azure DevOps Repos でエージェント"
 ---
 
 # Foundry エージェント × Agent 365 公開スキル
@@ -24,17 +28,38 @@ Teams / Microsoft 365 Copilot に公開するまでを一貫して行う。
 | 原則 | 内容 |
 |---|---|
 | SDK / REST のみ | すべて `azure-ai-projects` SDK と Agent 365 CLI（`a365`）で完結。ポータルのブラウザ自動操作は行わない |
-| テンプレート駆動 | コミットするのは `${VAR}` 入りテンプレートだけ。実値は `.env` / GitHub Secrets のみ |
+| ルート選択 | **ライト実装（PoC）**と**本格実装（本番運用）**を最初に選ぶ。PoC に CI/CD 一式を強制しない |
+| テンプレート駆動 | コミットするのは `${VAR}` 入りテンプレートだけ。実値は `.env` / CI のシークレットストアのみ |
+| Git ホスティング非依存 | 本格実装は GitHub / Azure DevOps Repos / その他 Git の **private リポジトリ**に対応（`GIT_PROVIDER` / `SECRET_BACKEND` で切り替え） |
 | 機械検証 | 秘匿化・汎用化は `review_sanitization.py` が CI で Pass/Fail 判定。人手のレビューに依存しない |
 | インスタンス化 | インストールごとに専用の Entra Agent ID を持たせるには Agent 365 ブループリント + `agenticUserTemplates` が必須 |
 | 自動配信 | Foundry の「常に最新を使用」により、新バージョンは Teams / M365 Copilot へ自動配信される |
 
-> 前提ツール: Python 3.10+、Azure CLI（`az`、ログイン済み）、GitHub CLI（`gh`、認証済み）、
-> Agent 365 CLI（`a365`）、Git。
+> 前提ツール: Python 3.10+、Azure CLI（`az`、ログイン済み）、Agent 365 CLI（`a365`）、Git。
+> 本格実装では Git ホスティングに応じて GitHub CLI（`gh`）または Azure CLI の `azure-devops` 拡張を追加で使う。
 > 参考: [アーキテクチャ（2 種類のブループリント）](references/architecture.md) /
+> [ライト実装（PoC）クイックスタート](references/poc-quickstart.md) /
+> [CI / Git ホスティング別の構成](references/ci-providers.md) /
 > [Agent 365 CLI 運用](references/a365-cli.md) /
 > [リポジトリ scaffold](references/repo-scaffold.md) /
 > [異常系・トラブルシュート](references/troubleshooting.md)
+
+## 実装ルートの選択（ライト / 本格）
+
+`architecture` スキルの AskUserQuestion で選択済みならその結果に従う。未選択なら Step 0 で確認する。
+
+| 観点 | ライト実装（PoC） | 本格実装（本番運用） |
+|---|---|---|
+| 目的 | まず Teams で動かして価値を検証する | 継続的に運用・改善する |
+| 公開形態 | 共有エージェント（`agenticUserTemplates` なし） | インスタンス化（Agent 365 ブループリント + `agenticUserTemplates`） |
+| リポジトリ | 任意（ローカルのみでも可） | **private リポジトリ必須**（GitHub / Azure DevOps Repos / その他 Git） |
+| 秘匿値 | ローカル `.env` のみ（`SECRET_BACKEND=none`） | `.env` + CI のシークレットストア（`SECRET_BACKEND`） |
+| デプロイ | ローカルから `deploy.py` を手動実行 | CI/CD（秘匿化ゲート + Agent Evals + 承認ゲート） |
+| 実施する Step | 0 → 1 → 2 → 3 → 4 → 5 → 7 → 8 → 9 | Step 0 〜 11 のすべて |
+
+> ライト実装は **Step 6（Agent 365 ブループリント）と Step 10（CI/CD）を省略**する最短ルート。
+> 検証が済んだら**その 2 Step を後から追加するだけ**で本格実装へ昇格できる（作り直し不要）。
+> 省略ルートの要約は [references/poc-quickstart.md](references/poc-quickstart.md)。
 
 ## スキル同梱スクリプト（再利用）
 
@@ -42,14 +67,14 @@ Teams / Microsoft 365 Copilot に公開するまでを一貫して行う。
 
 | スクリプト | 用途 | Step |
 |---|---|---|
-| [scripts/render.py](scripts/render.py) | テンプレートの `${VAR}` を環境変数で解決して実ファイルを生成 | 4 |
-| [scripts/create_blueprint.py](scripts/create_blueprint.py) | Foundry のマネージド ID ブループリントを作成／一覧／表示（REST 直呼び） | 3 |
-| [scripts/create_instance.py](scripts/create_instance.py) | manifest / definition / blueprint の 3 モードでエージェントを作成 | 4 |
-| [scripts/deploy.py](scripts/deploy.py) | レンダリング済み manifest から新バージョンを `create_version` | 4, 9 |
-| [scripts/build_teams_package.py](scripts/build_teams_package.py) | Teams manifest + アイコン + agenticUser を ZIP 化 | 7 |
-| [scripts/sanitize.py](scripts/sanitize.py) | 実値入り manifest を `${VAR}` 化し GitHub Secrets へ同期 | 9 |
-| [scripts/check_secrets.py](scripts/check_secrets.py) | ステージ済み差分への実値混入を検査（pre-commit） | 9 |
-| [scripts/review_sanitization.py](scripts/review_sanitization.py) | 秘匿化・汎用化の決定論レビューゲート（CI 必須チェック） | 9, 10 |
+| [scripts/render.py](scripts/render.py) | テンプレートの `${VAR}` を環境変数で解決して実ファイルを生成 | 5 |
+| [scripts/create_blueprint.py](scripts/create_blueprint.py) | Foundry のマネージド ID ブループリントを作成／一覧／表示（REST 直呼び） | 4 |
+| [scripts/create_instance.py](scripts/create_instance.py) | manifest / definition / blueprint の 3 モードでエージェントを作成 | 5 |
+| [scripts/deploy.py](scripts/deploy.py) | レンダリング済み manifest から新しいバージョンを `create_version` | 5, 10 |
+| [scripts/build_teams_package.py](scripts/build_teams_package.py) | Teams manifest + アイコン + agenticUser を ZIP 化 | 8 |
+| [scripts/sanitize.py](scripts/sanitize.py) | 実値入り manifest を `${VAR}` 化し CI のシークレットストア（GitHub / Azure DevOps / Key Vault）へ同期 | 10 |
+| [scripts/check_secrets.py](scripts/check_secrets.py) | ステージ済み差分への実値混入を検査（pre-commit、Git ホスティング非依存） | 10 |
+| [scripts/review_sanitization.py](scripts/review_sanitization.py) | 秘匿化・汎用化の決定論レビューゲート（CI 必須チェック、Git ホスティング非依存） | 10, 11 |
 
 ## 標準フォルダ構成（生成されるテーマ側）
 
@@ -57,33 +82,53 @@ Teams / Microsoft 365 Copilot に公開するまでを一貫して行う。
 <repo-root>/
 ├── .env                          # 実値（.gitignore 済み）
 ├── .env.example                  # プレースホルダーのみ（コミット対象）
-├── .githooks/pre-commit          # 汎用化 → Secrets 同期 → 漏洩検査
-├── .github/workflows/
-│   ├── review.yml                # sanitization-review（必須チェック）
-│   └── deploy.yml                # render → 承認 → create_version
+├── .githooks/pre-commit          # 汎用化 → Secrets 同期 → 漏洩検査（本格実装）
+├── <CI 定義>                     # 本格実装のみ。Git ホスティングに応じて選択（Step 0）
+│   ├── .github/workflows/        #   GitHub  : review.yml / deploy.yml
+│   └── .azuredevops/             #   Azure DevOps: azure-pipelines.yml / templates/
 ├── agents/<agent-name>/
 │   ├── agent.template.yaml       # コミット対象（${VAR} 入り）
 │   └── agent.yaml                # レンダリング結果（.gitignore 済み）
 ├── teams/
 │   ├── manifest.template.json    # コミット対象
-│   ├── agenticUser.template.json # コミット対象
+│   ├── agenticUser.template.json # コミット対象（インスタンス化時）
 │   └── <agent-name>-teams-app.zip# ビルド結果（.gitignore 済み）
 ├── assets/agent-icon.png         # アイコン元画像（正方形・背景透過）
 └── scripts/                      # 本スキルの scripts/ をコピー
 ```
 
+> ライト実装では `.githooks/` と CI 定義を作らない（`.env` を `.gitignore` するだけでよい）。
+
 ## ワークフロー（正常系）
 
-### Step 0: 公開形態を決める
+### Step 0: 実装レベルとリポジトリ形態を決める
+
+1. **ライト実装（PoC）か本格実装か**を AskUserQuestion で確認する
+   （`architecture` スキルで選択済みならその結果を使い、重複して聞かない）。
+2. 本格実装なら **Git ホスティング**を確認し、CI とシークレット保管先を決める。
+   エージェント定義は業務知識を含むため、**private リポジトリを前提**とする。
+
+| Git ホスティング | CI | シークレット保管先 | `GIT_PROVIDER` | `SECRET_BACKEND` |
+|---|---|---|---|---|
+| GitHub（private） | GitHub Actions | GitHub Actions Secrets | `github` | `github` |
+| Azure DevOps Repos（private） | Azure Pipelines | 変数グループ（Key Vault 連携可） | `azure-devops` | `azure-devops` |
+| その他 Git（GitLab / Bitbucket / 自己ホスト） | 各 CI | Azure Key Vault | `other` | `keyvault` |
+| ライト実装 | なし | ローカル `.env` のみ | （任意） | `none` |
+
+3. 決めた値を `.env` の `IMPLEMENTATION_MODE` / `GIT_PROVIDER` / `SECRET_BACKEND` に設定する。
+   → CI 定義の雛形と認証の差異は [references/ci-providers.md](references/ci-providers.md)。
+
+### Step 1: 公開形態を決める
 
 1. **共有エージェント**（全ユーザーが同じ 1 体を使う）か、
    **インスタンス化エージェント**（インストールごとに専用の Entra Agent ID を持つ）かを確認する。
-2. インスタンス化する場合のみ Agent 365 ブループリント（Step 5）と `agenticUserTemplates` が必要になる。
+   **ライト実装では常に共有エージェント**とし、Step 6 を省略する。
+2. インスタンス化する場合のみ Agent 365 ブループリント（Step 6）と `agenticUserTemplates` が必要になる。
    → 詳細は [references/architecture.md](references/architecture.md)。
 3. エージェント名（kebab-case、Teams 表示名とは別）を決める。
    エージェント名を3件 AskUserQuestion にて提案する。ここでのエージェント名は独自性のあるものとし、**商標・著作権に触れる名称やキャラクターを使用してはならない**。
 
-### Step 1: リポジトリを scaffold する
+### Step 2: リポジトリを scaffold する
 
 [references/repo-scaffold.md](references/repo-scaffold.md) の内容をそのまま配置する。
 
@@ -94,14 +139,16 @@ Copy-Item .github/skills/agent365/references/templates/agent.template.yaml agent
 Copy-Item .github/skills/agent365/references/templates/manifest.template.json teams/
 Copy-Item .github/skills/agent365/references/templates/agenticUser.template.json teams/
 Copy-Item .github/skills/agent365/references/.env.example .env.example
-git config core.hooksPath .githooks
+git config core.hooksPath .githooks   # 本格実装のみ
 pip install -r requirements.txt   # azure-ai-projects / azure-identity / PyYAML / Pillow
 ```
 
 `.gitignore` には最低限 `.env` / `agents/**/agent.yaml` / `teams/*.zip` / `a365.generated.config.json`
 / `*token-cache*` を追加する（[references/repo-scaffold.md](references/repo-scaffold.md) に完全版）。
+本格実装では Step 0 で選んだ Git ホスティングの CI 定義も配置する
+（[references/ci-providers.md](references/ci-providers.md)）。**ライト実装では `.githooks/` と CI 定義を作らない**。
 
-### Step 2: Foundry プロジェクトと `.env` を用意する
+### Step 3: Foundry プロジェクトと `.env` を用意する
 
 1. Foundry プロジェクトのエンドポイント（`https://<account>.services.ai.azure.com/api/projects/<project>`）を
    プロジェクト概要から取得する。
@@ -113,7 +160,7 @@ Copy-Item .env.example .env
 az account set --subscription $env:AZURE_SUBSCRIPTION_ID
 ```
 
-### Step 3: Foundry のマネージド ID ブループリントを作成する
+### Step 4: Foundry のマネージド ID ブループリントを作成する
 
 エージェントのマネージド ID の設計図。**`lifecycle=Manual` で作れば複数エージェントから共有できる**
 （エージェントが暗黙に作る `Auto` は所有者専用で共有不可）。
@@ -127,7 +174,7 @@ python scripts/create_blueprint.py --name <blueprint-name> --show
 出力された `blueprintId` / `principalId` / `clientId` を `.env` の
 `BLUEPRINT_ID` / `BLUEPRINT_PRINCIPAL_ID` / `BLUEPRINT_CLIENT_ID` に設定する。
 
-### Step 4: エージェントを定義してデプロイする
+### Step 5: エージェントを定義してデプロイする
 
 1. `agents/<agent-name>/agent.template.yaml` の `definition`（`model` / `instructions` / `tools`）を編集する。
    ARM リソース参照は必ず `${AZURE_SUBSCRIPTION_ID}` 等のプレースホルダーで書く。
@@ -148,9 +195,10 @@ python scripts/deploy.py --agent <agent-name>
 
 作成後、`INSTANCE_IDENTITY_PRINCIPAL_ID` / `INSTANCE_IDENTITY_CLIENT_ID` / `AGENT_GUID` を `.env` へ反映する。
 
-### Step 5: Agent 365 のエージェント ID ブループリントを作成する
+### Step 6: Agent 365 のエージェント ID ブループリントを作成する
 
-インストールごとの専用 Entra Agent ID が必要な場合のみ実施する（Step 0 の判断）。
+インストールごとの専用 Entra Agent ID が必要な場合のみ実施する（Step 1 の判断）。
+**ライト実装ではこの Step を飛ばす**（共有エージェントとして公開する）。
 **Foundry のブループリントとは別物**なので混同しない。
 
 ```powershell
@@ -163,7 +211,7 @@ a365 setup blueprint -n <agent-name> --no-endpoint
 - 初回はディレクトリ伝播の遅延で失敗することがあるが、**同じコマンドを再実行すれば冪等に修復される**。
 - Windows での認証（WAM）まわりのハマりどころは [references/a365-cli.md](references/a365-cli.md)。
 
-### Step 6: Azure Bot Service と Teams チャネルを作成する
+### Step 7: Azure Bot Service と Teams チャネルを作成する
 
 Bot の `msaAppId` には**エージェントのインスタンス ID の client id** を使う。
 
@@ -175,7 +223,7 @@ az bot create --resource-group $env:AZURE_RESOURCE_GROUP --name $env:AZURE_BOT_N
 az bot msteams create --resource-group $env:AZURE_RESOURCE_GROUP --name $env:AZURE_BOT_NAME
 ```
 
-### Step 7: Teams アプリパッケージをビルドする
+### Step 8: Teams アプリパッケージをビルドする
 
 ```powershell
 python scripts/build_teams_package.py
@@ -188,34 +236,53 @@ python scripts/build_teams_package.py
   未設定なら GA スキーマ（1.22）の**共有エージェント**パッケージに自動ダウングレードして警告を出す。
 - **再アップロードのたびに `.env` の `TEAMS_APP_VERSION` を上げる**（同一バージョンはアップロード時に拒否される）。
 
-### Step 8: アップロードして公開する
+### Step 9: アップロードして公開する
 
 1. Microsoft 365 管理センター（Agent 365 の Agents 画面）または Teams 管理センター >
    アプリを管理 > アップロード で、生成された ZIP を登録する。
 2. 組織向けのアクセス許可・公開範囲を設定する。
 3. Teams でエージェントを開き、利用者ごとのセッション（インスタンス）が開始されることを確認する。
 
-### Step 9: CI/CD と秘匿化ゲートを有効化する
+> **ライト実装はここで完了**。以降の Step 10 は本格実装のみ実施する。
+> ライト実装のまま運用する場合も、`.env` をコミットしていないことを Step 11 で必ず確認する。
 
-1. **pre-commit**: `sanitize.py`（実値 → `${VAR}` 化 + GitHub Secrets 同期 + ステージ）→
-   `check_secrets.py`（ステージ差分の漏洩検査）を実行する。
-2. **`review.yml`**: PR と main で `review_sanitization.py` を実行し、必須ステータスチェックにする。
-3. **`deploy.yml`**: main マージで `render.py` → OIDC ログイン（`azure/login@v2`）→ `deploy.py`。
-   `environment: production` の承認ゲートを付ける。
-4. GitHub Secrets には `.env` の秘匿値一式に加え、OIDC 用の `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` を登録する。
+### Step 10: CI/CD と秘匿化ゲートを有効化する（本格実装のみ）
+
+Git ホスティングに依存しない共通部分と、ホスティング別の定義を分けて考える。
+
+1. **pre-commit（共通）**: `sanitize.py`（実値 → `${VAR}` 化 + シークレット同期 + ステージ）→
+   `check_secrets.py`（ステージ差分の漏洩検査）を実行する。どちらも Git ホスティングに依存しない。
+2. **秘匿化ゲート（共通）**: PR と既定ブランチで `review_sanitization.py` を実行し、**必須チェック**にする
+   （GitHub: 必須ステータスチェック / Azure DevOps: ブランチポリシーのビルド検証）。
+3. **品質ゲート（共通）**: Agent Evals を実行し、合格した場合のみデプロイに進む。
+4. **デプロイ（ホスティング別）**: 既定ブランチへのマージで `render.py` → Azure へ OIDC / ワークロード ID ログイン
+   → `deploy.py`。承認ゲート（GitHub: `environment` / Azure DevOps: Environment の承認）を付ける。
+5. **シークレット同期**: `SECRET_BACKEND` に応じて `sanitize.py --set-secrets` の送信先が切り替わる。
+
+```powershell
+# GitHub Actions Secrets へ同期
+python scripts/sanitize.py --env .env --set-secrets --secret-backend github --stage
+# Azure DevOps の変数グループへ同期
+python scripts/sanitize.py --env .env --set-secrets --secret-backend azure-devops --stage
+# Azure Key Vault へ同期（その他 Git ホスティング）
+python scripts/sanitize.py --env .env --set-secrets --secret-backend keyvault --stage
+```
+
+CI 定義の雛形と認証・必須チェック設定の差異は [references/ci-providers.md](references/ci-providers.md) を参照する。
 
 ```mermaid
 flowchart TD
     A[ローカル編集] --> B[git commit]
-    B -->|pre-commit| C[汎用化 + Secrets 同期 + 漏洩検査]
+    B -->|pre-commit| C[汎用化 + シークレット同期 + 漏洩検査]
     C --> D[PR]
     D --> E[sanitization-review]
-    E -->|Pass| F[main マージ]
-    F --> G[deploy.yml: 承認後 create_version]
-    G --> H[常に最新を使用 → Teams / M365 Copilot へ自動配信]
+    E --> F[Agent Evals]
+    F -->|Pass| G[既定ブランチへマージ]
+    G --> H[CI: 承認後に create_version]
+    H --> I[常に最新を使用 → Teams / M365 Copilot へ自動配信]
 ```
 
-### Step 10: 検証する
+### Step 11: 検証する
 
 ```powershell
 python scripts/review_sanitization.py       # Pass であること
@@ -227,21 +294,33 @@ git status --short                          # .env / agent.yaml / *.zip が未�
 
 ## 検証チェックリスト
 
+### 共通（ライト実装も必須）
+
+- [ ] Step 0 で**ライト実装 / 本格実装**を確定し、`.env` の `IMPLEMENTATION_MODE` に反映した
 - [ ] `.env` / `agents/**/agent.yaml` / `teams/*.zip` / `a365.generated.config.json` が追跡されていない
 - [ ] `agent.template.yaml` / `*.template.json` に実 GUID・ARM パス・接続文字列が無い（`${VAR}` 化済み）
 - [ ] `.env.example` にすべての変数がプレースホルダー付きで定義されている
 - [ ] `AGENT_NAME` / `BLUEPRINT_ID` 等の公開識別子が `NON_SECRET_VARS` に入っている
 - [ ] Foundry ブループリントと Agent 365 ブループリントを取り違えていない
-- [ ] インスタンス化する場合、manifest に `agenticUserTemplates` と `functionsAs: agenticUserOnly` がある
 - [ ] Teams 再アップロード前に `TEAMS_APP_VERSION` を上げた
 - [ ] アイコン元画像がアルファチャンネル付きの正方形 PNG
-- [ ] `review_sanitization.py` が Pass、`deploy.yml` に承認ゲートがある
 - [ ] Teams / M365 Copilot での動作確認が済んでいる
+
+### 本格実装のみ
+
+- [ ] private リポジトリで運用している（GitHub / Azure DevOps Repos / その他 Git）
+- [ ] `GIT_PROVIDER` / `SECRET_BACKEND` が Step 0 の選択と一致している
+- [ ] インスタンス化する場合、manifest に `agenticUserTemplates` と `functionsAs: agenticUserOnly` がある
+- [ ] `review_sanitization.py` が Pass、必須チェックに登録されている
+- [ ] Agent Evals が CI に組み込まれ、合格時のみデプロイされる
+- [ ] デプロイに承認ゲートがある
 
 ## 参考リンク
 
+- [ライト実装（PoC）クイックスタート](references/poc-quickstart.md)
+- [CI / Git ホスティング別の構成（GitHub / Azure DevOps / その他）](references/ci-providers.md)
 - [アーキテクチャ（2 種類のブループリント・スキーマ選択）](references/architecture.md)
 - [Agent 365 CLI 運用（Windows / WAM / 権限）](references/a365-cli.md)
-- [リポジトリ scaffold（.gitignore / hook / workflows）](references/repo-scaffold.md)
+- [リポジトリ scaffold（.gitignore / hook / CI）](references/repo-scaffold.md)
 - [異常系・トラブルシュート](references/troubleshooting.md)
 - [環境変数サンプル](references/.env.example)

--- a/.github/skills/agent365/references/.env.example
+++ b/.github/skills/agent365/references/.env.example
@@ -4,6 +4,15 @@
 値は `scripts/*.py` が引数未指定時のデフォルトとして参照する。
 
 ```dotenv
+# === 実装ルートと CI のルーティング（非秘匿）===
+# poc  = ライト実装（CI/CD なし、共有エージェント）
+# full = 本格実装（private リポジトリ + CI/CD + インスタンス化）
+IMPLEMENTATION_MODE=poc
+# github | azure-devops | other
+GIT_PROVIDER=github
+# github | azure-devops | keyvault | none（poc は none）
+SECRET_BACKEND=none
+
 # === Azure / Foundry プロジェクト（秘匿）===
 # 取得元: az account show --query id / Foundry プロジェクトの概要ページ
 AZURE_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000
@@ -59,17 +68,31 @@ TEAMS_APP_RESOURCE_URI=api://www.example.com
 # create_instance.py の manifest モードで使うテンプレート ID
 # AGENT_TEMPLATE_ID=your-agent-template-id
 
-# === CI の Azure OIDC ログイン（GitHub Secrets 専用 / .env では未使用）===
-# フェデレーション資格情報を設定したアプリ登録
+# === CI の Azure ログイン（シークレットストア専用 / .env では未使用）===
+# GitHub Actions: フェデレーション資格情報を設定したアプリ登録
 # AZURE_CLIENT_ID=00000000-0000-0000-0000-000000000000
+
+# === Azure DevOps Repos を使う場合（SECRET_BACKEND=azure-devops）===
+# 取得元: 組織の URL / プロジェクト名
+# AZDO_ORG_URL=https://dev.azure.com/your-organization
+# AZDO_PROJECT=your-project
+# 取得元: az pipelines variable-group create --name agent365 --authorize true の id
+# AZDO_VARIABLE_GROUP_ID=1
+# ワークロード ID フェデレーションで作成した ARM サービス接続名
+# AZDO_SERVICE_CONNECTION=your-azure-service-connection
+
+# === その他 Git ホスティングを使う場合（SECRET_BACKEND=keyvault）===
+# 取得元: az keyvault create で作成したボールト名
+# AZURE_KEYVAULT_NAME=your-keyvault
 ```
 
 ## 秘匿区分
 
 | 区分 | 変数 | 扱い |
 |---|---|---|
-| 秘匿 | `AZURE_*` / `FOUNDRY_PROJECT_ENDPOINT` / `*_PRINCIPAL_ID` / `*_CLIENT_ID` / `AGENT_GUID` / `A365_AGENT_BLUEPRINT_ID` / `AZURE_BOT_NAME` | `.env` と GitHub Secrets のみ。テンプレートでは `${VAR}` |
+| 秘匿 | `AZURE_*`（`AZURE_KEYVAULT_NAME` を除く） / `FOUNDRY_PROJECT_ENDPOINT` / `*_PRINCIPAL_ID` / `*_CLIENT_ID` / `AGENT_GUID` / `A365_AGENT_BLUEPRINT_ID` / `AZURE_BOT_NAME` | `.env` と CI のシークレットストアのみ。テンプレートでは `${VAR}` |
 | 非秘匿 | `AGENT_NAME` / `BLUEPRINT_ID` / `TEAMS_APP_VERSION` / `AGENT_DISPLAY_NAME` / `AGENT_FULL_NAME` / `AGENT_DESCRIPTION_*` / `DEVELOPER_*` / `TEAMS_APP_RESOURCE_URI` | `scripts/sanitize.py` と `check_secrets.py` の `NON_SECRET_VARS` に登録し、置換対象から除外する |
+| ルーティング設定 | `IMPLEMENTATION_MODE` / `GIT_PROVIDER` / `SECRET_BACKEND` / `AZDO_*` / `AZURE_KEYVAULT_NAME` | 「秘匿値をどこへ送るか」を決める値。`BACKEND_CONFIG_VARS` に登録し、置換も同期もしない |
 
 非秘匿値を置換対象に含めると、`AGENT_NAME` のような短い文字列が
 manifest の散文中で誤って `${AGENT_NAME}` に置き換わり、テンプレートが壊れる。

--- a/.github/skills/agent365/references/ci-providers.md
+++ b/.github/skills/agent365/references/ci-providers.md
@@ -1,0 +1,176 @@
+# CI / Git ホスティング別の構成
+
+本格実装（本番運用）で使う。**エージェント定義とスクリプトは Git ホスティングに依存しない**ため、
+差し替えるのは「CI 定義」と「シークレット保管先」の 2 つだけ。
+
+| Git ホスティング | CI 定義の置き場 | シークレット保管先 | `SECRET_BACKEND` | 追加ツール |
+|---|---|---|---|---|
+| GitHub（private） | `.github/workflows/` | GitHub Actions Secrets | `github` | GitHub CLI（`gh`） |
+| Azure DevOps Repos（private） | `.azuredevops/` | 変数グループ（Key Vault 連携可） | `azure-devops` | `az extension add --name azure-devops` |
+| その他 Git（GitLab / Bitbucket / 自己ホスト） | 各 CI の規約に従う | Azure Key Vault | `keyvault` | Azure CLI のみ |
+
+ホスティングに依存しない共通部品:
+
+- `.githooks/pre-commit`（`sanitize.py` → `check_secrets.py`）
+- `scripts/review_sanitization.py`（Git の追跡状態とテンプレートのみを見る）
+- `scripts/render.py` / `scripts/deploy.py`（環境変数だけを見る）
+
+---
+
+## 1. GitHub（private リポジトリ）
+
+`.github/workflows/review.yml` と `.github/workflows/deploy.yml` は
+[repo-scaffold.md](repo-scaffold.md) の内容をそのまま使う。設定のポイントは 3 点。
+
+1. `review.yml` の `sanitization-review` ジョブを**必須ステータスチェック**にする
+   （Settings > Branches > Branch protection rules）。
+2. `deploy.yml` に `environment: production` を付け、Environment に**必須レビュアー**を設定する。
+3. Azure へのログインは OIDC（`azure/login@v2` + フェデレーション資格情報）を使い、
+   クライアントシークレットを保管しない。
+
+```powershell
+python scripts/sanitize.py --env .env --set-secrets --secret-backend github --stage
+# 別リポジトリへ送る場合
+python scripts/sanitize.py --env .env --set-secrets --secret-backend github --repo <owner>/<repo>
+```
+
+---
+
+## 2. Azure DevOps Repos（private リポジトリ）
+
+### 2.1 事前準備
+
+```powershell
+az extension add --name azure-devops
+az devops configure --defaults organization=$env:AZDO_ORG_URL project=$env:AZDO_PROJECT
+az devops login   # または AZURE_DEVOPS_EXT_PAT 環境変数に PAT を設定
+
+# シークレット同期先の変数グループを 1 度だけ作る（--authorize true でパイプラインから参照可能に）
+az pipelines variable-group create --name agent365 --variables PLACEHOLDER=init --authorize true
+```
+
+出力された変数グループ ID を `.env` の `AZDO_VARIABLE_GROUP_ID` に設定する。
+
+- **サービス接続**: Azure Resource Manager のサービス接続を
+  **ワークロード ID フェデレーション**で作成する（シークレット不要）。名前を `AZDO_SERVICE_CONNECTION` に設定する。
+  そのサービスプリンシパルに Foundry プロジェクトへのロール（Azure AI Developer / Cognitive Services User 等）を付与する。
+- **必須チェック**: リポジトリ > ブランチ > 既定ブランチ > ブランチ ポリシー >
+  **ビルド検証**に review パイプラインを追加する（GitHub の必須ステータスチェックに相当）。
+- **承認ゲート**: Pipelines > Environments > `production` > 承認とチェック に承認者を追加する。
+
+### 2.2 `.azuredevops/azure-pipelines.yml`
+
+```yaml
+trigger:
+  branches:
+    include: [ main ]
+  paths:
+    include:
+      - agents/*
+      - scripts/*
+      - requirements.txt
+pr:
+  branches:
+    include: [ main ]
+
+variables:
+  - group: agent365          # 変数グループ（秘匿値。Key Vault 連携も可）
+
+pool:
+  vmImage: ubuntu-latest
+
+stages:
+  - stage: review
+    displayName: Sanitization / quality gate
+    jobs:
+      - job: gate
+        steps:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.12'
+          - script: python scripts/review_sanitization.py
+            displayName: Sanitization / generalization gate
+          - script: |
+              pip install -r requirements.txt
+              python scripts/run_agent_evals.py --report evals-report.json
+            displayName: Agent Evals
+            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
+  - stage: deploy
+    displayName: Deploy new agent version
+    dependsOn: review
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+    jobs:
+      - deployment: deploy
+        environment: production      # 承認ゲート
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
+                - task: UsePythonVersion@0
+                  inputs:
+                    versionSpec: '3.12'
+                - script: pip install -r requirements.txt
+                  displayName: Install dependencies
+                - script: python scripts/render.py --agent "$(AGENT_NAME)"
+                  displayName: Render agent manifest
+                - task: AzureCLI@2
+                  displayName: Create new agent version
+                  inputs:
+                    azureSubscription: $(AZDO_SERVICE_CONNECTION)   # ワークロード ID フェデレーション
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: python scripts/deploy.py --agent "$(AGENT_NAME)"
+```
+
+> `run_agent_evals.py` は Agent Evals をテーマ側で実装するときのエントリポイント名。
+> 品質ゲートを使わない場合はこのステップを削除する（秘匿化ゲートは削除しない）。
+
+### 2.3 シークレット同期
+
+```powershell
+python scripts/sanitize.py --env .env --set-secrets --secret-backend azure-devops --stage
+```
+
+`.env` の `AZDO_ORG_URL` / `AZDO_PROJECT` / `AZDO_VARIABLE_GROUP_ID` を使って
+変数グループの各変数を `--secret true` で更新する（存在しない変数は追加される）。
+
+---
+
+## 3. その他の Git ホスティング（GitLab / Bitbucket / 自己ホスト）
+
+CI 定義は各サービスの規約に従い、**シークレットは Azure Key Vault に一元化**する。
+CI ランナーはワークロード ID フェデレーション（または管理 ID）で Key Vault からのみ値を取得する。
+
+```powershell
+python scripts/sanitize.py --env .env --set-secrets --secret-backend keyvault --stage
+```
+
+- Key Vault のシークレット名は英数字とハイフンのみ。`sanitize.py` が
+  `AZURE_TENANT_ID` → `AZURE-TENANT-ID` のように自動変換する。
+- CI 側では取得した値を環境変数へ戻してから `render.py` / `deploy.py` を実行する。
+
+```bash
+# 例: 実行前に Key Vault から .env 相当を復元する
+for name in AGENT-NAME AZURE-SUBSCRIPTION-ID FOUNDRY-PROJECT-ENDPOINT; do
+  value=$(az keyvault secret show --vault-name "$AZURE_KEYVAULT_NAME" --name "$name" --query value -o tsv)
+  export "${name//-/_}=$value"
+done
+python scripts/render.py --agent "$AGENT_NAME"
+python scripts/deploy.py --agent "$AGENT_NAME"
+```
+
+パイプラインの最低条件は次の 3 つ。これを満たせばホスティングは問わない。
+
+1. PR で `python scripts/review_sanitization.py` が実行され、失敗でマージがブロックされる。
+2. 既定ブランチへのマージ後に**承認**を挟んでから `deploy.py` が動く。
+3. 秘匿値がリポジトリではなくシークレットストアにのみ存在する。
+
+---
+
+## 4. private リポジトリを前提にする理由
+
+エージェント定義（`agent.template.yaml` の `instructions`）は**業務知識そのもの**であり、
+テンプレート化しても秘匿性が残る。`${VAR}` 化は「認証情報の漏洩防止」であって
+「業務ロジックの公開可否」とは別問題のため、本格実装では常に private リポジトリを使う。

--- a/.github/skills/agent365/references/poc-quickstart.md
+++ b/.github/skills/agent365/references/poc-quickstart.md
@@ -1,0 +1,100 @@
+# ライト実装（PoC）クイックスタート
+
+「まず Teams で動かして価値を検証する」ための最短ルート。
+CI/CD・インスタンス化・シークレットストア連携を**あえて作らない**ことで、構成要素を最小に保つ。
+
+## 前提
+
+| 項目 | 値 |
+|---|---|
+| 公開形態 | 共有エージェント（`agenticUserTemplates` なし。全ユーザーが同じ 1 体を使う） |
+| リポジトリ | 任意（ローカルのみでも可。private/public いずれでもよい） |
+| シークレット | ローカル `.env` のみ（`SECRET_BACKEND=none`） |
+| デプロイ | ローカルから手動実行 |
+| 追加ツール | `a365` CLI は不要（Step 6 を省略するため） |
+
+`.env` に最低限これだけを設定する。
+
+```dotenv
+IMPLEMENTATION_MODE=poc
+SECRET_BACKEND=none
+AGENT_NAME=your-agent
+BLUEPRINT_ID=your-agent
+AZURE_SUBSCRIPTION_ID=...
+AZURE_RESOURCE_GROUP=...
+AZURE_TENANT_ID=...
+FOUNDRY_PROJECT_ENDPOINT=https://<account>.services.ai.azure.com/api/projects/<project>
+```
+
+> `A365_AGENT_BLUEPRINT_ID` は**設定しない**。未設定なら `build_teams_package.py` が
+> 自動的に GA スキーマの共有エージェント用パッケージを生成する。
+
+## 手順（SKILL.md の Step 6 と Step 10 を省略）
+
+```powershell
+# Step 2: 最小 scaffold（.githooks/ と CI 定義は作らない）
+Copy-Item .github/skills/agent365/scripts -Destination scripts -Recurse
+New-Item -ItemType Directory -Force agents/$env:AGENT_NAME, teams, assets | Out-Null
+Copy-Item .github/skills/agent365/references/templates/agent.template.yaml agents/$env:AGENT_NAME/
+Copy-Item .github/skills/agent365/references/templates/manifest.template.json teams/
+Copy-Item .github/skills/agent365/references/.env.example .env.example
+pip install -r requirements.txt
+
+# Step 3: .env を用意して az login
+Copy-Item .env.example .env    # 実値を記入
+az login
+
+# Step 4: Foundry のマネージド ID ブループリント
+python scripts/create_blueprint.py --name $env:BLUEPRINT_ID
+python scripts/create_blueprint.py --name $env:BLUEPRINT_ID --show   # 出力値を .env へ
+
+# Step 5: エージェントを作成 / 更新
+python scripts/render.py --agent $env:AGENT_NAME
+python scripts/create_instance.py --name $env:AGENT_NAME --mode blueprint --blueprint-id $env:BLUEPRINT_ID
+python scripts/deploy.py --agent $env:AGENT_NAME   # 2 回目以降
+
+# Step 7: Bot Service + Teams チャネル
+az bot create --resource-group $env:AZURE_RESOURCE_GROUP --name $env:AZURE_BOT_NAME `
+  --app-type SingleTenant --appid $env:INSTANCE_IDENTITY_CLIENT_ID --tenant-id $env:AZURE_TENANT_ID `
+  --endpoint "$env:FOUNDRY_PROJECT_ENDPOINT/agents/$env:AGENT_NAME/endpoint/protocols/activityprotocol?api-version=2025-11-15-preview" `
+  --sku S1
+az bot msteams create --resource-group $env:AZURE_RESOURCE_GROUP --name $env:AZURE_BOT_NAME
+
+# Step 8: Teams パッケージ（共有エージェント）
+python scripts/build_teams_package.py
+
+# Step 9: 生成された ZIP をアップロードして公開
+```
+
+## PoC でも省略しないこと
+
+`.gitignore` だけは必ず配置する。CI が無くても**実値の混入は起きる**ため、
+最低限これらを追跡対象から外す。
+
+```gitignore
+.env
+agents/**/agent.yaml
+teams/*.zip
+a365.generated.config.json
+*token-cache*
+```
+
+コミット前に一度だけ手で確認する（フックが無いので自動実行されない）。
+
+```powershell
+git status --short                      # .env / agent.yaml / *.zip が未追跡であること
+python scripts/check_secrets.py --env .env
+```
+
+## 本格実装への昇格
+
+PoC の成果物はそのまま流用できる。追加するのは**次の 2 Step だけ**で、
+エージェント定義・Teams パッケージ・スクリプトの作り直しは発生しない。
+
+| 追加する Step | やること |
+|---|---|
+| Step 6 | `a365 setup blueprint` で Agent 365 ブループリントを作成し、`A365_AGENT_BLUEPRINT_ID` を `.env` へ。<br>`teams/agenticUser.template.json` を追加して再ビルド（`TEAMS_APP_VERSION` を上げる） |
+| Step 10 | private リポジトリへ移し、`.githooks/pre-commit` と CI 定義を配置。<br>`SECRET_BACKEND` を `github` / `azure-devops` / `keyvault` に変更して `sanitize.py --set-secrets` を実行 |
+
+> 昇格時は共有エージェント → インスタンス化エージェントへ公開形態が変わるため、
+> Teams 側で**アプリを入れ直す**必要がある（manifest の `manifestVersion` が GA → devPreview に変わる）。

--- a/.github/skills/agent365/references/repo-scaffold.md
+++ b/.github/skills/agent365/references/repo-scaffold.md
@@ -1,6 +1,15 @@
 # リポジトリ scaffold
 
-Step 1 で配置するファイル一式。テーマ固有の値はすべて `.env` から解決する。
+Step 2 で配置するファイル一式。テーマ固有の値はすべて `.env` から解決する。
+
+| ファイル | ライト実装（PoC） | 本格実装 |
+|---|---|---|
+| `requirements.txt` / `.gitignore` | 必須 | 必須 |
+| `.githooks/pre-commit` | 不要 | 必須 |
+| CI 定義（GitHub Actions / Azure Pipelines / その他） | 不要 | 必須（→ [ci-providers.md](ci-providers.md)） |
+| `.github/copilot-instructions.md`（レビュー観点） | 任意 | 推奨 |
+
+ライト実装の手順は [poc-quickstart.md](poc-quickstart.md) を参照。
 
 ## requirements.txt
 
@@ -46,20 +55,23 @@ Thumbs.db
 
 ## .githooks/pre-commit
 
-`git config core.hooksPath .githooks` で有効化する。
+本格実装のみ。`git config core.hooksPath .githooks` で有効化する。
+Git ホスティングには依存せず、送信先は `.env` の `SECRET_BACKEND` で切り替わる。
 
 ```sh
 #!/bin/sh
 set -e
 
-# 1. 実値入り manifest を汎用化し、GitHub Secrets へ同期してテンプレートをステージ
+# 1. 実値入り manifest を汎用化し、SECRET_BACKEND のストアへ同期してテンプレートをステージ
 python scripts/sanitize.py --env .env --set-secrets --stage
 
 # 2. ステージ済み差分に実値が残っていないか検査（残っていればコミット中止）
 python scripts/check_secrets.py --env .env
 ```
 
-## .github/workflows/review.yml
+## .github/workflows/review.yml（GitHub の場合）
+
+> Azure DevOps Repos / その他 Git ホスティングの定義は [ci-providers.md](ci-providers.md) を参照。
 
 ```yaml
 name: review
@@ -86,7 +98,7 @@ jobs:
 
 このジョブを**必須ステータスチェック**に設定して merge をブロックする。
 
-## .github/workflows/deploy.yml
+## .github/workflows/deploy.yml（GitHub の場合）
 
 ```yaml
 name: deploy

--- a/.github/skills/agent365/scripts/check_secrets.py
+++ b/.github/skills/agent365/scripts/check_secrets.py
@@ -32,6 +32,19 @@ NON_SECRET_VARS = {
     "TEAMS_APP_RESOURCE_URI",
 }
 
+# Routing/configuration variables: they select the Git hosting and secret store
+# and legitimately appear in committed CI definitions. Keep in sync with sanitize.py.
+BACKEND_CONFIG_VARS = {
+    "IMPLEMENTATION_MODE",
+    "GIT_PROVIDER",
+    "SECRET_BACKEND",
+    "AZDO_ORG_URL",
+    "AZDO_PROJECT",
+    "AZDO_VARIABLE_GROUP_ID",
+    "AZDO_SERVICE_CONNECTION",
+    "AZURE_KEYVAULT_NAME",
+}
+
 # Obvious placeholder values shipped in .env.example.
 PLACEHOLDER_HINTS = ("0000-0000", "your-", "example.com", "<")
 
@@ -68,7 +81,7 @@ def main() -> int:
                         help="Additional variable to treat as public; repeatable.")
     args = parser.parse_args()
 
-    values = load_env_values(Path(args.env), NON_SECRET_VARS | set(args.non_secret))
+    values = load_env_values(Path(args.env), NON_SECRET_VARS | BACKEND_CONFIG_VARS | set(args.non_secret))
     if not values:
         return 0
 

--- a/.github/skills/agent365/scripts/sanitize.py
+++ b/.github/skills/agent365/scripts/sanitize.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
-"""Generalize + hide secrets in an agent manifest, then sync GitHub secrets.
+"""Generalize + hide secrets in an agent manifest, then sync them to a secret store.
 
 1. Read a source manifest that still contains real values
    (default: ``agents/<agent>/agent.yaml`` — kept local, git-ignored).
 2. For every NAME=VALUE pair in ``.env`` (excluding public identifiers), replace
    occurrences of VALUE in the manifest text with the ``${NAME}`` placeholder.
-3. Optionally push each VALUE to GitHub Actions secrets via ``gh secret set``.
+3. Optionally push each VALUE to the CI secret store selected by ``--secret-backend``
+   (``github`` / ``azure-devops`` / ``keyvault`` / ``none``). The backend is
+   independent of the Git hosting used, so the same scripts work on GitHub,
+   Azure DevOps Repos and any other Git server.
 4. Write the generalized result to the template and optionally ``git add`` it.
 
 Intended to run from the pre-commit hook so that only the generalized,
@@ -13,11 +16,13 @@ secret-free template is ever committed.
 
 Usage:
     python scripts/sanitize.py --env .env --set-secrets --stage
+    python scripts/sanitize.py --env .env --set-secrets --secret-backend azure-devops
 """
 from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -39,6 +44,24 @@ NON_SECRET_VARS = {
     "TEAMS_APP_RESOURCE_URI",
 }
 
+# Routing/configuration variables. They describe *where* secrets go, so they are
+# never substituted into the manifest and never pushed to the secret store.
+BACKEND_CONFIG_VARS = {
+    "IMPLEMENTATION_MODE",
+    "GIT_PROVIDER",
+    "SECRET_BACKEND",
+    "AZDO_ORG_URL",
+    "AZDO_PROJECT",
+    "AZDO_VARIABLE_GROUP_ID",
+    "AZDO_SERVICE_CONNECTION",
+    "AZURE_KEYVAULT_NAME",
+}
+
+SECRET_BACKENDS = ("github", "azure-devops", "keyvault", "none")
+
+# Key Vault secret names accept alphanumerics and dashes only.
+KEYVAULT_NAME_RE = re.compile(r"[^0-9A-Za-z-]")
+
 
 def load_env(env_path: Path, non_secret: set[str]) -> dict[str, str]:
     values: dict[str, str] = {}
@@ -55,11 +78,97 @@ def load_env(env_path: Path, non_secret: set[str]) -> dict[str, str]:
     return values
 
 
-def set_github_secret(name: str, value: str, repo: str | None) -> None:
-    cmd = ["gh", "secret", "set", name, "--body", value]
-    if repo:
-        cmd += ["--repo", repo]
+def env_value(env_path: Path, name: str) -> str | None:
+    """Read a single raw value from .env, falling back to the process environment."""
+    if env_path.is_file():
+        for raw in env_path.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if line.startswith(f"{name}="):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    return os.environ.get(name)
+
+
+def _run(cmd: list[str]) -> None:
     subprocess.run(cmd, check=True, shell=False)
+
+
+def set_github_secret(name: str, value: str, opts: dict[str, str]) -> None:
+    cmd = ["gh", "secret", "set", name, "--body", value]
+    if opts.get("repo"):
+        cmd += ["--repo", opts["repo"]]
+    _run(cmd)
+
+
+def set_azure_devops_secret(name: str, value: str, opts: dict[str, str]) -> None:
+    """Update (or add) a secret variable in an Azure DevOps variable group."""
+    tail = [
+        "--group-id", opts["group_id"],
+        "--organization", opts["org_url"],
+        "--project", opts["project"],
+        "--name", name,
+        "--value", value,
+        "--secret", "true",
+    ]
+    head = ["az", "pipelines", "variable-group", "variable"]
+    try:
+        _run([*head, "update", *tail])
+    except subprocess.CalledProcessError:
+        # Variable does not exist in the group yet.
+        _run([*head, "create", *tail])
+
+
+def set_keyvault_secret(name: str, value: str, opts: dict[str, str]) -> None:
+    kv_name = KEYVAULT_NAME_RE.sub("-", name)
+    _run([
+        "az", "keyvault", "secret", "set",
+        "--vault-name", opts["vault"],
+        "--name", kv_name,
+        "--value", value,
+        "--output", "none",
+    ])
+
+
+def resolve_backend(backend: str, env_path: Path, repo: str | None) -> tuple[str, dict[str, str]]:
+    """Validate the backend and collect its required options up front.
+
+    Failing here (instead of mid-loop) guarantees that a misconfigured backend can
+    never push half of the secrets and leave the rest behind.
+    """
+    if backend not in SECRET_BACKENDS:
+        raise SystemExit(f"sanitize: unknown --secret-backend '{backend}' (expected one of {', '.join(SECRET_BACKENDS)}).")
+
+    if backend == "github":
+        return backend, {"repo": repo or ""}
+
+    if backend == "azure-devops":
+        required = {
+            "org_url": "AZDO_ORG_URL",
+            "project": "AZDO_PROJECT",
+            "group_id": "AZDO_VARIABLE_GROUP_ID",
+        }
+        opts = {key: env_value(env_path, var) or "" for key, var in required.items()}
+        missing = sorted(required[key] for key, val in opts.items() if not val)
+        if missing:
+            raise SystemExit(
+                "sanitize: --secret-backend azure-devops requires AZDO_ORG_URL / AZDO_PROJECT / "
+                f"AZDO_VARIABLE_GROUP_ID in {env_path} (missing: {', '.join(missing)})."
+            )
+        return backend, opts
+
+    if backend == "keyvault":
+        vault = env_value(env_path, "AZURE_KEYVAULT_NAME") or ""
+        if not vault:
+            raise SystemExit(f"sanitize: --secret-backend keyvault requires AZURE_KEYVAULT_NAME in {env_path}.")
+        return backend, {"vault": vault}
+
+    return backend, {}
+
+
+SETTERS = {
+    "github": set_github_secret,
+    "azure-devops": set_azure_devops_secret,
+    "keyvault": set_keyvault_secret,
+}
 
 
 def main() -> int:
@@ -68,15 +177,20 @@ def main() -> int:
     parser.add_argument("--source", help="Manifest with real values (default: agents/<agent>/agent.yaml).")
     parser.add_argument("--template", help="Generalized output (default: agents/<agent>/agent.template.yaml).")
     parser.add_argument("--env", default=".env")
-    parser.add_argument("--repo", default=None, help="owner/repo for gh secret set")
+    parser.add_argument("--repo", default=None, help="owner/repo for the github backend")
+    parser.add_argument("--secret-backend", default=None, choices=SECRET_BACKENDS,
+                        help="Secret store to sync to (default: SECRET_BACKEND from --env, else github).")
     parser.add_argument("--non-secret", action="append", default=[], metavar="NAME",
                         help="Additional variable to exclude from substitution; repeatable.")
-    parser.add_argument("--set-secrets", action="store_true", help="push values to GitHub secrets")
+    parser.add_argument("--set-secrets", action="store_true", help="push values to the secret store")
     parser.add_argument("--stage", action="store_true", help="git add the generated template")
     args = parser.parse_args()
 
-    non_secret = NON_SECRET_VARS | set(args.non_secret)
+    non_secret = NON_SECRET_VARS | BACKEND_CONFIG_VARS | set(args.non_secret)
     env_path = Path(args.env)
+
+    backend = args.secret_backend or env_value(env_path, "SECRET_BACKEND") or "github"
+    backend, backend_opts = resolve_backend(backend, env_path, args.repo)
 
     agent = args.agent
     if not agent:
@@ -119,9 +233,13 @@ def main() -> int:
         print("sanitize: generalized values -> " + ", ".join(sorted(replaced)))
 
     if args.set_secrets:
-        for name in sorted(env_values):
-            set_github_secret(name, env_values[name], args.repo)
-        print("sanitize: synced GitHub secrets -> " + ", ".join(sorted(env_values)))
+        if backend == "none":
+            print("sanitize: SECRET_BACKEND=none (PoC mode) -> keeping secrets in .env only; nothing synced.")
+        else:
+            setter = SETTERS[backend]
+            for name in sorted(env_values):
+                setter(name, env_values[name], backend_opts)
+            print(f"sanitize: synced secrets to {backend} -> " + ", ".join(sorted(env_values)))
 
     if args.stage:
         subprocess.run(["git", "add", str(template_path)], check=True, shell=False)

--- a/.github/skills/architecture/SKILL.md
+++ b/.github/skills/architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture
-description: "Power Platform ソリューションの全体アーキテクチャを設計する。Copilot Studio / Power Automate / Code Apps / Power Pages / AI Builder の使い分け判断、コンポーネント選定、統合パターンを決定する。"
+description: "Power Platform ソリューションの全体アーキテクチャを設計する。Copilot Studio / Power Automate / Code Apps / Power Pages / AI Builder の使い分け判断、コンポーネント選定、統合パターンを決定する。Agent 365 / Foundry エージェントを採用する場合はライト実装（PoC）と本格実装（private リポジトリ + CI/CD + Agent Evals）を AskUserQuestion で選ばせ、Git ホスティング（GitHub / Azure DevOps Repos / その他）も確定してから実装へ進む。"
 category: architecture
 triggers:
   - "アーキテクチャ設計"
@@ -18,6 +18,10 @@ triggers:
   - "設計判断"
   - "どれを使う"
   - "使い分け"
+  - "Agent 365"
+  - "Foundry エージェント"
+  - "ライト実装か本格実装か"
+  - "PoC か本番か"
 ---
 
 # Power Platform 共通アーキテクチャデザインスキル
@@ -65,6 +69,7 @@ triggers:
 | **Dataverse**         | リレーショナルデータ、行レベルセキュリティ、監査、ビジネスルール                             | 大量ログデータ、非構造化データ、全文検索                       |
 | **Copilot Studio v2 スキル + Dataverse MCP** | 自然言語での業務データ登録・照会（Dataverse MCP 経由）、Teams / Copilot Studio 上での利用、SKILL.md による業務知識の付与。**環境制約が少なく作りやすい（★ 第一候補）** | リッチな一覧/編集 UI、複雑なビジュアル、外部/匿名公開 |
 | **Copilot Cowork プラグイン** | M365 Copilot 上での自然言語登録・照会（Dataverse MCP 経由）。M365 Copilot との統合が必須要件の場合に採用。**会社環境で Cowork の利用が許可されている場合のみ推奨** | 環境制約が多い（Entra App 登録・Teams 開発者ポータル・M365 管理センター公開・Teams Admin / Global Admin 権限が必要）。環境が揃わない場合は Copilot Studio v2 + Dataverse MCP を優先 |
+| **Agent 365 / Foundry エージェント** | Foundry 上のカスタムエンジンエージェントをコードファーストでバージョン管理し、Teams / M365 Copilot へ公開。インストールごとの専用 Entra Agent ID（★ §7: 採用時はライト/本格を必ず確認） | ノーコードでの素早い構築、Code Apps / Web への埋め込み、Dataverse 標準 UI |
 
 ---
 
@@ -113,9 +118,13 @@ triggers:
     │     （メール受信・Teams 返信・スケジュール等のイベントで自動実行、無人で判断・応答）
     │        ──→ 【Copilot Studio（Workflow / トリガー）+ Power Automate】（§3・§4 へ）
     │
-    └─ ③ アプリ（Code Apps / Web サイト）に組み込んで呼び出す
-          （画面内チャット・埋め込み・WebChat SDK での外部公開）
-             ──→ 【Copilot Studio v1】（§3 へ）
+    ├─ ③ アプリ（Code Apps / Web サイト）に組み込んで呼び出す
+    │     （画面内チャット・埋め込み・WebChat SDK での外部公開）
+    │        ──→ 【Copilot Studio v1】（§3 へ）
+    │
+    └─ ④ Foundry のカスタムエンジンエージェントとして Teams / M365 Copilot に公開する
+          （独自モデル・独自ツール・コードファーストのバージョン管理が要る）
+             ──→ 【Agent 365 / Foundry エージェント】（§7 へ）
 ```
 
 > **使い分けの原則**:
@@ -378,12 +387,66 @@ Q: その AI 処理は再利用するか？
 
 ---
 
+## 7. Agent 365 / Foundry エージェントを使う判断ポイント（★ 実装レベルを必ず確認）
 
-## 7. 統合パターン・テンプレート
+**使う**: Foundry 上のカスタムエンジンエージェント（独自モデル・独自ツール）を Teams / M365 Copilot に公開したい／
+エージェント定義をコードとしてバージョン管理・レビューしたい／インストールごとに専用の Entra Agent ID を持たせたい。
+**使わない**（→ 代替）: Dataverse への自然言語登録・照会が主目的 → **Copilot Studio v2 スキル + Dataverse MCP**（§2.1.1）／
+Code Apps や Web サイトに埋め込む → **Copilot Studio v1**（§3）。
+
+### ★ ライト実装 / 本格実装を AskUserQuestion で選ぶ（`agent365` スキルに入る前に必ず実行）
+
+`agent365` スキルは **本格実装（private リポジトリ + CI/CD + Agent Evals）を既定**としているが、
+検証目的の PoC にはその一式が重すぎる。**着手前に実装レベルを確認し、選んだ結果を `agent365` スキルへ引き渡す**。
+
+AskUserQuestion で次のように尋ねる:
+
+> Foundry エージェントの作り方を選べます。どちらにしますか？
+> - **ライト実装（PoC・検証用）**: 共有エージェントとして最短で Teams に公開する。ローカルの `.env` だけで動かし、
+>   CI/CD・秘匿化ゲート・インスタンス化は作らない。**あとから本格実装へ昇格できる**（作り直し不要）。
+> - **本格実装（本番運用）**: private リポジトリでエージェント定義をバージョン管理し、
+>   秘匿化ゲート・**Agent Evals** による品質ゲート・承認付き自動デプロイまでを CI/CD で構築する。
+>   インストールごとに専用の Entra Agent ID を持つインスタンス化エージェントとして公開する。
+
+| 観点 | ライト実装（PoC） | 本格実装（本番運用） |
+|---|---|---|
+| 公開形態 | 共有エージェント（全員が同じ 1 体） | インスタンス化（Agent 365 ブループリント + `agenticUserTemplates`） |
+| リポジトリ | 任意（ローカルのみでも可） | **private リポジトリ必須** |
+| 秘匿値 | ローカル `.env` のみ | `.env` + CI のシークレットストア |
+| 品質担保 | 手動での動作確認 | 秘匿化ゲート + Agent Evals + 承認ゲート |
+| 実施 Step | `agent365` スキルの Step 6・10 を省略 | 全 Step |
+
+> **迷ったらライト実装から始める**。エージェント定義・Teams パッケージ・スクリプトはそのまま流用でき、
+> Step 6（Agent 365 ブループリント）と Step 10（CI/CD）を追加するだけで本格実装へ移行できる。
+
+### 本格実装を選んだ場合: Git ホスティングも AskUserQuestion で確認する
+
+**GitHub 前提にしない**。エージェント定義（`instructions`）は業務知識そのものなので private リポジトリを前提とし、
+利用中の Git ホスティングに合わせて CI とシークレット保管先を決める。
+
+> どの Git リポジトリで管理しますか？（いずれも private リポジトリ前提です）
+> - **GitHub（private）**
+> - **Azure DevOps Repos（private）**
+> - **その他の Git**（GitLab / Bitbucket / 自己ホスト）
+
+| Git ホスティング | CI | シークレット保管先 | `agent365` の `SECRET_BACKEND` |
+|---|---|---|---|
+| GitHub（private） | GitHub Actions | GitHub Actions Secrets | `github` |
+| Azure DevOps Repos（private） | Azure Pipelines | 変数グループ（Key Vault 連携可） | `azure-devops` |
+| その他 Git | 各 CI | Azure Key Vault | `keyvault` |
+| （ライト実装） | なし | ローカル `.env` のみ | `none` |
+
+> 選択結果は `agent365` スキルの Step 0 でそのまま使う（同じ質問を繰り返さない）。
+> 構築手順は [`agent365` スキル](../agent365/SKILL.md)、CI 定義の雛形は
+> [agent365/references/ci-providers.md](../agent365/references/ci-providers.md) を参照。
+
+---
+
+## 8. 統合パターン・テンプレート
 
 統合アーキテクチャパターン集・設計アウトプットテンプレート・よくある判断ミスは [設計リファレンス](references/design-patterns.md) を参照。
 
-## 8. 判断チェックリスト（設計開始時に確認）
+## 9. 判断チェックリスト（設計開始時に確認）
 
 設計を始める前に、以下を順番に確認する:
 
@@ -398,4 +461,6 @@ Q: その AI 処理は再利用するか？
 - [ ] **応答文の生成が必要か？** → YES なら Copilot Studio
 - [ ] **外部トリガー（メール/スケジュール）でエージェントを起動するか？** → YES なら Power Automate + Copilot Studio
 - [ ] **複数エージェント/フローから共用する AI 処理があるか？** → YES かつ Power Automate フロー内での利用なら AI Builder で共通化（社内汎用業務は Copilot Studio v2 + Dataverse MCP を優先）
+- [ ] **Foundry のカスタムエンジンエージェントを Teams / M365 Copilot に公開するか？** → YES なら §7 で **ライト実装（PoC）/ 本格実装** を AskUserQuestion で確定してから `agent365` スキルへ渡す
+- [ ] **本格実装を選んだか？** → YES なら **Git ホスティング（GitHub / Azure DevOps Repos / その他 Git）** も確認し、private リポジトリ前提で `SECRET_BACKEND` を決める
 - [ ] **画面設計はブロックの組み合わせで決めたか？** → 同じ CRUD をテーブル数だけ量産しない。可視化ニーズがあれば **ReactFlow を第一候補**に（[設計リファレンス §4](references/design-patterns.md#4-画面設計ブロックの組み合わせテンプレ化しない設計)）


### PR DESCRIPTION
## 目的

`agent365` スキルは **Agent Evals + GitHub Actions による CI/CD** を前提とした本格実装ルートしか用意しておらず、
「まず Teams で動かして価値を検証したい」PoC には重すぎた。また CI/CD が GitHub 前提で、
Azure DevOps Repos 等の **GitHub 以外の Git ホスティング**では流用できなかった。

本 PR で次の 2 点に対応する。

1. **ライト実装（PoC）ルートの追加** — `architecture` スキルの AskUserQuestion で
   「ライト実装 / 本格実装」を選んでから着手できるようにする。
2. **本格実装の Git ホスティング非依存化** — GitHub / Azure DevOps Repos / その他 Git の
   **private リポジトリ**に対応する。

## 変更点

### `architecture` スキル

- **§7 を新設**: 「Agent 365 / Foundry エージェントを使う判断ポイント（★ 実装レベルを必ず確認）」
  - `agent365` スキルに入る**前に** AskUserQuestion で **ライト実装（PoC）/ 本格実装**を確定する。
  - 本格実装を選んだ場合は続けて **Git ホスティング**（GitHub / Azure DevOps Repos / その他 Git）を確認し、
    CI とシークレット保管先（`SECRET_BACKEND`）まで決めてから `agent365` スキルへ引き渡す。
  - 選択結果は `agent365` の Step 0 でそのまま使い、同じ質問を繰り返さない。
- 既存 §7（統合パターン）→ §8、§8（判断チェックリスト）→ §9 に繰り下げ。
- §2.1.1 の対話型分岐に ④ Foundry カスタムエンジンエージェント（→ §7）を追加。
- コンポーネント早見表に Agent 365 / Foundry エージェントの行を追加。判断チェックリストに 2 項目追加。

### `agent365` スキル

- **Step 0「実装レベルとリポジトリ形態を決める」を新設**し、既存 Step を 1 つずつ繰り下げ（Step 0〜11、整数連番を維持）。
- ライト実装は **Step 6（Agent 365 ブループリント）と Step 10（CI/CD）を省略**する最短ルート。
  検証後は**その 2 Step を追加するだけ**で本格実装へ昇格でき、エージェント定義・Teams パッケージの作り直しは不要。
- Step 10 を Git ホスティング非依存の記述に変更（共通部分＝pre-commit / 秘匿化ゲート / Agent Evals、
  ホスティング別＝CI 定義と承認ゲート）。

### スクリプト

- `scripts/sanitize.py`: `--secret-backend {github,azure-devops,keyvault,none}` を追加。
  - `azure-devops` は変数グループの変数を `--secret true` で update（無ければ create）。
  - `keyvault` は Key Vault の命名規則に合わせて `AZURE_TENANT_ID` → `AZURE-TENANT-ID` に自動変換。
  - `none` は PoC 用（`.env` のみ・同期しない）。
  - **恒久的な事前チェック**: バックエンド必須オプションの不足を**同期ループに入る前に**検出して中止する
    （途中まで同期して残りが欠ける状態を構造的に起こせなくする）。
- `scripts/check_secrets.py`: `BACKEND_CONFIG_VARS`（`GIT_PROVIDER` / `SECRET_BACKEND` / `AZDO_*` /
  `AZURE_KEYVAULT_NAME` 等）を漏洩検査の対象外に。CI 定義に正当に現れる値での誤検知を防ぐ。

### references

- `references/poc-quickstart.md`（新規）: PoC 最短手順、PoC でも省略しない `.gitignore` と手動チェック、本格実装への昇格手順。
- `references/ci-providers.md`（新規）: GitHub / Azure DevOps / その他 Git 別の CI 定義。
  Azure Pipelines の `azure-pipelines.yml` 雛形（変数グループ + ワークロード ID フェデレーション + Environment 承認）、
  Key Vault 運用、ホスティングを問わず満たすべきパイプラインの最低条件 3 点。
- `references/repo-scaffold.md`: ライト/本格でどのファイルが必要かの対比表を追加、GitHub 固有部分を明示。
- `references/.env.example`: `IMPLEMENTATION_MODE` / `GIT_PROVIDER` / `SECRET_BACKEND` / `AZDO_*` /
  `AZURE_KEYVAULT_NAME` を追加し、秘匿区分表に「ルーティング設定」区分を追加。

### カタログ

- `.github/skills/README.md` の `architecture` / `agent365` の説明を更新。

## 検証

```powershell
python .github/skills/update-skills/scripts/validate_skill.py .github/skills/agent365     # OK
python .github/skills/update-skills/scripts/validate_skill.py .github/skills/architecture # OK
python -m py_compile .github/skills/agent365/scripts/sanitize.py .github/skills/agent365/scripts/check_secrets.py
```

- Step 番号は 0〜11 の整数連番（`validate_skill.py` で確認）。
- 秘匿情報スキャン ✅（実 GUID / 実 URL / メール / シークレットなし。プレースホルダーのみ）。
- `sanitize.py` のバックエンド検証を実機で確認（`azure-devops` / `keyvault` の必須値不足で exit 1、
  未知のバックエンドは argparse で拒否、`none` は no-op）。

## マージ順

既存のオープン PR（#293 / #294）は `code-apps` スキルのみを変更しており、本 PR とファイルの重複はない。
**マージ順の制約なし**（独立してマージ可能）。

## 後方互換

- `sanitize.py --set-secrets` を従来どおり引数なしで呼ぶと、`SECRET_BACKEND` 未設定時は `github` にフォールバックする
  （既存の `.githooks/pre-commit` はそのまま動作する）。
- 既存の GitHub Actions 用 workflow 定義（`repo-scaffold.md`）は変更していない。
