### PR TITLE
feat(code-apps): add mock data development pattern

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -394,6 +394,14 @@ SDK の `getContext().app.queryParams` で親ウィンドウの URL パラメー
 
 → 詳細: **[データソースパターン](references/data-source-patterns.md)**
 
+### 環境接続前のモックデータ開発
+
+取得系画面は `createMockDataExecutor` でローカル確認できる。モックは `import.meta.env.DEV` と
+`VITE_USE_MOCK=1` の両方で制限し、動的 import して本番成果物から除去する。
+SDK 1.2.7 の標準 executor は作成・更新・削除をサポートしないため、書き込み成功のテストには使わない。
+
+→ 詳細: **[モックデータ開発パターン](references/mock-data-pattern.md)**
+
 ### Lookup 名はクライアントサイド名前解決が必須
 
 SDK 生成サービスは Lookup 名フィールド（`createdbyname` 等）を返さない。
@@ -510,6 +518,7 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 | [npm CLI リファレンス](references/cli-reference.md) | `npx power-apps` 全コマンド（0.13.0 検証済み）・`push -s` の GUID 要件・`refresh-data-source` / `add-dataverse-api` / `auth-switch` |
 | [ソリューション ALM](references/solution-alm.md) | 接続参照バインド・`almMode` と初回 push・コンポーネント種別・共有時の権限モデル |
 | [データソースパターン](references/data-source-patterns.md) | 生成サービス・dataSourcesInfo・TanStack React Query（旧/native パターン含む） |
+| [モックデータ開発パターン](references/mock-data-pattern.md) | 開発限定の `createMockDataExecutor` 導入・本番バンドル混入防止・SDK 1.2.7 の取得専用制約 |
 | [Lookup 名前解決](references/lookup-resolution.md) | クライアントサイド名前解決・OData FormattedValue パターン・所有者（Owner）列の表示 |
 | [日本語サニタイズ](references/japanese-sanitize.md) | 旧ネイティブ add-data-source 方式の日本語 DisplayName 回避 |
 | [CSP 構成](references/csp.md) | iframe 埋め込み・外部 API 接続時の CSP 設定・CSP 安全な SDK メソッド一覧 |
@@ -532,7 +541,7 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 |---|---|
 | [check_code_apps_environment.py](scripts/check_code_apps_environment.py) | マネージド環境 / Code Apps 許可の前提条件を確認（`power-apps init` の前に実行） |
 | [setup_connection_reference.py](scripts/setup_connection_reference.py) | 接続参照をソリューションに用意する（既存流用ファースト→Web API で新規作成）。Step 1 で実行 |
-| [pre-deploy-check.mjs](scripts/pre-deploy-check.mjs) | `.env` / `power.config.json` のデプロイ前検証（`npm run predeploy`）。プロジェクト直下の `scripts/` にコピーして使う |
+| [pre-deploy-check.mjs](scripts/pre-deploy-check.mjs) | `.env` / `power.config.json` / モック実行基盤の本番混入を検証（`npm run predeploy`）。プロジェクト直下の `scripts/` にコピーして使う |
 | [inspect_table_metadata.py](scripts/inspect_table_metadata.py) | 既存テーブルの EntitySetName / 主キー / 列 / 参照先 / 選択肢を調査（既存テーブル接続時は実装前に必須） |
 | [validate_sample.py](scripts/validate_sample.py) | `samples/` 配下が欠落なくビルドできる状態か検証（必須ファイル・import 先の実在・秘匿情報・SDK の使い方） |
 | [sync_dataverse_client.py](scripts/sync_dataverse_client.py) | [templates/dataverse-client.ts](templates/dataverse-client.ts) を `samples/` 配下の全コピーへ反映（SDK の破壊的変更への追従はこの 1 ファイルを直して配布） |

