### PR TITLE
fix(code-apps): pre-deploy-check.mjs のルート解決とパス比較を修正

### DIFF
--- a/.github/skills/code-apps/scripts/pre-deploy-check.mjs
+++ b/.github/skills/code-apps/scripts/pre-deploy-check.mjs
@@ -4,17 +4,21 @@
  * pac code push / npx power-apps push の前に実行し、
  * テーマ固有のカスタマイズが行われていることを確認する。
  *
- * Usage: node .github/skills/code-apps/scripts/pre-deploy-check.mjs
- * npm script: "predeploy": "node .github/skills/code-apps/scripts/pre-deploy-check.mjs"
+ * このファイルはプロジェクト直下の scripts/ にコピーして使う。
+ * Usage: node scripts/pre-deploy-check.mjs
+ * npm script: "predeploy": "node scripts/pre-deploy-check.mjs"
  */
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
-const root = path.resolve(path.dirname(__filename), "../../../..");
+// scripts/ の一つ上がプロジェクトルート
+const root = path.resolve(path.dirname(__filename), "..");
 
 const errors = [];
+// config.ts は "/dashboard"、router.tsx の子ルートは "dashboard" と書くため先頭スラッシュを揃える
+const norm = (p) => p.replace(/^\//, "");
 
 // 1. .env が存在するか
 const envPath = path.join(root, ".env");
@@ -68,11 +72,11 @@ if (fs.existsSync(configTs) && fs.existsSync(routerPath)) {
   }
 
   // 4b. config.ts からナビパスを抽出: path: "xxx"
-  const navPaths = [...configContent.matchAll(/path:\s*["']([^"']+)["']/g)].map(m => m[1]);
+  const navPaths = [...configContent.matchAll(/path:\s*["']([^"']+)["']/g)].map(m => norm(m[1]));
 
   // router.tsx からルートパスを抽出: path: "xxx"（コメント行を除外）
   const routerLines = routerContent.split("\n").filter(l => !l.trim().startsWith("//"));
-  const routePaths = [...routerLines.join("\n").matchAll(/path:\s*["']([^"']+)["']/g)].map(m => m[1]);
+  const routePaths = [...routerLines.join("\n").matchAll(/path:\s*["']([^"']+)["']/g)].map(m => norm(m[1]));
 
   // ナビにあるがルーターに無いパス → 孤立メニュー
   const orphanedNav = navPaths.filter(p => !routePaths.includes(p));
@@ -84,7 +88,7 @@ if (fs.existsSync(configTs) && fs.existsSync(routerPath)) {
   }
 
   // ルーターにあるがナビに無いパス → 隠しページ（warning のみ）
-  const hiddenRoutes = routePaths.filter(p => !navPaths.includes(p) && p !== "*" && p !== "/");
+  const hiddenRoutes = routePaths.filter(p => !navPaths.includes(p) && p !== "*" && p !== "");
   if (hiddenRoutes.length > 0) {
     console.warn(`⚠ ルーター (router.tsx) にナビから到達できないページがあります: ${hiddenRoutes.join(", ")}`);
     console.warn(`  → 意図的な隠しページでなければ config.ts にナビを追加してください。`);


### PR DESCRIPTION
## 概要

`code-apps` スキルの `scripts/pre-deploy-check.mjs` に含まれる 2 つの不具合を修正します。
いずれも**ドキュメントどおりの手順で新規 Code App を作ると必ず `npm run predeploy` が失敗する**という影響があります。

## 不具合 1: ルート解決がスクリプトの配置場所と一致していない

```js
const root = path.resolve(path.dirname(__filename), "../../../..");
```

`.github/skills/code-apps/scripts/` から実行される前提の 4 階層上を参照していました。
しかし本リポジトリの**サンプル 21 件すべて**が、プロジェクト直下の `scripts/` に置く前提で宣言しています。

```json
"predeploy": "node scripts/pre-deploy-check.mjs"
```

この配置では `root` がプロジェクトの 3 階層上を指すため、`.env` と `power.config.json` を発見できず、
実際には設定済みにもかかわらず以下が出ます。

```
❌ デプロイ前チェック失敗:
  • .env ファイルが存在しません。.env.example をコピーして設定してください。
  • power.config.json が存在しません。pac code init を先に実行してください。
```

**修正**: `scripts/` の一つ上（＝プロジェクトルート）を参照します。あわせてヘッダーの Usage / npm script 例も実際の配置に合わせました。

## 不具合 2: nav ↔ route のパス比較で先頭スラッシュを正規化していない

スキルが定める規約では、ナビとルートで先頭スラッシュの有無が異なります。

- `src/config.ts` … `path: "/dashboard"`（絶対パス）
- `src/router.tsx` … `path: "dashboard"`（`createHashRouter` のネスト子ルートは相対パス）

現状は両者を素のまま `includes` で突き合わせているため、**規約どおりに実装すると全ページが孤立ナビとして誤検知**されます。

```
❌ デプロイ前チェック失敗:
  • ナビゲーション (config.ts) にルートが存在しないパスがあります: /dashboard, /stores, ...
```

**修正**: `norm()` で先頭スラッシュを除去してから比較します。隠しページ判定の除外条件も正規化後の値（`""`）に合わせました。

## 補足: 修正版はすでにサンプル内に存在します

`samples/geek-fieldservice/scripts/pre-deploy-check.mjs` は、この 2 点を修正済みの内容になっています。
本 PR は**その検証済み実装を正典スクリプトへ水平展開する**ものです（新規実装ではありません）。

## 検証

修正版を実プロジェクトの `scripts/` に配置して実行し、正しく通ることを確認しました。

```
$ node scripts/pre-deploy-check.mjs
✅ デプロイ前チェック OK
```

- `node --check` 構文チェック: OK
- `python .github/skills/update-skills/scripts/validate_skill.py .github/skills/code-apps`: ✅

## 影響範囲

- 変更ファイル: `.github/skills/code-apps/scripts/pre-deploy-check.mjs` の 1 件のみ
- 既存オープン PR（#293 / #296）はいずれも本ファイルに触れていないため、コンフリクトしません

## マージ順の提案

```
1. #293（code-apps Dataverse 標準化）  … ベースに近い
2. #296（ALM / agent365）              … 集約ファイルを含む
3. 本 PR                                … 独立・小さく、他の追随 PR の前提
```

本 PR は上記いずれとも独立しているため、先行してマージしても問題ありません。
