### PR TITLE
fix(code-apps): new-theme-checklist の存在しないスクリプト参照を修正

### DIFF
--- a/.github/skills/code-apps/references/new-theme-checklist.md
+++ b/.github/skills/code-apps/references/new-theme-checklist.md
@@ -50,7 +50,7 @@ cp .github/skills/standard/references/gitignore-template .gitignore
 ```
 0. テンプレート scaffold        ← vite.config.ts / plugins/ / styles/ / src/ 一式（@GeekPowerCode が scaffold）
 1. .env 設定（.env.example をコピーして新テーマの値を入れる）
-2. デザインテンプレート選択（design-templates.md → apply_design_template.py）
+2. デザインテンプレート選択（design-templates.md の CSS 変数を styles/index.pcss に適用）
 3. pac code init                  ← power.config.json / .power/ を生成（手で作らない）
 4. pac code add-data-source ...   ← src/generated/ が生成される
 5. 設計フェーズ（design-pattern.md）→ ユーザー承認 → 実装
@@ -63,4 +63,4 @@ cp .github/skills/standard/references/gitignore-template .gitignore
 | `.power/` / `src/generated/` / `power.config.json` | 削除 → 手順 3〜4 で SDK に再生成させる |
 | 前テーマの業務画面（`src/pages/*.tsx`） | 削除し、@GeekPowerCode に新規テーマとして scaffold し直すよう依頼 |
 | 前テーマのテーブル参照（dataSourcesInfo / services / types） | 削除。**コメントアウトで残さない**（ビルドエラー・接続エラーの温床） |
-| 前テーマの配色 | `apply_design_template.py 1 --project .` で Ocean Blue に戻すか、新テーマのテンプレートを適用 |
+| 前テーマの配色 | [design-templates.md](design-templates.md) の Ocean Blue または新テーマの CSS 変数を `styles/index.pcss` の `:root` / `.dark` に上書き適用 |


### PR DESCRIPTION
## 概要

`code-apps/references/new-theme-checklist.md` が、リポジトリに**存在しないスクリプト** `apply_design_template.py` を参照しているため修正します。

## 背景

`.github/skills/code-apps/scripts/` の実体は次の 4 件で、`apply_design_template.py` は存在しません。

```
add_app_to_solution.py
pre-deploy-check.mjs
scaffold_from_cache.ps1
toggle_table_lang.py
```

一方 `new-theme-checklist.md` には 2 箇所の参照が残っており、手順どおりに実行すると失敗します。

- L53 初期化の正しい順序: `2. デザインテンプレート選択（design-templates.md → apply_design_template.py）`
- L66 残骸を見つけたときの対処: `` `apply_design_template.py 1 --project .` で Ocean Blue に戻す ``

`design-templates.md` 自身は「CSS 変数一式を `styles/index.pcss` の `:root` / `.dark` に適用する」と定義しており、
スクリプトを介さない手順が正となっています。

## 変更内容

参照を実在する手順（`design-templates.md` の CSS 変数を `styles/index.pcss` に適用）に置き換えます。

| 箇所 | 変更後 |
|---|---|
| L53 | `2. デザインテンプレート選択（design-templates.md の CSS 変数を styles/index.pcss に適用）` |
| L66 | `design-templates.md` の Ocean Blue または新テーマの CSS 変数を `styles/index.pcss` の `:root` / `.dark` に上書き適用 |

ドキュメントのみの変更です。

## 検証

- `python .github/skills/update-skills/scripts/validate_skill.py .github/skills/code-apps`: ✅
- 変更後、リポジトリ全体に `apply_design_template` への参照が 0 件であることを確認

## 影響範囲

- 変更ファイル: `.github/skills/code-apps/references/new-theme-checklist.md` の 1 件のみ
- 既存オープン PR（#293 / #296 / #298）はいずれも本ファイルに触れていないため、コンフリクトしません
