### PR TITLE
fix(code-apps): samples のデッド npm スクリプトを削除し、参照実在チェックを一般化

### DIFF
--- a/.github/skills/code-apps/samples/geek-approval/package.json
+++ b/.github/skills/code-apps/samples/geek-approval/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-asset/package.json
+++ b/.github/skills/code-apps/samples/geek-asset/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-contract/package.json
+++ b/.github/skills/code-apps/samples/geek-contract/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-delivery/package.json
+++ b/.github/skills/code-apps/samples/geek-delivery/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-event/package.json
+++ b/.github/skills/code-apps/samples/geek-event/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-expense/package.json
+++ b/.github/skills/code-apps/samples/geek-expense/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-fieldservice/package.json
+++ b/.github/skills/code-apps/samples/geek-fieldservice/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-helpdesk/package.json
+++ b/.github/skills/code-apps/samples/geek-helpdesk/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-hr/package.json
+++ b/.github/skills/code-apps/samples/geek-hr/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-inventory/package.json
+++ b/.github/skills/code-apps/samples/geek-inventory/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-kaizen/package.json
+++ b/.github/skills/code-apps/samples/geek-kaizen/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-maintenance/package.json
+++ b/.github/skills/code-apps/samples/geek-maintenance/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-pm/package.json
+++ b/.github/skills/code-apps/samples/geek-pm/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-procurement/package.json
+++ b/.github/skills/code-apps/samples/geek-procurement/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-punchlist/package.json
+++ b/.github/skills/code-apps/samples/geek-punchlist/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-quality/package.json
+++ b/.github/skills/code-apps/samples/geek-quality/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-quote/package.json
+++ b/.github/skills/code-apps/samples/geek-quote/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-safety/package.json
+++ b/.github/skills/code-apps/samples/geek-safety/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-sales/package.json
+++ b/.github/skills/code-apps/samples/geek-sales/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-store/package.json
+++ b/.github/skills/code-apps/samples/geek-store/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/samples/geek-training/package.json
+++ b/.github/skills/code-apps/samples/geek-training/package.json
@@ -9,9 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && pac code push",
-    "check:env": "node scripts/bootstrap.mjs --check",
-    "setup": "node scripts/bootstrap.mjs --setup"
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/scripts/validate_sample.py
+++ b/.github/skills/code-apps/scripts/validate_sample.py
@@ -70,13 +70,14 @@ def check(sample: Path) -> list[str]:
 
     pkg_path = sample / "package.json"
     if pkg_path.is_file():
-        scripts = json.loads(pkg_path.read_text(encoding="utf-8")).get("scripts", {})
-        predeploy = scripts.get("predeploy", "")
-        if predeploy and not (sample / "scripts/pre-deploy-check.mjs").exists():
-            errors.append(
-                "package.json が predeploy を宣言しているのに scripts/pre-deploy-check.mjs がありません"
-                "（npm run predeploy が MODULE_NOT_FOUND で失敗します）"
-            )
+        pkg = json.loads(pkg_path.read_text(encoding="utf-8"))
+        for name, body in pkg.get("scripts", {}).items():
+            for m in re.finditer(r"\bnode\s+([\w./-]+\.(?:mjs|cjs|js))", body):
+                if not (sample / m.group(1)).exists():
+                    errors.append(
+                        f"package.json の scripts.{name} が実在しないファイルを実行しています: {m.group(1)}"
+                        "（npm run 実行時に MODULE_NOT_FOUND になります）"
+                    )
 
     index_css = sample / "src/index.css"
     if index_css.is_file():


### PR DESCRIPTION
## 概要

全 21 サンプルの `package.json` が、存在しない `scripts/bootstrap.mjs` を実行する
npm スクリプトを宣言していました。

```json
"check:env": "node scripts/bootstrap.mjs --check",
"setup": "node scripts/bootstrap.mjs --setup"
```

サンプルをコピーして `npm run setup` を実行すると `MODULE_NOT_FOUND` になります。
`#303` で追加した `templates/generic-base` では既に削除済みで、samples 側だけが取り残されていました。

## 変更内容

### 1. デッドスクリプトの削除（21 ファイル）

`check:env` / `setup` を削除し、`generic-base` と同じ scripts 構成に揃えました。

```json
"scripts": {
  "dev": "vite",
  "build": "tsc -b && vite build",
  "lint": "eslint .",
  "preview": "vite preview",
  "predeploy": "node scripts/pre-deploy-check.mjs",
  "deploy": "npm run build && pac code push"
}
```

### 2. `validate_sample.py` のチェックを一般化

これまでは `predeploy` → `scripts/pre-deploy-check.mjs` の 1 組だけを決め打ちで検証しており、
`check:env` / `setup` は素通りしていました。

**scripts 内のすべての `node <path>` を走査して実体の有無を検証**するよう変更し、
同種の不整合をスクリプト名に依存せず検出できるようにしました。

```
❌ geek-store
   • package.json の scripts.predeploy が実在しないファイルを実行しています: scripts/nope.mjs（npm run 実行時に MODULE_NOT_FOUND になります）
```

## 検証

- 意図的に `predeploy` の参照先を存在しないファイルに書き換えて、新チェックが検出することを確認
- 修正後: `21/21 サンプルが OK`
