### PR TITLE
docs(standard): auth_helper の CRUD ヘルパーの戻り値を明記

### DIFF
--- a/.github/skills/standard/references/auth-patterns.md
+++ b/.github/skills/standard/references/auth-patterns.md
@@ -7,6 +7,7 @@
 認証キャッシュ（`AuthenticationRecord`）は **`~/.power-platform-cli/auth_record_{TENANT_ID}.json`（ホームディレクトリ配下、テナント別ファイル）にマシン全体で共有保存**される。そのため、このマシンで一度でもそのテナントでデバイスコード認証を完了していれば、別プロジェクト・別リポジトリのスクリプトからでもデバイスコード認証は不要になる。
 
 - 認証は必ず `auth_helper.py` 経由（`requests` 直呼び出し・MSAL 直接呼び出しは禁止）
+- `api_get` / `api_post` などは `requests.Response` ではなく解析済みの値（`dict` / `str` / `None`）を返すため、戻り値に `.json()` を呼ばない
 - スクリプト内でユーザーに認証情報の入力を求めるプロンプトを出さない
 - 実行時に対話待ちが発生した場合は、スクリプトの認証部分を疑い `auth_helper.py` の呼び出し方法を見直す（新しい認証フローを自作しない）
 - テナント・アカウントを切り替えたい場合は `.env` の `TENANT_ID` を変更するだけでよい（テナントごとにキャッシュファイルが分離されているため、他テナントのキャッシュを壊さない）
@@ -26,11 +27,11 @@ token = get_token(scope="https://service.powerapps.com/.default")
 # Bearer ヘッダー付き Session
 session = get_session()
 
-# Dataverse CRUD ヘルパー
-api_get("accounts?$top=1")
-api_post("accounts", {"name": "Test"}, solution="SolutionName")
-api_patch("accounts(id)", {"name": "Updated"})
-api_delete("accounts(id)")
+# Dataverse CRUD ヘルパー（requests.Response ではなく解析済みの値を返す）
+rows = api_get("accounts?$top=1")                                   # -> dict（.json() は不要）
+account_id = api_post("accounts", {"name": "Test"}, solution="SolutionName")  # -> str | None（作成された ID）
+api_patch("accounts(id)", {"name": "Updated"})                      # -> None
+api_delete("accounts(id)")                                          # -> None
 
 # メタデータ操作のリトライ（0x80040237, 0x80044363 対応 + ネットワーク切断/429スロットリング対応）
 retry_metadata(lambda: api_post("EntityDefinitions", body), "テーブル作成")


### PR DESCRIPTION
## 概要

`standard` スキルの `references/auth-patterns.md` に、Dataverse CRUD ヘルパーの**戻り値**を明記します。

## 背景

現状のコード例は呼び出し方のみで、戻り値が示されていません。

```python
# Dataverse CRUD ヘルパー
api_get("accounts?$top=1")
api_post("accounts", {"name": "Test"}, solution="SolutionName")
```

名前が `requests` の API に似ているため `requests.Response` が返ると誤解しやすく、実際に
`api_get(...)` の戻り値へ `.json()` を呼んで `AttributeError: 'dict' object has no attribute 'json'`
になるという実装ミスが発生しました。

`scripts/auth_helper.py` の実装は次のとおりで、いずれも解析済みの値を返します。

```python
def api_get(path: str, scope: str | None = None) -> dict: ...
def api_post(path: str, body: dict, scope: str | None = None, *, solution: str = "") -> str | None: ...
def api_patch(path: str, body: dict, scope: str | None = None) -> None: ...
def api_delete(path: str, scope: str | None = None) -> None: ...
```

## 変更内容

- コード例の各行に戻り値をコメントで併記（`-> dict` / `-> str | None` / `-> None`）
- 前提の箇条書きに「戻り値に `.json()` を呼ばない」旨を 1 行追加

ドキュメントのみの変更で、スクリプトの挙動は変わりません。

## 検証

- `python .github/skills/update-skills/scripts/validate_skill.py .github/skills/standard`: ✅

## 影響範囲

- 変更ファイル: `.github/skills/standard/references/auth-patterns.md` の 1 件のみ
- 既存オープン PR（#293 / #296 / #298）はいずれも `standard` スキルに触れていないため、コンフリクトしません
