### PR TITLE
feat(code-apps): 既存テーブル接続時のメタデータ確定手順と inspect_table_metadata.py を追加

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -441,6 +441,7 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 |---|---|
 | [setup_connection_reference.py](scripts/setup_connection_reference.py) | 接続参照をソリューションに用意する（既存流用ファース→Web API で新規作成）。Step 1 で実行 |
 | [pre-deploy-check.mjs](scripts/pre-deploy-check.mjs) | `.env` / `power.config.json` のデプロイ前検証（`npm run predeploy`）。プロジェクト直下の `scripts/` にコピーして使う |
+| [inspect_table_metadata.py](scripts/inspect_table_metadata.py) | 既存テーブルの EntitySetName / 主キー / 列 / 参照先 / 選択肢を調査（既存テーブル接続時は実装前に必須） |
 | [validate_sample.py](scripts/validate_sample.py) | `samples/` 配下が欠落なくビルドできる状態か検証（必須ファイル・import 先の実在・秘匿情報） |
 | [scaffold_from_cache.ps1](scripts/scaffold_from_cache.ps1) | キャッシュからのテンプレート scaffold |
 | [toggle_table_lang.py](scripts/toggle_table_lang.py) | 旧方式の `pac code add-data-source` 向けにテーブル表示名を一時的に英語化 |

--- a/.github/skills/code-apps/references/build-reference.md
+++ b/.github/skills/code-apps/references/build-reference.md
@@ -234,6 +234,31 @@ npx power-apps add-data-source --api-id shared_commondataserviceforapps \
 > テーブルごとに `add-data-source` を繰り返さない。`organization` に使う Dataverse URL は `.env` の `DATAVERSE_URL`
 > などへ保持し、アプリ側では `getContext().app.dataverseOrgUrl` を優先して解決する。
 
