### PR TITLE
refactor(code-apps): SDK 依存を単一ラッパーに集約し、ドリフト／UI 層漏出を自動検出する

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -419,6 +419,28 @@ scaffold の取得元は **[templates/generic-base](templates/generic-base/)** �
 
 → 含める／含めないファイルの完全な一覧は **[新規テーマ開始チェックリスト](references/new-theme-checklist.md)**。
 
+### SDK に触れる面を 1 ファイルに閉じる
+
+`@microsoft/power-apps` は 2〜4 週ごとに更新され、マイナーバージョンでも破壊的変更が入る。
+影響範囲を押さえるため、**SDK を import してよいのは `src/lib` / `src/services` / `src/providers` の 3 階層だけ**とし、
+ページ・コンポーネントからは直接呼ばない（`validate_sample.py` が検出する）。
+
+Dataverse CRUD ラッパーは **[templates/dataverse-client.ts](templates/dataverse-client.ts) を正**とし、手書きせずコピーして使う。
+
+```bash
+cp .github/skills/code-apps/templates/dataverse-client.ts src/lib/
+```
+
+SDK の破壊的変更への追従は、この 1 ファイルを直して `python scripts/sync_dataverse_client.py` で配布する。
+
+> [!NOTE]
+> `templates/generic-base` にはこのファイルを同梱していない。
+> `@/generated/services/MicrosoftDataverseService` に依存しており、`add-data-source` 前の状態では `tsc -b` が通らないため。
+> Step 6 で接続を追加した後にコピーする。
+>
+> `samples/geek-asset` / `geek-hr` / `geek-expense` / `geek-sales` / `geek-fieldservice` は、このラッパーではなく
+> `getClient()` の `*Async` 系・テーブル別生成サービスを使う別パターンの参照実装。上記 3 階層の制約は同じく適用される。
+
 ### 構築手順の詳細
 
 詳細な構築手順（初期化・Dataverse 接続・ビルド・デプロイ）は [構築リファレンス](references/build-reference.md) を参照。
@@ -495,7 +517,8 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 | [setup_connection_reference.py](scripts/setup_connection_reference.py) | 接続参照をソリューションに用意する（既存流用ファースト→Web API で新規作成）。Step 1 で実行 |
 | [pre-deploy-check.mjs](scripts/pre-deploy-check.mjs) | `.env` / `power.config.json` のデプロイ前検証（`npm run predeploy`）。プロジェクト直下の `scripts/` にコピーして使う |
 | [inspect_table_metadata.py](scripts/inspect_table_metadata.py) | 既存テーブルの EntitySetName / 主キー / 列 / 参照先 / 選択肢を調査（既存テーブル接続時は実装前に必須） |
-| [validate_sample.py](scripts/validate_sample.py) | `samples/` 配下が欠落なくビルドできる状態か検証（必須ファイル・import 先の実在・秘匿情報） |
+| [validate_sample.py](scripts/validate_sample.py) | `samples/` 配下が欠落なくビルドできる状態か検証（必須ファイル・import 先の実在・秘匿情報・SDK の使い方） |
+| [sync_dataverse_client.py](scripts/sync_dataverse_client.py) | [templates/dataverse-client.ts](templates/dataverse-client.ts) を `samples/` 配下の全コピーへ反映（SDK の破壊的変更への追従はこの 1 ファイルを直して配布） |
 | [scaffold_from_cache.ps1](scripts/scaffold_from_cache.ps1) | キャッシュからのテンプレート scaffold |
 | [toggle_table_lang.py](scripts/toggle_table_lang.py) | 旧方式の `pac code add-data-source` 向けにテーブル表示名を一時的に英語化 |
 

