### PR TITLE
fix(code-apps,standard): PAC CLI インストール誤記の修正と CLI 0.13.0 / SDK 1.2.7 追従

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -246,6 +246,10 @@ pac code push -env {ENVIRONMENT_ID} -s {SOLUTION_NAME}
 > push してもソリューションに入らず、Power Apps ポータルの「既存の追加 → アプリ → コード アプリ」でしか
 > 復旧できない。詳細は [ソリューション ALM リファレンス](references/solution-alm.md)。
 
+> **`-s` に渡す値は CLI で違う**: `pac code push -s` はソリューション**名**だが、
+> `npx power-apps push -s` は **GUID** を要求する（CLI 0.13.0 で GUID 検証が入り、名前はエラーになった）。
+> 詳細は [ソリューション ALM](references/solution-alm.md#npm-cli-npx-power-apps-push-の場合は-guid-を渡す)。
+
 > **インポート／ラッパーの必須パターン**: 生成された `MicrosoftDataverseService` を薄いラッパーで包み、`ListRecordsWithOrganization` / `CreateRecordWithOrganization` / `GetItemWithOrganization` / `UpdateRecordWithOrganization` / `DeleteRecordWithOrganization` に **Dataverse URL（organization）を必ず渡す**。`organization` を省略すると `Invalid organization URL 'null' provided` で失敗する。詳細は [ビルドリファレンス](references/build-reference.md) を参照。
 
 ### デプロイコマンドの選択
@@ -500,6 +504,7 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 | [クロス集計マトリクスパターン](references/cross-tab-pattern.md) | 2 軸の組み合わせ件数をヒート色付きピボット表で俯瞰（行列自動生成・合計行/列・追加依存なし） |
 | [縦タイムライン/ステッパーパターン](references/timeline-stepper-pattern.md) | 順序を持つ項目の進行状態を縦に可視化（done/current/problem/pending・行ごとに操作ボタン差込可・追加依存なし） |
 | [構築リファレンス](references/build-reference.md) | ビルド・デプロイの詳細手順・vite.config.ts 必須設定・TypeScript エラー対処 |
+| [npm CLI リファレンス](references/cli-reference.md) | `npx power-apps` 全コマンド（0.13.0 検証済み）・`push -s` の GUID 要件・`refresh-data-source` / `add-dataverse-api` / `auth-switch` |
 | [ソリューション ALM](references/solution-alm.md) | 接続参照バインド・`almMode` と初回 push・コンポーネント種別・共有時の権限モデル |
 | [データソースパターン](references/data-source-patterns.md) | 生成サービス・dataSourcesInfo・TanStack React Query（旧/native パターン含む） |
 | [Lookup 名前解決](references/lookup-resolution.md) | クライアントサイド名前解決・OData FormattedValue パターン・所有者（Owner）列の表示 |

--- a/.github/skills/code-apps/references/build-reference.md
+++ b/.github/skills/code-apps/references/build-reference.md
@@ -133,10 +133,14 @@ import type { IContext } from "@microsoft/power-apps/app";
 
 | サブパス | エクスポート |
 |---|---|
-| `@microsoft/power-apps/data` | `getClient`, `DataClient` 型, `IOperationResult` 型 |
-| `@microsoft/power-apps/app` | `getContext`, `IContext` 型 |
-| `@microsoft/power-apps/data/metadata/dataverse` | `EntityMetadata`, `GetEntityMetadataOptions` 型 |
-| `@microsoft/power-apps/telemetry` | テレメトリ API |
+| `@microsoft/power-apps/data` | `getClient`, `DataClient` 型, `IOperationOptions` / `IOperationResult` 型, `serializeMultiSelectPicklistFields`, `deserializeMultiSelectPicklistFields` |
+| `@microsoft/power-apps/app` | `getContext`, `setConfig`, `IContext` / `IConfig` 型 |
+| `@microsoft/power-apps/data/executors` | `createMockDataExecutor`, `MockDataStore` / `IDataOperationExecutor` 型 |
+| `@microsoft/power-apps/data/metadata/dataverse` | `EntityMetadata`, `GetEntityMetadataOptions` 型, `get*Name` 系関数 |
+| `@microsoft/power-apps/telemetry` | `initializeLogger`, `ILogger` / `Metric` 型 |
+| `@microsoft/power-apps/internal/data` | `setDataOperationExecutor`（※ `/data` には無い） |
+
+> **`getContext()` は `Promise<IContext>` を返す非同期関数**（SDK 1.2.7 で確認）。`await` を忘れないこと。
 
 `DataClient` のメソッドは全て `*Async` で、戻り値は `IOperationResult<T>`。
 `getRecords` / `createRecord` / `updateRecord` / `deleteRecord` は存在しない。
@@ -217,6 +221,19 @@ pac code push -env {ENVIRONMENT_ID} -s {SOLUTION_NAME}
 
 > **注意**: `npx power-apps push` はテナント解決の不具合で 403/404 になることがある。
 > `pac code push` を標準とする。`npm run deploy` が `pac code push` を内包する場合はそちらを使用。
+
+> **二つの CLI で `-s` の値が違う（npm CLI 0.13.0 で検証済み）**
+>
+> | コマンド | フラグ | 渡す値 |
+> |---|---|---|
+> | `pac code push` | `-s, --solutionName` | ソリューション**名** |
+> | `npx power-apps push` | `-s, --solution-id` | ソリューション **ID（GUID）** |
+>
+> npm CLI は 0.13.0 で GUID 検証が入り、名前を渡すと
+> `Invalid --solution-id value: expected a GUID, got '<値>'.` で即失敗する
+> （0.12.3 までは名前を GUID に解決してくれていた——**破壊的変更**）。
+> `-s` を省略した場合の npm CLI の振る舞いは
+> [ソリューション ALM](solution-alm.md) を参照。
 
 ### Step 4: Dataverse コネクタ追加（1 回で全テーブルをカバー）
 

--- a/.github/skills/code-apps/references/cli-reference.md
+++ b/.github/skills/code-apps/references/cli-reference.md
@@ -1,0 +1,281 @@
+# npm CLI リファレンス（`@microsoft/power-apps-cli`）
+
+Code Apps 用 npm CLI（`npx power-apps`）の全コマンド一覧。
+
+**検証環境**: `@microsoft/power-apps-cli` **0.13.0**（`@microsoft/power-apps` 1.2.7 の依存として導入）。
+本ドキュメントの内容は実際の `npx power-apps <command> --help` 出力に基づく。
+
+> [!IMPORTANT]
+> **PAC CLI（`pac`）とは別物**。`@microsoft/power-apps-cli` が提供するバイナリは `power-apps` のみで、
+> `pac` は含まれない。PAC CLI は VS Code 拡張機能「Power Platform Tools」または
+> `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` で導入する（npm 配布なし）。
+
+## 目次
+
+- [導入と実行方法](#導入と実行方法)
+- [全コマンド一覧](#全コマンド一覧)
+- [グローバルオプション](#グローバルオプション)
+- [アプリライフサイクル](#アプリライフサイクル)
+- [データソース](#データソース)
+- [Dataverse API（アクション／関数）](#dataverse-apiアクション関数)
+- [探索系（list-\*）](#探索系list-)
+- [クラウドフロー](#クラウドフロー)
+- [接続](#接続)
+- [認証](#認証)
+- [テレメトリ](#テレメトリ)
+- [PAC CLI との対応表](#pac-cli-との対応表)
+
+---
+
+## 導入と実行方法
+
+`@microsoft/power-apps`（SDK）の依存として自動的に入るため、**単体インストールは不要**。
+
+```bash
+npm install            # @microsoft/power-apps 経由で CLI も入る
+npx power-apps --help
+```
+
+Node.js **22 以上**が必要（`engines: { "node": ">=22" }`）。
+
+## 全コマンド一覧
+
+| コマンド | 用途 |
+|---|---|
+| `init` | コードアプリの初期化（`power.config.json` 生成） |
+| `push` | 環境へ発行 |
+| `run` | ローカルサーバー起動（接続をローカル読み込み） |
+| `add-data-source` | データソース追加 |
+| `refresh-data-source` | データソースのスキーマ／生成コード再取得 |
+| `delete-data-source` | データソース削除 |
+| `find-dataverse-api` | Dataverse のアクション／関数を名前検索 |
+| `add-dataverse-api` | Dataverse のアクション／関数をアプリに追加 |
+| `list-codeapps` | 環境内のコードアプリ一覧 |
+| `list-datasets` | 接続配下のデータセット一覧 |
+| `list-tables` | データセット配下のテーブル一覧 |
+| `list-sqlStoredProcedures` | SQL ストアドプロシージャ一覧 |
+| `list-environment-variables` | 環境変数一覧 |
+| `list-connection-references` | 接続参照一覧 |
+| `list-connections` | 接続一覧 |
+| `list-connectors` | 利用可能なコネクタ一覧 |
+| `list-flows` | Power Apps から呼び出せるソリューション内クラウドフロー一覧 |
+| `add-flow` | クラウドフローをアプリに追加 |
+| `remove-flow` | クラウドフローをアプリから削除 |
+| `create-connection` | コネクタの接続を新規作成 |
+| `login` / `logout` | サインイン／キャッシュ全消去 |
+| `auth-status` / `auth-switch` | キャッシュ済みアカウントの確認／切り替え |
+| `telemetry` | テレメトリ設定 |
+
+## グローバルオプション
+
+全コマンド共通。
+
+| オプション | 説明 |
+|---|---|
+| `--non-interactive` | プロンプトを出さない。必要な値はフラグか環境変数で渡す（CI 用） |
+| `--json` | 出力を JSON 化（`list-*` をスクリプトから使うときに必須） |
+| `--no-color` | 色付けを無効化 |
+| `-v, --version` / `-h, --help` | バージョン／ヘルプ |
+| `-e, --environment-id <id>` | 接続先環境 ID |
+| `--cloud <cloud>` | `prod`（既定・商用） / `gccmoderate` / `gcchigh` / `dod` / `mooncake` |
+
+> `--cloud` は日本国内の通常テナントでは指定不要。GCC / DoD / 21Vianet 環境でのみ使用する。
+
+## アプリライフサイクル
+
+### `init`
+
+```bash
+npx power-apps init --environment-id {ENVIRONMENT_ID} --display-name "AppName"
+```
+
+| オプション | 説明 |
+|---|---|
+| `-t, --app-type` | `CodeApp` または `MobileApp` |
+| `-n, --display-name` | 表示名 |
+| `-d, --description` | 説明 |
+| `-b, --build-path` | ビルド出力パス（既定 `./dist`） |
+| `-f, --file-entry-point` | エントリポイントファイル |
+| `-a, --app-url` | ローカル実行 URL |
+| `-l, --logo-path` | ロゴファイルパス |
+
+### `push`
+
+```bash
+npx power-apps push --solution-id {SOLUTION_ID}
+```
+
+| オプション | 説明 |
+|---|---|
+| `-s, --solution-id <GUID>` | 追加先ソリューションの **ID（GUID）** |
+
+> [!WARNING]
+> **0.13.0 の破壊的変更**: `-s` は **GUID のみ**を受け付ける。0.12.3 まではソリューション**名**を
+> 渡すと内部で GUID に解決していたが、0.13.0 では
+> `Invalid --solution-id value: expected a GUID, got '<値>'.` で即失敗する。
+> `pac code push -s` はソリューション**名**なので、値を取り違えないこと。
+> `-s` 省略時の自動解決挙動は [ソリューション ALM](solution-alm.md) を参照。
+
+### `run`
+
+```bash
+npx power-apps run --port 8080 --local-app-url http://localhost:3000
+```
+
+`-p, --port` / `-l, --local-app-url` を指定できる。
+
+## データソース
+
+### `add-data-source`
+
+| オプション | 説明 |
+|---|---|
+| `-a, --api-id` | API 識別子（`shared_commondataserviceforapps`, `shared_sql` など） |
+| `-c, --connection-id` | 接続 ID（ソリューションに入らない。PoC 用） |
+| `-cr, --connection-ref` | 接続参照名（**ALM 標準**） |
+| `-t, --resource-name` | テーブル／リソース名 |
+| `-d, --dataset` | データセット識別子 |
+| `-u, --org-url` | 組織 URL |
+| `-sp, --sql-stored-procedure` | SQL ストアドプロシージャ名 |
+| `-s, --solution-id` | ソリューション ID（`-cr` と併用） |
+
+### `refresh-data-source`
+
+Dataverse 側でテーブル定義（列追加・型変更など）を変えた後、生成コードを追従させる。
+
+```bash
+npx power-apps refresh-data-source                          # 全データソース
+npx power-apps refresh-data-source -n {DATA_SOURCE_NAME}    # 個別
+```
+
+> テーブルに列を足したのに生成型に出てこない場合は、まずこれを実行する。
+
+### `delete-data-source`
+
+```bash
+npx power-apps delete-data-source --api-id {API_ID} --data-source-name {NAME} --force
+```
+
+`-f, --force` で確認プロンプトを省略（CI 用）。`-sp` で SQL ストアドプロシージャ単位の削除も可能。
+
+## Dataverse API（アクション／関数）
+
+カスタム API・カスタムアクション・OOB 関数を型付きで呼び出せるようにする。
+
+```bash
+# 1. 名前で検索して正確な API 名を特定する
+npx power-apps find-dataverse-api --search "account" --json
+
+# 2. アプリに追加する
+npx power-apps add-dataverse-api --api-name {API_NAME}
+```
+
+> フロー呼び出し（`add-flow`）と違い、**Dataverse ネイティブのアクション／関数**が対象。
+> `WinOpportunity` のような OOB 操作や、`msdyn_` 系のカスタム API を型安全に叩ける。
+
+## 探索系（list-*）
+
+いずれも `--json` を付けるとスクリプトからパースできる。エージェントが値を自動取得する場合は `--json` 必須。
+
+| コマンド | 主なオプション | 用途 |
+|---|---|---|
+| `list-codeapps` | — | 環境内のコードアプリ棚卸し |
+| `list-connections` | `-s, --search` | 接続 ID の特定 |
+| `list-connectors` | `-s, --search` | `--api-id` に渡す値の特定 |
+| `list-connection-references` | `-s, --solution-id` | 接続参照の論理名確認 |
+| `list-environment-variables` | — | 環境変数の棚卸し |
+| `list-datasets` | `-a, --api-id` / `-c, --connection-id` | SQL 等のデータベース一覧 |
+| `list-tables` | `-a` / `-c` / `-d, --dataset` | テーブル一覧 |
+| `list-sqlStoredProcedures` | `-c` / `-d` | ストアドプロシージャ一覧 |
+| `list-flows` | `-s, --search` | 呼び出し可能なフローと ID の特定 |
+
+```bash
+# 例: コネクタ ID → 接続 ID → データセット → テーブル の順に絞り込む
+npx power-apps list-connectors --search sharepoint --json
+npx power-apps list-connections --search sharepoint --json
+```
+
+## クラウドフロー
+
+```bash
+# 1. 呼び出せるフローと GUID を確認
+npx power-apps list-flows --search "approval" --json
+
+# 2. アプリに追加
+npx power-apps add-flow --flow-id {FLOW_ID}
+
+# 3. 削除（名前 or ID のどちらか）
+npx power-apps remove-flow --flow-name {FLOW_DATA_SOURCE_NAME}
+npx power-apps remove-flow --flow-id {FLOW_ID}
+```
+
+> `list-flows` が返すのは**ソリューション内**かつ Power Apps から呼び出せるフローのみ。
+> 対象が出てこない場合は、フローがソリューションに含まれているかを先に確認する。
+
+## 接続
+
+```bash
+npx power-apps create-connection --api-id {API_ID} --display-name "Prod SQL"
+```
+
+SSO 専用コネクタはサイレント SSO、それ以外はブラウザが開いてサインインする。
+
+> 接続**参照**（Connection Reference）を新規作成する CLI コマンドは存在しない。
+> ALM 対応が必要な場合は `scripts/setup_connection_reference.py` を使う
+> （[ソリューション ALM](solution-alm.md)）。
+
+## 認証
+
+PAC CLI とは**別のトークンキャッシュ**を持つ。`pac auth create` 済みでも、npm CLI 側は別途サインインが要る。
+
+| コマンド | 説明 |
+|---|---|
+| `login` | サインインしてアカウントをローカルキャッシュに追加。`--non-interactive` でもブラウザは開く |
+| `logout` | **キャッシュ済みアカウントを全消去**。アクティブアカウントの切り替え目的で使わない |
+| `auth-status` | キャッシュ済みアカウント一覧（アクティブなものに印が付く） |
+| `auth-switch` | アクティブアカウントの切り替え。`--account {email}` 省略時は対話選択、`--non-interactive` では必須 |
+
+```bash
+npx power-apps auth-status --json
+npx power-apps auth-switch --account user@contoso.com
+```
+
+> テナントを跨いで作業するときに `logout` → `login` を繰り返す必要はない。
+> 複数アカウントをキャッシュしておき `auth-switch` で切り替える。
+
+## テレメトリ
+
+```bash
+npx power-apps telemetry --show-settings
+npx power-apps telemetry --disable
+```
+
+| オプション | 説明 |
+|---|---|
+| `-ts, --show-settings` | 現在の設定表示 |
+| `-te, --enable` / `-td, --disable` | 有効化／無効化 |
+| `-tc, --console-only <v>` | コンソール出力のみ（送信しない） |
+| `-to, --output-to-console <v>` | 送信に加えてコンソールにも出力 |
+
+> 顧客環境・機微データを扱うプロジェクトでは、着手時に `--show-settings` で状態を確認する。
+
+## PAC CLI との対応表
+
+`pac code` 系コマンドは将来非推奨予定（Learn 記載）。npm CLI が後継となる。
+
+| PAC CLI | npm CLI | 備考 |
+|---|---|---|
+| `pac code init` | `power-apps init` | |
+| `pac code push -s {名前}` | `power-apps push -s {GUID}` | **`-s` の値が名前と GUID で異なる** |
+| `pac code run` | `power-apps run` | |
+| `pac code add-data-source` | `power-apps add-data-source` | |
+| `pac code delete-data-source` | `power-apps delete-data-source` | |
+| `pac code list` | `power-apps list-codeapps` | 名称が異なる |
+| `pac code list-datasets` | `power-apps list-datasets` | |
+| `pac code list-tables` | `power-apps list-tables` | |
+| `pac code list-sql-stored-procedures` | `power-apps list-sqlStoredProcedures` | ハイフンとキャメルケースの違いに注意 |
+| `pac code list-connection-references` | `power-apps list-connection-references` | |
+| （なし） | `refresh-data-source` / `find-dataverse-api` / `add-dataverse-api` / `add-flow` / `remove-flow` / `list-flows` / `list-connections` / `list-connectors` / `list-environment-variables` / `create-connection` / `auth-*` | npm CLI のみ |
+
+> 現時点の本スキルの標準は `pac code push`（テナント解決の安定性のため）。
+> npm CLI 主体への全面移行は別途検証のうえ切り替える。

--- a/.github/skills/code-apps/references/solution-alm.md
+++ b/.github/skills/code-apps/references/solution-alm.md
@@ -59,6 +59,30 @@ Power Apps API でアプリのメタデータを見ると `almMode` プロパテ
 > [Learn: ALM for code apps](https://learn.microsoft.com/en-us/power-apps/developer/code-apps/how-to/alm)
 > の「Add to a solution in Power Apps UI」（ソリューション → 既存の追加 → アプリ → コード アプリ）。
 
+### npm CLI (`npx power-apps push`) の場合は GUID を渡す
+
+`pac code push -s` はソリューション**名**だが、npm CLI の `npx power-apps push -s` は
+**ソリューション ID（GUID）**を要求する。同じ `-s` でも受け付ける値が違うので注意。
+
+```bash
+npx power-apps push --solution-id {SOLUTION_ID}
+```
+
+| CLI バージョン | `-s` に名前を渡した場合 |
+|---|---|
+| `@microsoft/power-apps-cli` 0.12.3 以前 | 内部で `friendlyname` / `uniquename` を検索し GUID に解決（動いていた） |
+| `@microsoft/power-apps-cli` 0.13.0 以降 | `Invalid --solution-id value: expected a GUID, got '<値>'.` で即失敗（**破壊的変更**） |
+
+`-s` を**省略**したときの 0.13.0 の自動解決（初回 push のみ適用。二回目以降は既存の所属を変えない）:
+
+1. 環境の優先ソリューション（未設定なら Common Data Service Default Solution）
+2. それも無ければ全コンポーネントの Default solution
+3. Dataverse が無効な環境ならソリューション無しで push
+
+意図しない Default ソリューションへの混入を避けるため、**初回 push では `--solution-id` を明示する**。
+なお `--solution-id ""`（空文字）は
+`Invalid --solution-id value: expected a GUID, got an empty value.` でエラーになる。
+
 ---
 
 ## 接続参照の用意（既存流用ファースト）

--- a/.github/skills/code-apps/references/template-snapshot/package-lock.json
+++ b/.github/skills/code-apps/references/template-snapshot/package-lock.json
@@ -11,7 +11,7 @@
         "@base-ui/react": "^1.6.0",
         "@dnd-kit/core": "^6.3.1",
         "@fontsource-variable/geist": "^5.2.9",
-        "@microsoft/power-apps": "^1.2.5",
+        "@microsoft/power-apps": "^1.2.7",
         "@tanstack/react-query": "^5.101.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -621,7 +621,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1668,18 +1667,18 @@
       }
     },
     "node_modules/@microsoft/power-apps": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@microsoft/power-apps/-/power-apps-1.2.5.tgz",
-      "integrity": "sha512-IeZ7vZ/bOaZ/yeNjp79msTO1UKq6ZZ2yIGtNOr6bjvqkBu0goHm+nbCaxr9iTlVe4xZGfGnbTylZ04dGgj7tMg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/power-apps/-/power-apps-1.2.7.tgz",
+      "integrity": "sha512-FCN+Rv4TYSLPTfsH8WLiT7uDgmbwz3YlgKvwlUgwJXZ4DwMXymnO41pjVjqADCgN3tmAHLS/njHIaIreHFiUeg==",
       "license": "See license in LICENSE file",
       "dependencies": {
-        "@microsoft/power-apps-cli": "0.12.3"
+        "@microsoft/power-apps-cli": "0.13.0"
       }
     },
     "node_modules/@microsoft/power-apps-actions": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/power-apps-actions/-/power-apps-actions-1.6.1.tgz",
-      "integrity": "sha512-Z95aXen4ZcEDUx/v4H4NJmptr2665dKV7tQ8miLBzNvB0vROk5iTSuErN2Thmjk6sm8j/nDpVqLKFokzR3gudA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/power-apps-actions/-/power-apps-actions-1.8.0.tgz",
+      "integrity": "sha512-RtVmSMCPNqF8yD0E3ZkxfzGoa93pI2y+bLTgegSfhkwq0DS4IWuzKhjdVvhHfw0xNG/f6rSQytRiIrCsH0MTng==",
       "license": "See license in LICENSE file",
       "dependencies": {
         "@microsoft/power-apps-common": "1.3.0",
@@ -1712,9 +1711,9 @@
       }
     },
     "node_modules/@microsoft/power-apps-cli": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/power-apps-cli/-/power-apps-cli-0.12.3.tgz",
-      "integrity": "sha512-xBVZkdwjE7hDrRWds9dA9nhOCaoH3F8TMh7z+FDVMh68Td7zHX3Emn47rilG/pwJrmF1OiLOnhW3S82Eqrg5Cw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/power-apps-cli/-/power-apps-cli-0.13.0.tgz",
+      "integrity": "sha512-WLxcQwDp15o9myLlKpAwy9F25bd4+9x9aa9roPeiedWOqxFDXp5Jjyn9ZdWsSBCNS9+Zu+ZBOcEjVwDe2tA7hg==",
       "license": "See license in LICENSE file",
       "dependencies": {
         "@azure/msal-node": "3.6.3",
@@ -1722,11 +1721,12 @@
         "@clack/prompts": "0.6.3",
         "@microsoft/1ds-core-js": "4.3.11",
         "@microsoft/1ds-post-js": "4.3.11",
-        "@microsoft/power-apps-actions": "1.6.1",
+        "@microsoft/power-apps-actions": "1.8.0",
         "@microsoft/power-apps-common": "1.3.0",
         "chalk": "4.1.2",
         "commander": "10.0.1",
-        "open": "8.4.0"
+        "open": "8.4.0",
+        "ts-morph": "27.0.2"
       },
       "bin": {
         "power-apps": "dist/Bin.js"
@@ -1856,9 +1856,9 @@
       }
     },
     "node_modules/@nevware21/ts-utils": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.15.0.tgz",
-      "integrity": "sha512-+bUMKIiKAgoW5uNEb5xxzBzdwdLS9SKRcOy8SxLE+KqSlIdUYV5O9nxJVq1RUYcO2DtL5DlrK1GbgcVEHv6GVA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.16.0.tgz",
+      "integrity": "sha512-DDln15VUBSw5JjJlNno1UCSzgAGzHHklm7u695jXDCzwSn7W2F7B2VYHwLLcT1cOWQQBQAJK6e2/Y8oTG+W0Ig==",
       "funding": [
         {
           "type": "github",
@@ -2593,6 +2593,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
@@ -2689,24 +2755,24 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/.github/skills/code-apps/references/template-snapshot/package.json
+++ b/.github/skills/code-apps/references/template-snapshot/package.json
@@ -7,7 +7,7 @@
     "@base-ui/react": "^1.6.0",
     "@dnd-kit/core": "^6.3.1",
     "@fontsource-variable/geist": "^5.2.9",
-    "@microsoft/power-apps": "^1.2.5",
+    "@microsoft/power-apps": "^1.2.7",
     "@tanstack/react-query": "^5.101.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/.github/skills/power-pages/scripts/check_prerequisites.py
+++ b/.github/skills/power-pages/scripts/check_prerequisites.py
@@ -138,7 +138,11 @@ def main() -> int:
         print(f"  ✅ pac CLI: {info}")
     else:
         print("  ❌ pac CLI: 未検出")
-        errors.append("pac CLI をインストール: npm install -g @microsoft/power-apps-cli")
+        errors.append(
+            "pac CLI をインストール: VS Code 拡張機能『Power Platform Tools』 "
+            "または dotnet tool install --global Microsoft.PowerApps.CLI.Tool "
+            "（npm では配布されていません）"
+        )
 
     # 必須: node
     ok, info = check_node()

--- a/.github/skills/standard/references/interactive-setup.md
+++ b/.github/skills/standard/references/interactive-setup.md
@@ -3,7 +3,8 @@
 プロジェクト新規開始時に **PAC CLI** と **Dataverse API** を使って `.env` を対話的に構成する。
 手動でセッション詳細を開く必要がなく、エージェントがユーザーに選択肢を提示して進める。
 
-> 前提: PAC CLI がインストール済み（`npm install -g @microsoft/power-apps-cli` or Power Platform Tools 拡張機能）。
+> 前提: PAC CLI がインストール済み（VS Code 拡張機能『Power Platform Tools』 or `dotnet tool install --global Microsoft.PowerApps.CLI.Tool`）。
+> PAC CLI は npm では配布されていない。`@microsoft/power-apps-cli` は別物（Code Apps 用の `power-apps` コマンド）なので混同しないこと。
 
 ## 標準フロー（PAC プロファイル → 環境選択 → デバイスコード認証）
 

--- a/.github/skills/standard/references/power-platform-development-standard.md
+++ b/.github/skills/standard/references/power-platform-development-standard.md
@@ -199,7 +199,22 @@ PUBLISHER_PREFIX=geek
 | Node.js (LTS)                 | Code Apps ビルド    | v18.x / v20.x                                |
 | Python 3.10+                  | 自動化スクリプト    | Dataverse SDK 利用                           |
 | pip                           | Python 依存導入     | `python -m ensurepip --upgrade`              |
-| PAC CLI                       | Power Platform CLI  | `npm install -g @microsoft/power-apps-cli`   |
+| PAC CLI                       | Power Platform CLI  | Power Platform Tools 拡張機能 / .NET tool    |
+
+#### 2.1.1 2 つの CLI を混同しない
+
+名前が似ているが**別物**であり、インストール方法も配布元も異なる。
+
+| 項目           | PAC CLI                                                                                                                             | Code Apps CLI                                     |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| コマンド       | `pac`                                                                                                                                 | `power-apps`（`npx power-apps`）                  |
+| 配布           | VS Code 拡張機能 / .NET tool / Windows MSI                                                                                            | npm パッケージ `@microsoft/power-apps-cli`        |
+| インストール   | 拡張機能「Power Platform Tools」<br>`dotnet tool install --global Microsoft.PowerApps.CLI.Tool`<br>MSI: <https://aka.ms/PowerAppsCLI> | `npm install`（プロジェクトの devDependencies）   |
+| 主な用途       | 認証プロファイル、ソリューション ALM、Power Pages、環境操作                                                                            | Code Apps の init / push / データソース接続       |
+| インストール単位 | マシン全体（グローバル）                                                                                                            | プロジェクトローカル                              |
+
+> **PAC CLI は npm では配布されていない。** `npm install -g @microsoft/power-apps-cli` を実行しても
+> インストールされるのは `power-apps` コマンドのみで、`pac` は入らない。
 
 ### 2.2 .env ファイル設定
 

--- a/.github/skills/standard/scripts/bootstrap.mjs
+++ b/.github/skills/standard/scripts/bootstrap.mjs
@@ -145,7 +145,7 @@ function checkPac() {
   }
   log(
     "⚠️",
-    "PAC CLI 未検出 — 必要に応じて `npm install -g @microsoft/power-apps-cli` → `pac auth create --environment {ENVIRONMENT_ID}`",
+    "PAC CLI 未検出 — VS Code 拡張機能『Power Platform Tools』または `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` で導入し、`pac auth create --environment {ENVIRONMENT_ID}`（npm では配布されていません）",
   );
 }
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Python と pip が利用可能な場合は、`spec-builder` 用 `.venv` の作�
 
 - Python 未検出: Python 3.10+ を導入して `python --version` または `py -3 --version` を通す
 - pip 未検出: `python -m ensurepip --upgrade`（または `py -3 -m ensurepip --upgrade`）
-- `pac` 未検出: `npm install -g @microsoft/power-apps-cli` 後、`pac auth create --environment {ENVIRONMENT_ID}`
+- `pac` 未検出: VS Code 拡張機能『Power Platform Tools』または `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` で導入後、`pac auth create --environment {ENVIRONMENT_ID}`（**PAC CLI は npm では配布されていない**）
 - `npx power-apps` 未検出: `npm install` を再実行し `@microsoft/power-apps` 依存を確認
 
 </details>


### PR DESCRIPTION
## 概要

Power Apps SDK 1.2.7 / npm CLI 0.13.0 へのスキル追従と、PAC CLI インストール手順の誤記修正。
すべての記述は**ローカルに実際の CLI / SDK を導入して実測した結果**に基づいています。

Fixes #314
Fixes #315
Fixes #316

---

## #316 PAC CLI は npm では配布されていない（bug / documentation）

5 箇所で `npm install -g @microsoft/power-apps-cli` を **PAC CLI（`pac`）の導入手順**として案内していました。
このパッケージが提供するバイナリは `power-apps` のみで、`pac` は入りません。

```
# @microsoft/power-apps-cli@0.13.0 の package.json
"bin": { "power-apps": "./dist/Bin.js" }
"engines": { "node": ">=22" }

# 実際にインストールした node_modules/.bin
power-apps          ← これだけ。pac は無い
```

修正内容:

- 正しい導入方法（VS Code 拡張機能「Power Platform Tools」/ `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` / MSI）に差し替え
- `standard` リファレンスに **2 つの CLI の比較表**を追加（コマンド・配布・用途・インストール単位）
- `check_prerequisites.py` / `bootstrap.mjs` のエラーメッセージも修正

---

## #315 `push` の solution 指定と依存バージョン（bug）

### 調査で判明した「実際の破壊的変更」

Issue 起票時は「`--solution-name` → `--solution-id` へのフラグ改名」と書いていましたが、
実測したところ**フラグ名は両バージョンとも `-s, --solution-id`** で、変わったのは**受け付ける値**でした。

```
# 0.12.3
-s, --solution-id <solution-id>   Solution name to add the app to.
Examples: $ npx power-apps push --solution-name "MySolution"    ← 存在しないフラグ（当時のドキュメントバグ）

# 0.13.0
-s, --solution-id <solution-id>   Solution ID (GUID) to add the app to. When omitted, ...
Examples: $ npx power-apps push --solution-id "00000000-0000-0000-0000-000000000000"
```

実装を追うと、これは**ドキュメントだけの変更ではなく挙動の破壊的変更**でした。

| バージョン | `-s` に名前を渡したとき |
|---|---|
| 0.12.3 | `Push.js` の `customPrompt` が `isGuid()` で判定し、GUID でなければ `getSolutions()` から `friendlyname` / `uniquename` 一致で GUID に解決 → **動いていた** |
| 0.13.0 | `customPrompt` が削除され、`resolveSolutionForPush()`（`@microsoft/power-apps-actions`）が `isGuidPermissive()` で検証 → `Invalid --solution-id value: expected a GUID, got '<値>'.` で**即失敗** |

さらに、Learn を確認したところ **`pac code push` は `--solutionName`（名前）のまま**でした。
つまり同じ `-s` でも 2 つの CLI で渡す値が違うという罠があるため、
リポジトリの `pac code push -s {SOLUTION_NAME}` は**正しいので変更せず**、
npm CLI との差異を明記する方針にしています。

| コマンド | フラグ | 渡す値 |
|---|---|---|
| `pac code push` | `-s, --solutionName` | ソリューション**名** |
| `npx power-apps push` | `-s, --solution-id` | ソリューション **ID（GUID）** |

`-s` 省略時の 0.13.0 の自動解決も `solution-alm.md` に追記しました
（優先ソリューション → CDS Default Solution → 全コンポーネント Default → ソリューション無し、
初回 push のみ適用・二回目以降は既存の所属を変更しない）。

### バージョン更新

`template-snapshot` を `@microsoft/power-apps` **1.2.5 → 1.2.7**（連動して CLI 0.12.3 → 0.13.0、
`power-apps-actions` 1.6.1 → 1.8.0）に更新。
lock ファイルは公開レジストリ（`--registry https://registry.npmjs.org/`）で再生成し、
社内プロキシ URL が混入していないことを確認済みです。

### SDK サブパス表の修正

`package.json` の `exports` を実測して表を更新しました。

| サブパス | 追加・修正内容 |
|---|---|
| `@microsoft/power-apps/data` | `IOperationOptions` / MultiSelectPicklist ユーティリティを追記 |
| `@microsoft/power-apps/app` | `setConfig` / `IConfig` を追記 |
| `@microsoft/power-apps/data/executors` | **新規追記**（`createMockDataExecutor`, `MockDataStore`） |
| `@microsoft/power-apps/telemetry` | `initializeLogger` / `ILogger` / `Metric` を明記 |
| `@microsoft/power-apps/internal/data` | **新規追記**。`setDataOperationExecutor` は `/data` には無くここからのみ公開 |

あわせて `getContext()` が **`Promise<IContext>` を返す非同期関数**である点を明記しました
（型チェックで発覚。`await` 漏れの原因になります）。

---

## #314 npm CLI リファレンス新設（enhancement）

`references/cli-reference.md` を追加しました。`npx power-apps <command> --help` の**実出力**をもとに、
0.13.0 の全コマンドを整理しています。

これまでスキルで未カバーだったもの:

- `refresh-data-source` — テーブル定義変更後に生成コードを追従させる
- `find-dataverse-api` / `add-dataverse-api` — Dataverse アクション・関数の検索と型付き追加
- `list-flows` / `add-flow` / `remove-flow` — クラウドフロー連携
- `list-connections` / `list-connectors` / `list-environment-variables` / `list-codeapps`
- `create-connection` — 接続の新規作成
- `auth-status` / `auth-switch` — 複数アカウントのキャッシュと切り替え（`logout` → `login` の往復が不要）
- `telemetry` — テレメトリ設定

PAC CLI との対応表も収録しました（`pac code list` ↔ `power-apps list-codeapps`、
`pac code list-sql-stored-procedures` ↔ `power-apps list-sqlStoredProcedures` など命名差あり）。

---

## 検証

Vite 7 + React 19 + TypeScript 5.9 のサンプルアプリを作成し、SDK 1.2.7 の**全公開サブパス**を
import して型チェックとビルドを通しました。

```
npx tsc --noEmit    → エラー 0
npx vite build      → 成功（vendor 200.21 kB / gzip 62.81 kB）
```

さらにランタイム挙動も実測しています（Vite でバンドルして Node 実行）。

```
serialize([])        → {"geek_tags":null}      空配列は null（Dataverse は空文字を拒否）
serialize([1,2])     → {"geek_tags":"1,2"}     新しいオブジェクトを返す
deserialize("")      → []
deserialize 戻り値   → undefined（引数を in-place 変更）
mock retrieveRecordAsync / retrieveMultipleRecordsAsync → success: true
mock 未登録テーブル   → {"success":false,"error":{"message":"table <nope> not found"}}
mock createRecordAsync → {"success":false,"error":"createRecordAsync is not supported by MockDataOperationExecutor"}
```

> `createMockDataExecutor` が**読み取り専用**である点は #308（モックデータ実行基盤）の
> ドキュメント化で必ず明記します。

## スコープ外

**#317**（`pac code` 非推奨 → npm CLI 主体への移行、`auth-switch` 再検証）は
テナント実機での push / 認証切り替え検証が必要なため、別 PR とします。
本 PR では現行標準の `pac code push` を維持したまま、npm CLI との差異を明記するに留めています。