--- a/.github/skills/code-apps/references/mock-data-pattern.md
+++ b/.github/skills/code-apps/references/mock-data-pattern.md
@@ -1,0 +1,153 @@
+# モックデータ開発パターン
+
+Power Apps SDK 1.2.7 の `createMockDataExecutor` を使うと、Power Platform 環境へ接続せずに取得系画面を確認できる。
+モックはローカル開発専用とし、本番成果物へ含めない。
+
+## SDK 1.2.7 の制約
+
+`MockDataStore` の実際の構造は「テーブル名 → レコード ID → レコード」であり、レコード配列ではない。
+
+```typescript
+export type MockDataStore<TRecord = unknown> = {
+  [tableName: string]: {
+    [id: string]: TRecord
+  }
+}
+```
+
+標準の `MockDataOperationExecutor` が成功を返すのは次の取得操作だけである。
+
+- `retrieveRecordAsync`
+- `retrieveMultipleRecordsAsync`
+
+`createRecordAsync` / `updateRecordAsync` / `deleteRecordAsync` / `executeAsync` / ファイル操作は
+`not supported by MockDataOperationExecutor` を返す。したがって、標準モックで確認できる範囲は一覧・詳細・空状態・取得エラー・
+作成や更新の失敗時 UI までとする。書き込み成功を含むテストが必要な場合は、service 層を差し替えるか
+`IDataOperationExecutor` を実装したテスト専用 executor を別途用意する。
+
+取得時の `filter` / `select` / `orderBy` / `top` / `skip` も評価されず、複数取得は store 内の全レコードを返す。
+検索・ソート・ページングの正確な結合テストには実環境か、オプションを解釈する独自 executor を使う。
+
+## ファイル分割
+
+モックデータと SDK のモック用 import は通常のアプリコードから分離する。
+
+```text
+src/
+├── main.tsx
+└── mocks/
+    ├── enable-mock-data.ts
+    └── mock-data.ts
+```
+
+### `src/mocks/mock-data.ts`
+
+テーブルキーは `getClient()` の各メソッドへ渡すテーブル論理名と完全に一致させる。
+生成サービスを使う場合は `.power/schemas/appschemas/dataSourcesInfo.ts` の該当テーブル定義も確認する。
+公開サンプルではパブリッシャープレフィックスをハードコードしない。
+
+```typescript
+import type { MockDataStore } from "@microsoft/power-apps/data/executors"
+
+const accountTable = `${import.meta.env.VITE_PUBLISHER_PREFIX}_accounts`
+const firstAccountId = "00000000-0000-0000-0000-000000000001"
+
+export const mockData = {
+  [accountTable]: {
+    [firstAccountId]: {
+      accountid: firstAccountId,
+      name: "サンプル取引先",
+      statuscode: 1,
+    },
+  },
+} satisfies MockDataStore
+```
+
+レコード ID は辞書のキーだけでなく、主キー列にも同じ値を設定する。
+
+### `src/mocks/enable-mock-data.ts`
+
+`import.meta.env.DEV` と明示的な feature flag の両方を満たす場合だけ、モック関連モジュールを動的 import する。
+静的 import にすると、本番コードからモックデータを除去できない可能性がある。
+
+```typescript
+export async function enableMockData(): Promise<void> {
+  if (!import.meta.env.DEV || import.meta.env.VITE_USE_MOCK !== "1") return
+
+  const [{ createMockDataExecutor }, { setDataOperationExecutor }, { mockData }] =
+    await Promise.all([
+      import("@microsoft/power-apps/data/executors"),
+      import("@microsoft/power-apps/internal/data"),
+      import("./mock-data"),
+    ])
+
+  setDataOperationExecutor(createMockDataExecutor(mockData))
+}
+```
+
+`setDataOperationExecutor` は公開 package export の `@microsoft/power-apps/internal/data` から import する。
+`@microsoft/power-apps/data` からは export されていない。
+
+### `src/main.tsx`
+
+データ取得が始まる前に executor を差し替えるため、React の描画前に初期化を完了させる。
+
+```typescript
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import App from "./App"
+import { enableMockData } from "./mocks/enable-mock-data"
+
+async function bootstrap(): Promise<void> {
+  await enableMockData()
+
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  )
+}
+
+void bootstrap()
+```
+
+## 有効化
+
+コミットしない `.env.local` にだけ feature flag を設定する。
+
+```dotenv
+VITE_USE_MOCK=1
+```
+
+`VITE_USE_MOCK=0` や未設定では実環境の executor を使う。`VITE_` 変数はブラウザへ公開されるため、
+モックレコードへ実データ・個人情報・トークンを入れてはならない。
+
+## 本番混入チェック
+
+`npm run deploy` はビルド後にも `npm run predeploy` を実行する。
+`scripts/pre-deploy-check.mjs` は次の両方を検査する。
+
+1. `src/` でモック API を使うファイルに DEV flag・feature flag・2 つの動的 import があること
+2. `dist/` の JavaScript に次の文字列が残っていないこと
+
+- `createMockDataExecutor`
+- `setDataOperationExecutor`
+- `@microsoft/power-apps/data/executors`
+
+```bash
+npm run build
+npm run predeploy
+```
+
+チェックが失敗した場合は、モック関連の静的 import を削除し、`import.meta.env.DEV && VITE_USE_MOCK === "1"` の
+分岐内にある動的 import へ移す。ソースマップは検査対象外のため、成果物の JavaScript から除去されていることを判定できる。
+
+## チェックリスト
+
+- [ ] store は「テーブル名 → ID → レコード」の形になっている
+- [ ] テーブルキーは実際に SDK へ渡す論理名と一致している
+- [ ] executor の設定は React 描画前に完了する
+- [ ] `import.meta.env.DEV` と `VITE_USE_MOCK === "1"` の両方で制限している
+- [ ] モック関連モジュールは動的 import している
+- [ ] モックデータに実データや PII がない
+- [ ] `npm run build` 後の `npm run predeploy` が成功する