+### Step 4.5: 既存テーブルのメタデータ確定（既存テーブルに接続する場合は必須）
+
+Step 4 の生成物（`MicrosoftDataverseModel.ts`）はコネクタ共通のスキーマで、**業務テーブルの列は含まれない**。
+既存テーブルに接続する場合、以下を実装前に確定させないと Step 6 の CRUD で手戻りする。
+
+| 確定させる情報 | 用途 |
+|---|---|
+| `EntitySetName` | `retrieveMultipleRecords` の `entityName` に渡す値（論理名ではない） |
+| `PrimaryIdAttribute` | 更新・削除の対象 ID |
+| `PrimaryNameAttribute` | 一覧の既定表示列 |
+| 列の論理名と型 | `$select` / フォームの入力コントロール |
+| 参照列の Targets | `$expand` の可否と関連先 |
+| Picklist の値とラベル | ステータス表示・フィルタ（**値は 100000000 起点で、ラベルは API から取得しないと分からない**） |
+
+```bash
+# 論理名を渡すと上記を一括出力する（認証は auth_helper、非対話で完走）
+python .github/skills/code-apps/scripts/inspect_table_metadata.py {prefix}_store {prefix}_salesplan --custom-only
+
+# 型定義生成などに使う場合は JSON で出力
+python .github/skills/code-apps/scripts/inspect_table_metadata.py {prefix}_salesplan --json > table-metadata.json
+```
+
+> Picklist の選択肢を UI 側にハードコードする場合も、**必ずこの出力の値を転記する**。
+> 推測値（0/1/2 など）で実装すると、書き込みは成功するのに一覧で該当レコードが消える形の不具合になる。
+
 ### Step 5: 技術スタック導入
 
 ```bash

--- a/.github/skills/code-apps/scripts/inspect_table_metadata.py
+++ b/.github/skills/code-apps/scripts/inspect_table_metadata.py
@@ -1,0 +1,175 @@
+"""
+既存 Dataverse テーブルのメタデータを調査し、Code Apps 実装に必要な情報を出力する。
+
+Code Apps で既存テーブルに接続する場合、生成される型定義だけでは
+EntitySetName / 主キー / 主名称列 / 選択肢（OptionSet）の値が分からず、
+クエリや表示ラベルの実装で手戻りが発生する。実装前にこれを確定させる。
+
+認証は standard スキルの auth_helper を使う（requests / MSAL の直呼びは禁止）。
+
+使い方:
+  python .github/skills/code-apps/scripts/inspect_table_metadata.py {prefix}_store {prefix}_salesplan
+  python .github/skills/code-apps/scripts/inspect_table_metadata.py {prefix}_store --custom-only
+  python .github/skills/code-apps/scripts/inspect_table_metadata.py {prefix}_store --json > table-metadata.json
+
+必要な環境変数（`.env` / references/.env.example 参照）:
+  DATAVERSE_URL           Dataverse 組織 URL
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# --- auth_helper（standard スキル）を import パスに追加 ---
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_CANDIDATES = [
+    _SCRIPT_DIR.parent.parent / "standard" / "scripts",  # .github/skills/standard/scripts
+    *[p / ".github" / "skills" / "standard" / "scripts" for p in _SCRIPT_DIR.parents],
+    *[p / "scripts" for p in _SCRIPT_DIR.parents],
+    *_SCRIPT_DIR.parents,
+]
+for _c in _CANDIDATES:
+    if (_c / "auth_helper.py").is_file():
+        sys.path.insert(0, str(_c))
+        break
+else:  # noqa: PLW0120
+    sys.exit("auth_helper.py が見つかりません（standard スキルの scripts フォルダを確認）")
+
+for _p in _SCRIPT_DIR.parents:
+    if (_p / ".env").is_file():
+        load_dotenv(_p / ".env")
+        break
+
+from auth_helper import api_get  # noqa: E402
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+
+# 子属性（yomi_ / _base など）を除いた実列だけを対象にする
+ATTR_SELECT = (
+    "LogicalName,SchemaName,AttributeType,IsCustomAttribute,"
+    "IsValidForCreate,IsValidForUpdate,AttributeOf"
+)
+
+
+def label(node):
+    """DisplayName / OptionSet ラベルからユーザー既定言語のラベルを取り出す。"""
+    if not node:
+        return ""
+    localized = node.get("UserLocalizedLabel") or {}
+    if localized.get("Label"):
+        return localized["Label"]
+    labels = node.get("LocalizedLabels") or []
+    return labels[0]["Label"] if labels else ""
+
+
+def fetch_table(logical_name, custom_only):
+    entity = api_get(
+        f"EntityDefinitions(LogicalName='{logical_name}')"
+        "?$select=LogicalName,EntitySetName,PrimaryIdAttribute,PrimaryNameAttribute,DisplayName"
+    )
+
+    attrs = api_get(
+        f"EntityDefinitions(LogicalName='{logical_name}')/Attributes"
+        f"?$select={ATTR_SELECT}"
+    )["value"]
+    attrs = [a for a in attrs if not a.get("AttributeOf")]
+    if custom_only:
+        attrs = [a for a in attrs if a.get("IsCustomAttribute")]
+    attrs.sort(key=lambda a: a["LogicalName"])
+
+    picklists = api_get(
+        f"EntityDefinitions(LogicalName='{logical_name}')/Attributes"
+        "/Microsoft.Dynamics.CRM.PicklistAttributeMetadata"
+        "?$select=LogicalName&$expand=OptionSet($select=Options)"
+    )["value"]
+    options = {
+        p["LogicalName"]: [
+            {"value": o["Value"], "label": label(o.get("Label"))}
+            for o in (p.get("OptionSet") or {}).get("Options", [])
+        ]
+        for p in picklists
+        if not custom_only or any(a["LogicalName"] == p["LogicalName"] for a in attrs)
+    }
+
+    lookups = api_get(
+        f"EntityDefinitions(LogicalName='{logical_name}')/Attributes"
+        "/Microsoft.Dynamics.CRM.LookupAttributeMetadata"
+        "?$select=LogicalName,Targets"
+    )["value"]
+
+    return {
+        "logicalName": entity["LogicalName"],
+        "displayName": label(entity.get("DisplayName")),
+        "entitySetName": entity["EntitySetName"],
+        "primaryIdAttribute": entity["PrimaryIdAttribute"],
+        "primaryNameAttribute": entity["PrimaryNameAttribute"],
+        "attributes": [
+            {
+                "logicalName": a["LogicalName"],
+                "type": a["AttributeType"],
+                "isCustom": bool(a.get("IsCustomAttribute")),
+                "writable": bool(a.get("IsValidForCreate") or a.get("IsValidForUpdate")),
+            }
+            for a in attrs
+        ],
+        "optionSets": options,
+        "lookups": {
+            l["LogicalName"]: l.get("Targets", [])
+            for l in lookups
+            if not custom_only or any(a["LogicalName"] == l["LogicalName"] for a in attrs)
+        },
+    }
+
+
+def print_table(t):
+    print(f"\n=== {t['logicalName']}  {t['displayName']} ===")
+    print(f"  EntitySetName        : {t['entitySetName']}")
+    print(f"  PrimaryIdAttribute   : {t['primaryIdAttribute']}")
+    print(f"  PrimaryNameAttribute : {t['primaryNameAttribute']}")
+
+    print(f"\n  列 ({len(t['attributes'])})")
+    width = max((len(a["logicalName"]) for a in t["attributes"]), default=0)
+    for a in t["attributes"]:
+        flag = "" if a["writable"] else "  (読み取り専用)"
+        print(f"    {a['logicalName']:<{width}}  {a['type']}{flag}")
+
+    if t["lookups"]:
+        print("\n  参照列（$expand の対象）")
+        for name, targets in sorted(t["lookups"].items()):
+            print(f"    {name} -> {', '.join(targets)}")
+
+    if t["optionSets"]:
+        print("\n  選択肢")
+        for name, opts in sorted(t["optionSets"].items()):
+            print(f"    {name}")
+            for o in opts:
+                print(f"      {o['value']}  {o['label']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tables", nargs="+", help="調査対象テーブルの論理名")
+    parser.add_argument("--custom-only", action="store_true", help="カスタム列のみ出力")
+    parser.add_argument("--json", action="store_true", help="JSON で出力")
+    args = parser.parse_args()
+
+    if not os.environ.get("DATAVERSE_URL", "").strip():
+        raise SystemExit("DATAVERSE_URL が .env に設定されていません。")
+
+    result = [fetch_table(name, args.custom_only) for name in args.tables]
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        for t in result:
+            print_table(t)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

既存 Dataverse テーブルに接続する Code Apps を作るときに必要な**テーブルメタデータの確定手順**が、
スキルに欠けていました。調査スクリプトと Step を追加します。

## 背景

Step 4 の `add-data-source` が生成するのは `MicrosoftDataverseService.ts` / `MicrosoftDataverseModel.ts` の 2 つだけで、
これは**コネクタ共通のスキーマ**です。業務テーブルの列も選択肢も含まれません。
そのため既存テーブルに接続する場合、実装前に以下を別途確定させる必要がありますが、
その手順がどのリファレンスにも書かれていませんでした。

| 情報 | 分からないと起きること |
|---|---|
| `EntitySetName` | `retrieveMultipleRecords` に論理名を渡して 400 |
| `PrimaryIdAttribute` / `PrimaryNameAttribute` | 更新対象 ID・既定表示列を推測することになる |
| 参照列の `Targets` | `$expand` できるかどうかが実行時まで分からない |
| Picklist の値とラベル | **値が 100000000 起点のため推測不能**。0/1/2 で実装すると書き込みは成功するのに一覧から消える |

## 変更内容

### 1. `scripts/inspect_table_metadata.py`（新規）

論理名を引数で渡すと、上記を 1 コマンドで出力します。

```bash
python .github/skills/code-apps/scripts/inspect_table_metadata.py {prefix}_store {prefix}_salesplan --custom-only
python .github/skills/code-apps/scripts/inspect_table_metadata.py {prefix}_salesplan --json > table-metadata.json
```

- 認証は `auth_helper` の `api_get` のみ（`requests` / MSAL 直呼びなし）
- `auth_helper` / `.env` の解決は `setup_connection_reference.py` と同じパターンを踏襲
- テーブル論理名は引数、環境は `.env` の `DATAVERSE_URL` から解決（ハードコードなし）
- `AttributeOf` を持つ子属性（`yomi_` / `_base` など）は除外。`--custom-only` でカスタム列のみに絞り込み

### 2. `references/build-reference.md` に Step 4.5 を追加

Step 4（コネクタ追加）と Step 5 の間に「既存テーブルのメタデータ確定」を追加し、
何を確定させるのかを表で明示しました。

### 3. `SKILL.md` のスクリプト一覧に追記

## 検証

実環境の既存テーブル 2 件に対して実行し、期待どおりの出力を確認しました（値はマスク）。

```
=== {prefix}_salesplan  販売プラン ===
  EntitySetName        : {prefix}_salesplans
  PrimaryIdAttribute   : {prefix}_salesplanid
  PrimaryNameAttribute : {prefix}_name

  列 (9)
    {prefix}_areaid          Lookup
    ...
    {prefix}_status          Picklist

  参照列（$expand の対象）
    {prefix}_areaid     -> {prefix}_area
    {prefix}_reviewedbyid -> systemuser
    {prefix}_storeid    -> {prefix}_store

  選択肢
    {prefix}_status
      100000000  Draft
      100000001  Reviewed
      100000002  Released
```

- `--json` 出力が有効な JSON としてパースできることを確認
- `validate_skill.py .github/skills/code-apps`: ✅

## マージ順の注意

`SKILL.md` に 1 行の追記があるため #296 と競合し得ます。#296 は既に main に対して CONFLICTING のため、
いずれにせよ #296 側でのリベースが必要です。