--- a/.github/skills/code-apps/references/build-reference.md
+++ b/.github/skills/code-apps/references/build-reference.md
@@ -323,94 +323,25 @@ export const router = createHashRouter([
 `organization` を省略した通常メソッドは `Invalid organization URL 'null' provided` で失敗しやすいため、
 **常に `*WithOrganization` 系メソッドを薄いラッパーで包む**。
 
-```typescript
-// src/lib/dataverse-service.ts
-import { getContext } from "@microsoft/power-apps/app";
-import { MicrosoftDataverseService } from "@/generated/services/MicrosoftDataverseService";
+このラッパーは [`templates/dataverse-client.ts`](../templates/dataverse-client.ts) を正とする。
+手書きせずコピーして使う（SDK の破壊的変更時は、この 1 ファイルを直せば全アプリに反映できる）。
 
-const PREFER = "return=representation";
-const READ_PREFER = 'odata.include-annotations="*"';
-const ACCEPT = "application/json";
-
-type DataverseRow = Record<string, unknown>;
-
-let cachedOrgUrl: string | undefined;
-
-async function getOrgUrl(): Promise<string> {
-  if (cachedOrgUrl) return cachedOrgUrl;
-  const ctx = await getContext();
-  const orgUrl = ctx.app.dataverseOrgUrl;
-  if (!orgUrl) throw new Error("Dataverse org URL を取得できません。");
-  cachedOrgUrl = orgUrl;
-  return orgUrl;
-}
-
-function unwrap<T>(result: { success?: boolean; data?: T; error?: { message?: string } }): T {
-  if (result.success === false) {
-    throw new Error(result.error?.message ?? "Unknown Dataverse connector error");
-  }
-  return result.data as T;
-}
-
-export const DataverseService = {
-  async ListRecords(entityName: string, select?: string[], filter?: string) {
-    const org = await getOrgUrl();
-    const result = await MicrosoftDataverseService.ListRecordsWithOrganization(
-      org,
-      entityName,
-      READ_PREFER,
-      ACCEPT,
-      undefined,
-      undefined,
-      select?.join(","),
-      filter,
-    );
-    return unwrap<{ value?: DataverseRow[] }>(result).value ?? [];
-  },
-  async GetItem(entityName: string, recordId: string, select?: string[]) {
-    const org = await getOrgUrl();
-    const result = await MicrosoftDataverseService.GetItemWithOrganization(
-      READ_PREFER,
-      ACCEPT,
-      org,
-      entityName,
-      recordId,
-      undefined,
-      undefined,
-      select?.join(","),
-    );
-    return unwrap<DataverseRow>(result);
-  },
-  async CreateRecord(entityName: string, body: DataverseRow) {
-    const org = await getOrgUrl();
-    const result = await MicrosoftDataverseService.CreateRecordWithOrganization(
-      PREFER,
-      ACCEPT,
-      org,
-      entityName,
-      body,
-    );
-    return unwrap<void>(result);
-  },
-  async UpdateRecord(entityName: string, recordId: string, body: DataverseRow) {
-    const org = await getOrgUrl();
-    const result = await MicrosoftDataverseService.UpdateRecordWithOrganization(
-      PREFER,
-      ACCEPT,
-      org,
-      entityName,
-      recordId,
-      body,
-    );
-    return unwrap<DataverseRow>(result);
-  },
-  async DeleteRecord(entityName: string, recordId: string) {
-    const org = await getOrgUrl();
-    const result = await MicrosoftDataverseService.DeleteRecordWithOrganization(org, entityName, recordId);
-    return unwrap<void>(result);
-  },
-};
+```bash
+cp .github/skills/code-apps/templates/dataverse-client.ts src/lib/
 ```
+
+公開している API は次のとおり。いずれも `organization` を内部で解決するため、呼び出し側は `entityName` だけを渡す。
+
+| メソッド | 用途 |
+|---|---|
+| `DataverseService.ListRecords(entityName, select?, filter?)` | 一覧取得（`value` を展開して返す） |
+| `DataverseService.GetItem(entityName, recordId, select?)` | 単一取得 |
+| `DataverseService.CreateRecord(entityName, body)` | 作成 |
+| `DataverseService.UpdateRecord(entityName, recordId, body)` | 更新 |
+| `DataverseService.DeleteRecord(entityName, recordId)` | 削除 |
+
+内部では `getContext()` から得た `ctx.app.dataverseOrgUrl` をキャッシュし、
+`success === false` のレスポンスを `Error` に変換している。
 
 ```
 ❌ MicrosoftDataverseService.ListRecords(...) のように organization を省略

--- a/.github/skills/code-apps/scripts/sync_dataverse_client.py
+++ b/.github/skills/code-apps/scripts/sync_dataverse_client.py
@@ -1,0 +1,55 @@
+"""templates/dataverse-client.ts を、samples 配下の全コピーへ反映する。
+
+SDK の破壊的変更でラッパーを直すときは、templates/dataverse-client.ts だけを編集し
+本スクリプトで配布する。
+
+使い方:
+  python sync_dataverse_client.py            # 差分のあるコピーを上書き
+  python sync_dataverse_client.py --check    # 上書きせず差分の有無だけを返す（CI 用）
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+
+BASE = Path(__file__).resolve().parent.parent
+CANONICAL = BASE / "templates" / "dataverse-client.ts"
+COPY_REL = Path("src/lib/dataverse-client.ts")
+
+
+def main() -> int:
+    check_only = "--check" in sys.argv
+
+    if not CANONICAL.is_file():
+        print(f"❌ 正となるファイルがありません: {CANONICAL}")
+        return 1
+
+    expected = CANONICAL.read_bytes()
+    drifted = []
+
+    for sample in sorted(p for p in (BASE / "samples").iterdir() if p.is_dir()):
+        target = sample / COPY_REL
+        if not target.is_file():
+            continue
+        if target.read_bytes() == expected:
+            continue
+        drifted.append(sample.name)
+        if not check_only:
+            target.write_bytes(expected)
+
+    if not drifted:
+        print("✅ すべてのコピーが templates/dataverse-client.ts と一致しています")
+        return 0
+
+    verb = "差分あり" if check_only else "更新しました"
+    for name in drifted:
+        print(f"{'⚠️' if check_only else '🔄'} {name}: {verb}")
+    return 1 if check_only else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills/code-apps/scripts/validate_sample.py
+++ b/.github/skills/code-apps/scripts/validate_sample.py
@@ -60,6 +60,14 @@ SDK_PATTERNS = [
     ),
 ]
 
+# SDK の破壊的変更の影響範囲を押さえるため、SDK に直接触れてよいのは
+# サービス層と初期化 provider だけに限定する（UI 層への漏出を検出する）
+SDK_SURFACE_DIRS = ("src/lib", "src/services", "src/providers")
+
+# CRUD ラッパーは templates/dataverse-client.ts を正とし、各サンプルはそのコピーにする
+CANONICAL_CLIENT = Path(__file__).resolve().parent.parent / "templates" / "dataverse-client.ts"
+CLIENT_REL = "src/lib/dataverse-client.ts"
+
 
 def check(sample: Path) -> list[str]:
     errors: list[str] = []
@@ -96,7 +104,20 @@ def check(sample: Path) -> list[str]:
 
     errors.extend(scan_secrets(sample))
     errors.extend(scan_sdk_usage(sample))
+    errors.extend(check_dataverse_client(sample))
     return errors
+
+
+def check_dataverse_client(sample: Path) -> list[str]:
+    target = sample / CLIENT_REL
+    if not target.is_file() or not CANONICAL_CLIENT.is_file():
+        return []
+    if target.read_bytes() == CANONICAL_CLIENT.read_bytes():
+        return []
+    return [
+        f"{CLIENT_REL} が templates/dataverse-client.ts と一致しません"
+        "（python sync_dataverse_client.py で反映してください）"
+    ]
 
 
 def scan_sdk_usage(sample: Path) -> list[str]:
@@ -112,6 +133,12 @@ def scan_sdk_usage(sample: Path) -> list[str]:
             m = pattern.search(text)
             if m:
                 found.append(f"{label}: {rel} → {m.group(0)}")
+        posix = rel.as_posix()
+        if "@microsoft/power-apps" in text and not posix.startswith(SDK_SURFACE_DIRS):
+            found.append(
+                f"SDK を UI 層から直接 import しています: {rel}"
+                f"（{' / '.join(SDK_SURFACE_DIRS)} のいずれかに隠してください）"
+            )
     return found
 
 

--- a/.github/skills/code-apps/templates/dataverse-client.ts
+++ b/.github/skills/code-apps/templates/dataverse-client.ts
@@ -1,0 +1,90 @@
+import { getContext } from "@microsoft/power-apps/app"
+import { MicrosoftDataverseService } from "@/generated/services/MicrosoftDataverseService"
+
+// pac code add-data-source -a shared_commondataserviceforapps で生成される
+// 単一・非型付けサービスの薄いラッパー。
+// organization を省略すると Invalid organization URL 'null' provided で失敗するため、
+// 常に *WithOrganization 系を使う。
+
+const PREFER = "return=representation"
+const READ_PREFER = 'odata.include-annotations="*"'
+const ACCEPT = "application/json"
+
+export type DataverseRow = Record<string, unknown>
+
+let cachedOrgUrl: string | undefined
+
+async function getOrgUrl(): Promise<string> {
+  if (cachedOrgUrl) return cachedOrgUrl
+  const ctx = await getContext()
+  const orgUrl = ctx.app.dataverseOrgUrl
+  if (!orgUrl) throw new Error("Dataverse org URL を取得できません。")
+  cachedOrgUrl = orgUrl
+  return orgUrl
+}
+
+function unwrap<T>(result: { success?: boolean; data?: T; error?: { message?: string } }): T {
+  if (result.success === false) {
+    throw new Error(result.error?.message ?? "Unknown Dataverse connector error")
+  }
+  return result.data as T
+}
+
+export const DataverseService = {
+  async ListRecords(entityName: string, select?: string[], filter?: string) {
+    const org = await getOrgUrl()
+    const result = await MicrosoftDataverseService.ListRecordsWithOrganization(
+      org,
+      entityName,
+      READ_PREFER,
+      ACCEPT,
+      undefined,
+      undefined,
+      select?.join(","),
+      filter,
+    )
+    return unwrap<{ value?: DataverseRow[] }>(result).value ?? []
+  },
+  async GetItem(entityName: string, recordId: string, select?: string[]) {
+    const org = await getOrgUrl()
+    const result = await MicrosoftDataverseService.GetItemWithOrganization(
+      READ_PREFER,
+      ACCEPT,
+      org,
+      entityName,
+      recordId,
+      undefined,
+      undefined,
+      select?.join(","),
+    )
+    return unwrap<DataverseRow>(result)
+  },
+  async CreateRecord(entityName: string, body: DataverseRow) {
+    const org = await getOrgUrl()
+    const result = await MicrosoftDataverseService.CreateRecordWithOrganization(
+      PREFER,
+      ACCEPT,
+      org,
+      entityName,
+      body,
+    )
+    return unwrap<void>(result)
+  },
+  async UpdateRecord(entityName: string, recordId: string, body: DataverseRow) {
+    const org = await getOrgUrl()
+    const result = await MicrosoftDataverseService.UpdateRecordWithOrganization(
+      PREFER,
+      ACCEPT,
+      org,
+      entityName,
+      recordId,
+      body,
+    )
+    return unwrap<DataverseRow>(result)
+  },
+  async DeleteRecord(entityName: string, recordId: string) {
+    const org = await getOrgUrl()
+    const result = await MicrosoftDataverseService.DeleteRecordWithOrganization(org, entityName, recordId)
+    return unwrap<void>(result)
+  },
+}


### PR DESCRIPTION
## 背景

`@microsoft/power-apps` は **2〜4 週ごと**にリリースされ、マイナーバージョンでも破壊的変更が入ります。

| バージョン | 公開日 |
|---|---|
| 1.0.17 | 2026-03-30 |
| 1.1.1 / 1.1.3 / 1.1.9 | 2026-04-08 / 05-06 / 06-03 |
| 1.2.2 / 1.2.5 / 1.2.7 | 2026-06-11 / 06-30 / 07-15 |

`#304` では 1.1 → 1.2 の破壊的変更に追従するため **57 ファイル**を修正しました。
同じ内容のラッパーが 16 サンプルに複製されていたためです。

この PR は「次に同じことが起きたとき、直す場所を 1 ファイルにする」ための構造変更です。

## 変更内容

### 1. `templates/dataverse-client.ts` を正とする

16 サンプルにバイト単位で複製されていた CRUD ラッパーを、単一の正として切り出しました。

`templates/generic-base/` の**中には置いていません**。
このファイルは `@/generated/services/MicrosoftDataverseService` に依存するため、
`add-data-source` 実行前の generic-base に同梱すると `tsc -b` が通らなくなるためです。

### 2. `sync_dataverse_client.py`（新規）

正を各サンプルへ配布します。

```bash
python sync_dataverse_client.py           # 差分のあるコピーを上書き
python sync_dataverse_client.py --check   # 上書きせず差分の有無だけを返す（CI 用）
```

### 3. `validate_sample.py` に 2 つのチェックを追加

**(a) ラッパーのドリフト検出** — コピーが正と一致しなくなったら失敗させます。

**(b) SDK の使用面の制限** — `@microsoft/power-apps` を import してよいのは
`src/lib` / `src/services` / `src/providers` の 3 階層だけとし、UI 層への漏出を検出します。

```
❌ geek-store
   • SDK を UI 層から直接 import しています: src\pages\not-found.tsx（src/lib / src/services / src/providers のいずれかに隠してください）
   • src/lib/dataverse-client.ts が templates/dataverse-client.ts と一致しません（python sync_dataverse_client.py で反映してください）
```

### 4. ドキュメント

- `build-reference.md`: 70 行のラッパー全文コピペを削除し、`templates/dataverse-client.ts` の参照と公開 API 表に置き換え
- `SKILL.md`: 「SDK に触れる面を 1 ファイルに閉じる」節と `sync_dataverse_client.py` の行を追加

## 適用範囲

| 対象 | 方式 |
|---|---|
| 16 サンプル | `src/lib/dataverse-client.ts`（この PR で単一の正に集約） |
| `geek-asset` / `geek-hr` / `geek-expense` / `geek-sales` / `geek-fieldservice` | `getClient()` の `*Async` 系・テーブル別生成サービスを使う**別パターンの参照実装**。今回は変換していません |

後者は SKILL.md が代替手段として説明している方式で、動作する実装を統一目的だけで書き換えるのは
リスクに見合わないと判断しました。**(b) の 3 階層制約は 21 サンプル全部に適用**されるため、
どちらの方式でも SDK が UI 層へ漏れることはありません。

## 検証

意図的にドリフトと UI 層 import を作り、両チェックが発火 → `sync_dataverse_client.py` で修復されることを確認しました。

```
validate_sample.py                  → 21/21 サンプルが OK
sync_dataverse_client.py --check    → ✅ すべてのコピーが一致（exit 0）
validate_skill.py code-apps         → ✅
```