--- a/.github/skills/code-apps/scripts/pre-deploy-check.mjs
+++ b/.github/skills/code-apps/scripts/pre-deploy-check.mjs
@@ -95,6 +95,64 @@ if (fs.existsSync(configTs) && fs.existsSync(routerPath)) {
   }
 }
 
+// 5. モック実行基盤が開発限定の動的 import になっているか
+const srcPath = path.join(root, "src");
+if (fs.existsSync(srcPath)) {
+  const pending = [srcPath];
+
+  while (pending.length > 0) {
+    const currentPath = pending.pop();
+    for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
+      const entryPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+        continue;
+      }
+      if (!entry.isFile() || !/\.[cm]?[jt]sx?$/.test(entry.name)) continue;
+
+      const content = fs.readFileSync(entryPath, "utf-8");
+      if (!content.includes("createMockDataExecutor") && !content.includes("setDataOperationExecutor")) continue;
+
+      const hasDevelopmentGuards = content.includes("import.meta.env.DEV") && content.includes("VITE_USE_MOCK");
+      const hasDynamicImports = /import\(\s*["']@microsoft\/power-apps\/data\/executors["']\s*\)/.test(content)
+        && /import\(\s*["']@microsoft\/power-apps\/internal\/data["']\s*\)/.test(content);
+      if (!hasDevelopmentGuards || !hasDynamicImports) {
+        errors.push(
+          `${path.relative(root, entryPath)} のモックデータ実行基盤が開発限定の動的 import になっていません。\n` +
+          `     → import.meta.env.DEV && VITE_USE_MOCK === "1" で制限し、SDK の 2 モジュールを動的 import してください。`
+        );
+      }
+    }
+  }
+}
+
+// 6. 本番成果物にモック実行基盤が混入していないか
+const distPath = path.join(root, "dist");
+if (fs.existsSync(distPath)) {
+  const mockMarkers = ["createMockDataExecutor", "setDataOperationExecutor", "@microsoft/power-apps/data/executors"];
+  const pending = [distPath];
+
+  while (pending.length > 0) {
+    const currentPath = pending.pop();
+    for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
+      const entryPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+        continue;
+      }
+      if (!entry.isFile() || entry.name.endsWith(".map")) continue;
+
+      const content = fs.readFileSync(entryPath, "utf-8");
+      if (mockMarkers.some(marker => content.includes(marker))) {
+        errors.push(
+          `本番成果物 ${path.relative(root, entryPath)} にモックデータ実行基盤が含まれています。\n` +
+          `     → import.meta.env.DEV && VITE_USE_MOCK === "1" の動的 import に限定してください。`
+        );
+      }
+    }
+  }
+}
+
 // 結果出力
 if (errors.length > 0) {
   console.error("\n❌ デプロイ前チェック失敗:\n");

--- a/.github/skills/code-apps/scripts/validate_sample.py
+++ b/.github/skills/code-apps/scripts/validate_sample.py
@@ -100,10 +100,10 @@ def check(sample: Path) -> list[str]:
     if pkg_path.is_file():
         pkg = json.loads(pkg_path.read_text(encoding="utf-8"))
         deploy = pkg.get("scripts", {}).get("deploy")
-        if deploy != "npm run build && npx power-apps push":
+        if deploy != "npm run build && npm run predeploy && npx power-apps push":
             errors.append(
                 "package.json の scripts.deploy は "
-                "'npm run build && npx power-apps push' に統一してください"
+                "'npm run build && npm run predeploy && npx power-apps push' に統一してください"
             )
         for name, body in pkg.get("scripts", {}).items():
             for m in re.finditer(r"\bnode\s+([\w./-]+\.(?:mjs|cjs|js))", body):

--- a/.github/skills/code-apps/templates/generic-base/package.json
+++ b/.github/skills/code-apps/templates/generic-base/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run build && npx power-apps push"
+    "deploy": "npm run build && npm run predeploy && npx power-apps push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/.github/skills/code-apps/templates/generic-base/scripts/pre-deploy-check.mjs
+++ b/.github/skills/code-apps/templates/generic-base/scripts/pre-deploy-check.mjs
@@ -95,6 +95,64 @@ if (fs.existsSync(configTs) && fs.existsSync(routerPath)) {
   }
 }
 
+// 5. モック実行基盤が開発限定の動的 import になっているか
+const srcPath = path.join(root, "src");
+if (fs.existsSync(srcPath)) {
+  const pending = [srcPath];
+
+  while (pending.length > 0) {
+    const currentPath = pending.pop();
+    for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
+      const entryPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+        continue;
+      }
+      if (!entry.isFile() || !/\.[cm]?[jt]sx?$/.test(entry.name)) continue;
+
+      const content = fs.readFileSync(entryPath, "utf-8");
+      if (!content.includes("createMockDataExecutor") && !content.includes("setDataOperationExecutor")) continue;
+
+      const hasDevelopmentGuards = content.includes("import.meta.env.DEV") && content.includes("VITE_USE_MOCK");
+      const hasDynamicImports = /import\(\s*["']@microsoft\/power-apps\/data\/executors["']\s*\)/.test(content)
+        && /import\(\s*["']@microsoft\/power-apps\/internal\/data["']\s*\)/.test(content);
+      if (!hasDevelopmentGuards || !hasDynamicImports) {
+        errors.push(
+          `${path.relative(root, entryPath)} のモックデータ実行基盤が開発限定の動的 import になっていません。\n` +
+          `     → import.meta.env.DEV && VITE_USE_MOCK === "1" で制限し、SDK の 2 モジュールを動的 import してください。`
+        );
+      }
+    }
+  }
+}
+
+// 6. 本番成果物にモック実行基盤が混入していないか
+const distPath = path.join(root, "dist");
+if (fs.existsSync(distPath)) {
+  const mockMarkers = ["createMockDataExecutor", "setDataOperationExecutor", "@microsoft/power-apps/data/executors"];
+  const pending = [distPath];
+
+  while (pending.length > 0) {
+    const currentPath = pending.pop();
+    for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
+      const entryPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+        continue;
+      }
+      if (!entry.isFile() || entry.name.endsWith(".map")) continue;
+
+      const content = fs.readFileSync(entryPath, "utf-8");
+      if (mockMarkers.some(marker => content.includes(marker))) {
+        errors.push(
+          `本番成果物 ${path.relative(root, entryPath)} にモックデータ実行基盤が含まれています。\n` +
+          `     → import.meta.env.DEV && VITE_USE_MOCK === "1" の動的 import に限定してください。`
+        );
+      }
+    }
+  }
+}
+
 // 結果出力
 if (errors.length > 0) {
   console.error("\n❌ デプロイ前チェック失敗:\n");


### PR DESCRIPTION
## Summary
- add the Power Apps SDK 1.2.7 mock data development pattern
- document the real `MockDataStore` shape and read-only limitations
- reject unguarded mock imports and mock markers in production bundles
- run `predeploy` after production build and enforce that order in the validator

## Verification
- `node --check` for both pre-deploy scripts
- source guard fixture: unguarded imports rejected, guarded dynamic imports accepted
- bundle fixture: clean bundle accepted, mock-contaminated bundle rejected
- generic-base production build succeeded
- temporary generic-base mock sample ran in Vite with `VITE_USE_MOCK=1`
- Playwright confirmed `data-mock-count="1"`, the dashboard rendered, and no console/page errors occurred
- production build of the same mock sample passed post-build `npm run predeploy`, confirming mock code was excluded

## Existing sample limitation
The committed `geek-*` samples require Power Apps CLI-generated files that are intentionally not in Git (`.power/...` or `src/generated/...`), so a clean checkout cannot build them before `power-apps add-data-source`. `geek-asset` and `geek-approval` both stopped only on those missing generated imports.

Closes #308