### PR TITLE
skill(cowork): スキルを追加/更新

### DIFF
--- a/.github/skills/cowork/SKILL.md
+++ b/.github/skills/cowork/SKILL.md
@@ -67,6 +67,7 @@ Cowork から Dataverse を直接操作できるようにする。
 | [scripts/setup_entra_oauth_graph.py](scripts/setup_entra_oauth_graph.py) | **（推奨）** Entra OAuth クライアントアプリを Microsoft Graph API 経由で作成。auth_helper.py のキャッシュ済み認証を利用するため追加のデバイスコード認証が不要（Step 3） |
 | [scripts/setup_entra_oauth.ps1](scripts/setup_entra_oauth.ps1) | （代替）az CLI 経由で同等の処理。az login のデバイスコード認証が必要（Step 3） |
 | [scripts/register_mcp_client.py](scripts/register_mcp_client.py) | Client ID を Dataverse 許可 MCP クライアント（`allowedmcpclients`）に登録・有効化・確認（Step 4） |
+| [scripts/diagnose_cowork_connector.py](scripts/diagnose_cowork_connector.py) | アプリ登録・admin consent・allowedmcpclients の3層をまとめて診断（Step 4→5 の間で実行推奨） |
 | [scripts/build_agent_package.ps1](scripts/build_agent_package.ps1) | `.env` の `COWORK_OAUTH_REGISTRATION_ID`（引用符付きでも可）を manifest.json のプレースホルダーに注入し、必須ファイルを検証して .zip を生成（Step 7） |
 
 ## ワークフロー（正常系）
@@ -201,6 +202,14 @@ $secret = az ad app credential reset --id $appId --display-name "cowork-oauth" `
 >   `.default` にすることで、このアプリに静的設定された `mcp.tools` が要求される。
 > - **シークレットは機密**。`.env` は `.gitignore` で除外する。スキルや manifest には絶対に書かない。
 
+> **テナント管理者の事前同意（admin consent）が必要な場合がある**: テナントがユーザーの自己同意
+> （user consent）を制限していると、`mcp.tools` への同意は Cowork 初回利用時にサイレントに失敗する
+> （エラー表示なしで「コネクタが反応しない」ように見える → troubleshooting #22）。
+> `setup_entra_oauth_graph.py` はアプリ登録後にサービスプリンシパルの作成と admin consent の状態を
+> 自動確認し、未完了なら `https://login.microsoftonline.com/<TENANT_ID>/adminconsent?client_id=<appId>`
+> の形式で URL を表示する。開発者自身がテナント管理者でなければ、この URL をテナント管理者に共有し、
+> 同意を得てから Step 4 以降に進む。
+
 ### Step 4: Entra Client ID を許可 MCP クライアントに登録（必須）
 
 OAuth 認可コードフローでは Dataverse に提示されるトークンの **appid がこのカスタムアプリ**になる。
@@ -224,6 +233,14 @@ python .github/skills/cowork/scripts/register_mcp_client.py --app-id <CLIENT_ID>
 > uniquename 未指定時は `<PUBLISHER_PREFIX>_<name のスラッグ>` で生成される。
 > GUI なら Power Platform 管理センター → 環境 → 設定 → 機能 →
 > Dataverse MCP の詳細設定（`etn=allowedmcpclient`）で +New。
+
+> **Step 5 に進む前に一括診断する（推奨）**: Teams 開発者ポータル登録や zip 再アップロードは
+> 手戻りのコストが高いブラウザ操作なので、その前に3層（アプリ登録・admin consent・
+> allowedmcpclients）が揃っているかを1コマンドで確認しておく。
+> ```powershell
+> python .github/skills/cowork/scripts/diagnose_cowork_connector.py
+> ```
+> いずれかのレイヤーが ❌/❓ の場合は、表示される対処コマンドを実行してから Step 5 に進む。
 
 ### Step 5: Teams 開発者ポータルで OAuth client 登録 → registrationId 取得（ブラウザ）
 
@@ -319,6 +336,10 @@ Save すると **OAuth client registration ID** が発行される。これを `
   > 旧 `search`（データ検索の意味）をそのまま書かない。現在の正しいツール名一覧は
   > [standard/references/dataverse-mcp-setup.md](../standard/references/dataverse-mcp-setup.md#主な-mcpツール) を参照）。
   > 古いツール名のまま公開すると、Cowork 側で該当ツールが認識されずスキルが動作しない（→ troubleshooting #15）。
+  > 上記の例は**読み取り専用の4ツールのみ**。スキルが `create_record`/`update_record`/`delete_record`/
+  > `upsert_skill` 等の**書き込み系ツールを呼ぶ場合は、そのツール名もここに追加する**こと。
+  > 追加を忘れると、読み取りは動くのに書き込み操作だけ「反応しない」原因不明の部分故障になる
+  > （→ troubleshooting #15 の補足）。
 - **アイコンはドメイン文脈を読んでから設計する**（→ [standard/references/icon-creation.md](../standard/references/icon-creation.md)
   の「アイコン画像提案フロー」）。`generate_icon_png.py` の汎用スパークルをそのまま登録しない。
   この manifest の `name`/`description`（プラグインの業務目的）と `accentColor` からモチーフ・配色を決め、
@@ -355,7 +376,7 @@ ZIP 検証: ルートに `manifest.json`（build 後、プレースホルダー�
 
 > ⚠️ Cowork プラグインは**「統合アプリ」ではなく、新しい「エージェント」画面**からアップロードする（UI 変更済み）。
 
-> **ブラウザ自動化で実施する場合の既知の落とし穴**（詳細は troubleshooting #17-19）。事前に把握してから進めると手戻りがない。
+> **ブラウザ自動化で実施する場合の既知の落とし穴**（詳細は troubleshooting #18-20）。事前に把握してから進めると手戻りがない。
 > ブラウザ操作は **VS Code 統合 Playwright ブラウザ**（`playwright-browser_navigate` / `playwright-browser_click` / `playwright-browser_handle_dialog` 等）を使う
 > （Playwright MCP サーバー・Playwright 単体ブラウザは使わない → [ブラウザ自動化方針](../standard/references/browser-automation.md)）。
 > 1. Teams 開発者ポータル → 管理センターへの遷移で **SSO 自動サインインが「Trying to sign you in」で止まる**ことがある。数秒進まなければアカウントピッカーを探してクリックする。
@@ -406,7 +427,9 @@ ZIP 検証: ルートに `manifest.json`（build 後、プレースホルダー�
 - [ ] 生成したスキル本文の最初の Step が「`describe` でスキーマ確認」になっている
 - [ ] フォルダ名 = SKILL.md `name`（kebab-case）
 - [ ] Entra: redirect URI×2 / Dynamics CRM **mcp.tools** / クライアントシークレット（.env）— `scripts/setup_entra_oauth.ps1`
+- [ ] Entra: **テナント管理者の事前同意（admin consent）**が付与済み（未同意だと Cowork 初回同意がサイレントに失敗 → troubleshooting #22）
 - [ ] Power Platform: Entra の **Client ID** を許可された MCP クライアントとして登録・有効化— `scripts/register_mcp_client.py`（`--check` で検証）
+- [ ] 上記3層を `scripts/diagnose_cowork_connector.py` で一括確認（すべて ✅）
 - [ ] Teams ポータル **OAuth client registration**（SSO ではない）: Base URL は `/api/mcp` なし、scope は `.default offline_access`、Restrict by app = Any Teams app → registrationId を manifest に反映
 - [ ] manifest に `mcpToolDescription: { file: "dataverse-mcp-tools.json" }`（JSONツール定義）
 - [ ] ZIP ルートに manifest.json / dataverse-mcp-tools.json、skills/<name>/SKILL.md

--- a/.github/skills/cowork/references/troubleshooting.md
+++ b/.github/skills/cowork/references/troubleshooting.md
@@ -138,6 +138,13 @@ Dataverse ではないため Dataverse 側が拒否し、認証が通らない�
 **対処**: **OAuth 2.0 認可コードフロー**に切り替える（→ SKILL.md Step 2〜3）。
 - Teams ポータルでは **SSO client registration ではなく「OAuth client registration」**を使う。
 - Entra アプリに**クライアントシークレット**を作成し `.env` に保存（Git 非コミット）。
+- Scope に `https://<org>.crm.dynamics.com/user_impersonation` を指定 → Enterprise Token Store が
+  **Dataverse 宛トークンを直接取得**するので audience が一致して通る。
+- OAuth 方式では `Expose an API`・`preAuthorizedApplications`・`identifierUris` は不要。
+- referenceId は発行された **registration ID をそのまま**使う（`Base64("tenant##regId")` 変換は SSO 専用）。
+
+> 見分け方: コネクタの「！」にカーソルを合わせ、`AADSTS500011`（リソース未登録）や
+> `invalid audience` 系のメッセージが出ていれば audience 不一致 = SSO 方式が原因。
 
 ## 15. ツール名変更で `dataverse-mcp-tools.json` が古くなる
 
@@ -155,15 +162,14 @@ Dataverse ではないため Dataverse 側が拒否し、認証が通らない�
 2. `dataverse-mcp-tools.json` を最新のツール名に更新する（廃止済みツール名は削除）。
 3. パッケージを再ビルド・再アップロードする（Step 7 と同じ手順）。
 4. MCP クライアントの許可/拒否リストをツール名で管理している場合は、そちらも合わせて更新する。
-- Scope に `https://<org>.crm.dynamics.com/user_impersonation` を指定 → Enterprise Token Store が
-  **Dataverse 宛トークンを直接取得**するので audience が一致して通る。
-- OAuth 方式では `Expose an API`・`preAuthorizedApplications`・`identifierUris` は不要。
-- referenceId は発行された **registration ID をそのまま**使う（`Base64("tenant##regId")` 変換は SSO 専用）。
 
-> 見分け方: コネクタの「！」にカーソルを合わせ、`AADSTS500011`（リソース未登録）や
-> `invalid audience` 系のメッセージが出ていれば audience 不一致 = SSO 方式が原因。
+> **書き忘れに注意**: `dataverse-mcp-tools.json` は列挙したツールしか Cowork 側に認識されない。
+> 読み取り専用ツール（`read_query`/`search_data`/`search`/`describe`）だけを載せたテンプレートのまま、
+> 書き込みが必要なスキル（`create_record`/`update_record`/`upsert_skill` 等）を追加した場合、
+> 読み取りは動くのに書き込みだけ「反応しない」という一見原因不明の部分故障になる。
+> スキルが実際に呼ぶツール名をすべて含めているか、Step 6 のテンプレートと突き合わせて確認する。
 
-## 15. .env の値を引用符付きで読み込むと referenceId が壊れる
+## 16. .env の値を引用符付きで読み込むと referenceId が壊れる
 
 `.env` に `COWORK_OAUTH_REGISTRATION_ID='xxxx'` のように引用符付きで保存していると、
 単純な正規表現置換（`$Matches[1]`）では**引用符を含んだ文字列**が manifest.json に注入される。
@@ -174,14 +180,14 @@ Cowork 初回同意時にコネクタ認証が失敗する（症状が出るの�
 （→ [scripts/build_agent_package.ps1](../scripts/build_agent_package.ps1) は対応済み）。
 ビルド後は zip を展開して `referenceId` の値にクォートが含まれていないか目視確認するとよい。
 
-## 16. Teams 開発者ポータルの Scope フィールドはカンマ区切り
+## 17. Teams 開発者ポータルの Scope フィールドはカンマ区切り
 
 OAuth client registration の Scope 入力欄は UI のヘルプ文言が
 「Enter each resource, separated by a comma.」＝**カンマ区切り**を要求する。
 `https://<org>.crm.dynamics.com/.default offline_access`（スペース区切り）ではなく
 `https://<org>.crm.dynamics.com/.default,offline_access`（カンマ区切り）で入力する。
 
-## 17. Choose file ボタンはブラウザ自動化では OS ネイティブのファイル選択ダイアログを開く
+## 18. Choose file ボタンはブラウザ自動化では OS ネイティブのファイル選択ダイアログを開く
 
 M365 管理センターの Upload agent ウィザードの「Choose file」ボタンをクリックしても、
 ブラウザ操作ツールの `click` だけではファイルを選択できない（OS ダイアログは DOM 外）。
@@ -189,21 +195,21 @@ M365 管理センターの Upload agent ウィザードの「Choose file」ボ�
 ボタンクリック後に file chooser ダイアログが発生するので、それを待ってから
 `playwright-browser_handle_dialog` でパスを渡す実装にする（Playwright MCP サーバーを別途インストールする必要はない）。
 
-## 18. Fluent UI の ChoiceGroup（ラジオボタン）を直接クリックするとタイムアウトする
+## 19. Fluent UI の ChoiceGroup（ラジオボタン）を直接クリックするとタイムアウトする
 
 管理センター/開発者ポータルの一部フォーム（Publish to users の Install セクション等）では、
 `<input type="radio">` を直接クリックすると、ラベルの `<label>` 要素が pointer-events を奪っていて
 `locator.click: Timeout exceeded` になることがある。
 `input[id=...]` ではなく **対応する `label[for=<id>]` をクリック**すると成功する。
 
-## 19. admin.cloud.microsoft への遷移で SSO 自動サインインが不安定
+## 20. admin.cloud.microsoft への遷移で SSO 自動サインインが不安定
 
 Teams 開発者ポータルから M365 管理センターへ遷移する際、自動 SSO サインインが
 「Trying to sign you in」でスピナーのまま止まることがある。数秒待っても進まない場合は
 アカウント選択画面が裏で待機していることが多いので、アカウントピッカーの表示を確認し、
 サインイン済みアカウントを明示的にクリックすると解消する。
 
-## 20. Cowork セッションワークスペースが DLP でブロックされる（EU National ID / TIN 等）
+## 21. Cowork セッションワークスペースが DLP でブロックされる（EU National ID / TIN 等）
 
 **症状**: Cowork セッション中に作成・共有されたファイル（SharePoint Embedded 上の
 `.../contentstorage/CSP_<containerTypeId>/Document Library/cowork/sessions/<sessionId>/workspace`）
@@ -264,5 +270,44 @@ SharePoint Embedded ストレージ自体は既存のテナント DLP ポリシ�
      ポリシー自体の設定とは無関係。ダイアログが不安定でクリックが安定しない場合は、
      ルール一覧の**状態トグルをオフにするだけ**の方が操作がシンプルで確実。
 3. **現状維持**: 検証用データで GDPR SIT が検出されるのは意図した動作であり、対処不要と判断する。
+
+## 22. テナント管理者の事前同意（admin consent）未実施 → Cowork 初回同意がサイレントに失敗する
+
+**症状**: manifest のアップロード・公開は成功し、Cowork の Sources & Skills にプラグインも
+表示される。だが実際にスキルを実行すると Dataverse MCP コネクタ経由の操作（`read_query` 等）が
+一切完了しない。コネクタの状態アイコンにはっきりしたエラーが出ないことが多く、「同意ダイアログが
+一瞬出て消える」「何も起きたように見えない」だけで再現手順も分かりにくい。トラブルシュート #14 の
+SSO/OAuth 方式の切り分け（audience 不一致）を確認しても異常が見つからない場合はこちらを疑う。
+
+**原因**: Step 3 で作成した Entra アプリの Dynamics CRM 委任スコープ `mcp.tools` は、既定では
+**ユーザーが個別に同意する（user consent）**扱いになる。テナントの同意設定が
+「ユーザーはアプリへの同意ができない」（Enterprise ガバナンスで一般的な設定）になっていると、
+Cowork 初回利用時に Enterprise Token Store が試みる同意フローがブロックされる。ブロックは
+バックエンドで起きるため、Cowork の UI 上はエラーメッセージなしで「コネクタが反応しない」ように
+しか見えない。**テナント管理者による事前の管理者同意（admin consent）**が必要。
+
+**診断方法**:
+
+```powershell
+# レイヤー1（アプリ登録）/ レイヤー2（admin consent）/ レイヤー3（allowedmcpclients）を一括診断
+python .github/skills/cowork/scripts/diagnose_cowork_connector.py
+```
+
+レイヤー2（テナント管理者の事前同意）が ❌/❓ の場合が本事象の典型パターン。
+
+**対処**:
+
+1. [scripts/setup_entra_oauth_graph.py](../scripts/setup_entra_oauth_graph.py) を実行すると
+   admin consent の状態を自動確認し、未完了なら次の形式の URL を表示する。
+   ```
+   https://login.microsoftonline.com/<TENANT_ID>/adminconsent?client_id=<COWORK_OAUTH_CLIENT_ID>
+   ```
+2. この URL に **Global Administrator（または Privileged Role Administrator）権限を持つテナント管理者**
+   がアクセスし、表示された権限（Dynamics CRM の `mcp.tools`）に同意する。
+3. 同意完了後、`diagnose_cowork_connector.py` を再実行し、レイヤー2 が ✅ になることを確認する。
+4. Cowork でスキルを再実行し、初回同意ダイアログが正常に完了することを確認する。
+
+> 開発者自身がテナント管理者を兼ねる場合は、Step 3 の直後に `setup_entra_oauth_graph.py` が表示する
+> URL に自分でアクセスするだけで完了する（追加のポータル操作は不要）。
 
 

--- a/.github/skills/cowork/scripts/diagnose_cowork_connector.py
+++ b/.github/skills/cowork/scripts/diagnose_cowork_connector.py
@@ -1,0 +1,214 @@
+"""Cowork の Dataverse MCP コネクタが動作する状態か、Teams ポータル/M365 管理センターの
+手作業（アップロード）に進む前に一括診断する。
+
+Cowork プラグインは「アップロードは成功するがコネクタが動かない」という失敗の仕方をする
+（エラーが表示されないことが多い）。原因は主に次の3層のどこかが欠けていることが多い。
+
+  レイヤー1: Entra OAuth アプリ登録・シークレット・リダイレクト URI が正しいか
+  レイヤー2: テナント管理者の事前同意（admin consent）が mcp.tools に付与されているか
+             （欠けていると、ユーザー個々の同意画面がテナントの user consent 制限で
+             ブロックされ、Cowork 初回利用時の同意がサイレントに失敗する）
+  レイヤー3: Dataverse 環境の allowedmcpclients に登録・有効化されているか
+
+このスクリプトは上記3層を API で確認し、失敗しているレイヤーごとに次の対処コマンドを提示する。
+手動の Teams ポータル登録・zip 再ビルド・M365 管理センターへの再アップロードといった
+時間のかかる工程に進む前に、まずこれで原因を切り分ける。
+
+前提: auth_helper.py（standard/scripts）、python-dotenv、requests。
+.env に TENANT_ID / DATAVERSE_URL / COWORK_OAUTH_CLIENT_ID が必要
+（COWORK_OAUTH_CLIENT_SECRET はレイヤー1のシークレット有効期限チェックにのみ使用）。
+
+使い方:
+  python diagnose_cowork_connector.py
+  python diagnose_cowork_connector.py --app-id <CLIENT_ID>
+
+終了コード: 全レイヤー OK なら 0、1件以上 NG/確認不能なら 1。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+for candidate in [
+    HERE / ".." / ".." / "standard" / "scripts",
+    HERE / ".." / ".." / ".." / ".github" / "skills" / "standard" / "scripts",
+]:
+    resolved = candidate.resolve()
+    if (resolved / "auth_helper.py").is_file():
+        sys.path.insert(0, str(resolved))
+        break
+
+from auth_helper import get_token, get_session, DATAVERSE_URL  # noqa: E402
+
+try:
+    from dotenv import load_dotenv
+except ImportError:
+    sys.exit("python-dotenv が必要です: pip install python-dotenv")
+
+import requests  # noqa: E402
+
+DYNAMICS_CRM_APP_ID = "00000007-0000-0000-c000-000000000000"
+GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+TEAMS_REDIRECT_URIS = {
+    "https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect",
+    "https://teams.microsoft.com/api/platform/v1.0/oAuthConsentRedirect",
+}
+
+
+def resolve_env() -> Path | None:
+    d = HERE
+    while d != d.parent:
+        candidate = d / ".env"
+        if candidate.is_file():
+            return candidate
+        d = d.parent
+    return None
+
+
+def graph_get(path: str) -> dict:
+    token = get_token(scope="https://graph.microsoft.com/.default")
+    r = requests.get(f"{GRAPH_BASE}{path}", headers={"Authorization": f"Bearer {token}"})
+    r.raise_for_status()
+    return r.json()
+
+
+def check_layer1_app(app_id: str) -> tuple[bool | None, str]:
+    """レイヤー1: アプリ登録・リダイレクト URI・シークレット有効期限。"""
+    try:
+        found = graph_get(
+            f"/applications?$filter=appId eq '{app_id}'"
+            "&$select=displayName,web,passwordCredentials"
+        )
+    except requests.HTTPError as exc:
+        return None, f"確認不能（Graph API 呼び出し失敗: {exc}）"
+
+    values = found.get("value", [])
+    if not values:
+        return False, f"appId={app_id} のアプリ登録が見つかりません"
+
+    app = values[0]
+    redirect_uris = set((app.get("web") or {}).get("redirectUris") or [])
+    missing_redirects = TEAMS_REDIRECT_URIS - redirect_uris
+    if missing_redirects:
+        return False, f"リダイレクト URI が不足: {missing_redirects}"
+
+    creds = app.get("passwordCredentials") or []
+    if not creds:
+        return False, "クライアントシークレットが未作成"
+
+    now = datetime.now(timezone.utc)
+    expiries = []
+    for c in creds:
+        end = c.get("endDateTime")
+        if end:
+            expiries.append(datetime.fromisoformat(end.replace("Z", "+00:00")))
+    if expiries and max(expiries) < now:
+        return False, f"全てのクライアントシークレットが期限切れ（最新: {max(expiries)}）"
+
+    return True, f"アプリ '{app.get('displayName')}' 登録済み・リダイレクト URI OK・シークレット有効"
+
+
+def check_layer2_consent(app_id: str) -> tuple[bool | None, str]:
+    """レイヤー2: テナント管理者の事前同意（admin consent）。"""
+    try:
+        sp_found = graph_get(f"/servicePrincipals?$filter=appId eq '{app_id}'&$select=id")
+        sp_values = sp_found.get("value", [])
+        if not sp_values:
+            return False, "サービスプリンシパルが未作成（admin consent が一度も行われていない可能性）"
+        sp_id = sp_values[0]["id"]
+
+        dyn_found = graph_get(
+            f"/servicePrincipals?$filter=appId eq '{DYNAMICS_CRM_APP_ID}'&$select=id"
+        )
+        dyn_values = dyn_found.get("value", [])
+        if not dyn_values:
+            return None, "Dynamics CRM サービスプリンシパルが見つかりません（環境異常）"
+        resource_id = dyn_values[0]["id"]
+
+        grants = graph_get(f"/servicePrincipals/{sp_id}/oauth2PermissionGrants")
+        for g in grants.get("value", []):
+            if g.get("resourceId") == resource_id and "mcp.tools" in (g.get("scope") or "").split():
+                return True, f"mcp.tools への事前同意あり（consentType={g.get('consentType')}）"
+        return False, "mcp.tools への事前同意（admin consent）が見つかりません"
+    except requests.HTTPError as exc:
+        return None, f"確認不能（Graph API 権限不足の可能性: {exc}）"
+
+
+def check_layer3_allowlist(app_id: str) -> tuple[bool | None, str]:
+    """レイヤー3: Dataverse 環境の allowedmcpclients 登録・有効化。"""
+    try:
+        session = get_session()
+        url = (
+            f"{DATAVERSE_URL}/api/data/v9.2/allowedmcpclients"
+            f"?$filter=applicationid eq '{app_id}'&$select=name,isenabled"
+        )
+        r = session.get(url)
+        r.raise_for_status()
+        values = r.json().get("value", [])
+        if not values:
+            return False, "allowedmcpclients に未登録"
+        client = values[0]
+        if not client.get("isenabled"):
+            return False, f"'{client.get('name')}' は登録済みだが無効化されています"
+        return True, f"'{client.get('name')}' が登録・有効化済み"
+    except requests.HTTPError as exc:
+        return None, f"確認不能（Dataverse API 呼び出し失敗: {exc}）"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Cowork Dataverse MCP コネクタの3層診断")
+    ap.add_argument("--app-id", default=os.getenv("COWORK_OAUTH_CLIENT_ID", ""),
+                    help="診断対象の Entra Client ID（既定: .env の COWORK_OAUTH_CLIENT_ID）")
+    args = ap.parse_args()
+
+    env_path = resolve_env()
+    if env_path:
+        load_dotenv(env_path)
+    app_id = args.app_id or os.getenv("COWORK_OAUTH_CLIENT_ID", "")
+    if not app_id:
+        sys.exit("--app-id か .env の COWORK_OAUTH_CLIENT_ID を指定してください。")
+
+    print(f"診断対象アプリ: {app_id}")
+    print(f"Dataverse 環境: {DATAVERSE_URL}\n")
+
+    checks = [
+        ("レイヤー1: Entra OAuth アプリ登録", check_layer1_app(app_id),
+         "python .github/skills/cowork/scripts/setup_entra_oauth_graph.py"),
+        ("レイヤー2: テナント管理者の事前同意（admin consent）", check_layer2_consent(app_id),
+         "python .github/skills/cowork/scripts/setup_entra_oauth_graph.py の Step 5 の案内 URL を管理者に共有"),
+        ("レイヤー3: 環境の allowedmcpclients 登録", check_layer3_allowlist(app_id),
+         "python .github/skills/cowork/scripts/register_mcp_client.py"),
+    ]
+
+    overall_ok = True
+    for label, (ok, detail), fix_cmd in checks:
+        if ok is True:
+            mark = "✅"
+        elif ok is False:
+            mark = "❌"
+            overall_ok = False
+        else:
+            mark = "❓"
+            overall_ok = False
+        print(f"{mark} {label}")
+        print(f"   {detail}")
+        if ok is not True:
+            print(f"   → 対処: {fix_cmd}")
+        print()
+
+    if overall_ok:
+        print("✅ 3層すべて OK です。Teams 開発者ポータルでの OAuth client registration / manifest の")
+        print("   referenceId・mcpToolDescription（ツール名の一致）を確認してください。")
+        return 0
+
+    print("❌ 上記の対処を行ってから再実行してください（Teams ポータル登録・zip 再アップロードより先に解消する）。")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/cowork/scripts/diagnose_dlp_block.py
+++ b/.github/skills/cowork/scripts/diagnose_dlp_block.py
@@ -2,7 +2,7 @@
 
 auth_helper.py のキャッシュ済み認証（Microsoft Graph スコープ）を使い、追加のサインインなしで
 共有 URL の driveItem 解決を試みる。実際にはこのテナントでは Graph API 経由での DLP ポリシー
-閲覧・アラート取得は機能しないことが多い（→ troubleshooting.md #20 参照）ため、本スクリプトは
+閲覧・アラート取得は機能しないことが多い（→ troubleshooting.md #21 参照）ため、本スクリプトは
 「本当にブロックされているか」の一次切り分けにのみ使い、ポリシーの特定・是正は
 Microsoft Purview ポータル（https://purview.microsoft.com/datalossprevention/policies）を
 VS Code 統合ブラウザツールで直接確認する。
@@ -74,7 +74,7 @@ def main() -> None:
             "\n→ 次のステップ: Microsoft Purview ポータル "
             "(https://purview.microsoft.com/datalossprevention/policies) を"
             "VS Code 統合ブラウザツールで開き、SharePoint サイトを対象に含むポリシーを確認する"
-            "（詳細は troubleshooting.md #20）。"
+            "（詳細は troubleshooting.md #21）。"
         )
     elif resp.status_code == 200:
         print("\n→ アクセス可能。DLP ブロックは発生していない（または既に解除済み）。")

--- a/.github/skills/cowork/scripts/setup_entra_oauth_graph.py
+++ b/.github/skills/cowork/scripts/setup_entra_oauth_graph.py
@@ -16,6 +16,12 @@ Dynamics CRM の委任権限 mcp.tools を付与、クライアントシーク�
   COWORK_OAUTH_CLIENT_ID     作成後に書き込まれる Client ID
   COWORK_OAUTH_CLIENT_SECRET 作成後に書き込まれるクライアントシークレット
 
+  テナントがユーザーの自己同意（user consent）を制限している場合、Dynamics CRM の
+  委任スコープ mcp.tools はユーザー個々の同意画面でブロックされ、Cowork 初回利用時の
+  OAuth 同意がサイレントに失敗する（エラーが出ずコネクタが動かないだけに見える）。
+  このスクリプトはアプリ登録後に **テナント管理者の事前同意（admin consent）** の状態を
+  確認し、未完了なら admin consent URL を提示する（→ SKILL.md Step 3 / troubleshooting #22）。
+
 教訓:
   元々は az CLI (setup_entra_oauth.ps1) で Entra アプリを作成していたが、
   auth_helper.py で既にキャッシュ済みの認証情報があるのに毎回 az login の
@@ -89,6 +95,56 @@ def graph_post(path: str, body: dict) -> dict:
     return r.json()
 
 
+def graph_get(path: str) -> dict:
+    r = requests.get(f"{GRAPH_BASE}{path}", headers=graph_headers())
+    if not r.ok:
+        print(f"  ERROR {r.status_code}: {r.text}", file=sys.stderr)
+    r.raise_for_status()
+    return r.json()
+
+
+def ensure_service_principal(app_id: str) -> str | None:
+    """自アプリのサービスプリンシパルを取得（無ければ作成）し、その id を返す。
+
+    テナント管理者の事前同意（admin consent）状態を後から検証するために必要。
+    作成に失敗しても（権限不足等）致命的エラーにはせず None を返す
+    （admin consent URL を踏めばテナント側で自動的に作成されるため）。
+    """
+    found = graph_get(f"/servicePrincipals?$filter=appId eq '{app_id}'&$select=id")
+    values = found.get("value", [])
+    if values:
+        return values[0]["id"]
+    try:
+        created = graph_post("/servicePrincipals", {"appId": app_id})
+        return created.get("id")
+    except requests.HTTPError:
+        return None
+
+
+def check_admin_consent(sp_id: str) -> bool | None:
+    """mcp.tools の委任スコープにテナント全体の事前同意が既にあるかを確認する。
+
+    戻り値: True=同意済み / False=未同意 / None=権限不足等で確認不能（要手動確認）。
+    """
+    if not sp_id:
+        return None
+    try:
+        dynamics_sp = graph_get(
+            f"/servicePrincipals?$filter=appId eq '{DYNAMICS_CRM_APP_ID}'&$select=id"
+        )
+        dyn_values = dynamics_sp.get("value", [])
+        if not dyn_values:
+            return None
+        resource_id = dyn_values[0]["id"]
+        grants = graph_get(f"/servicePrincipals/{sp_id}/oauth2PermissionGrants")
+        for g in grants.get("value", []):
+            if g.get("resourceId") == resource_id and "mcp.tools" in (g.get("scope") or "").split():
+                return True
+        return False
+    except requests.HTTPError:
+        return None
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Entra OAuth クライアントを Graph API で作成（auth_helper 利用）")
     ap.add_argument("--display-name", default="Cowork-DataverseMCP-OAuth",
@@ -144,14 +200,38 @@ def main() -> int:
     set_key(str(env_path), "COWORK_OAUTH_CLIENT_ID", app_id)
     set_key(str(env_path), "COWORK_OAUTH_CLIENT_SECRET", client_secret)
 
+    # ---- Step 4: サービスプリンシパルを作成（admin consent 状態確認の前提） ----
+    print("== 4. サービスプリンシパルを確認/作成 ==")
+    time.sleep(2)  # アプリ作成のレプリケーション待ち
+    sp_id = ensure_service_principal(app_id)
+    if sp_id:
+        print(f"   servicePrincipal id={sp_id}")
+    else:
+        print("   WARN: サービスプリンシパルの作成/確認に失敗（権限不足の可能性。admin consent URL を踏めば自動作成される）")
+
+    # ---- Step 5: テナント管理者の事前同意（admin consent）状態確認 ----
+    print("== 5. テナント管理者の事前同意（admin consent）確認 ==")
+    tenant_id = os.environ.get("TENANT_ID", "")
+    consent_url = f"https://login.microsoftonline.com/{tenant_id or '<TENANT_ID>'}/adminconsent?client_id={app_id}"
+    consented = check_admin_consent(sp_id) if sp_id else None
+    if consented is True:
+        print("   ✅ 既にテナント全体への事前同意が付与済みです（mcp.tools）。")
+    else:
+        status = "❌ 未同意" if consented is False else "❓ 確認不能（権限不足）"
+        print(f"   {status}: テナント管理者（Global Admin 等）が下記 URL にアクセスして事前同意してください：")
+        print(f"   {consent_url}")
+        print("   （ユーザー自己同意がテナントで禁止されていると、この事前同意がない限り Cowork 初回利用時の同意がサイレントに失敗します）")
+
     print()
     print("✅ 完了:")
     print(f"   COWORK_OAUTH_CLIENT_ID={app_id}")
     print("   COWORK_OAUTH_CLIENT_SECRET=（.env に保存。表示は省略）")
     print()
     print("次のステップ:")
-    print("  1. python .github/skills/cowork/scripts/register_mcp_client.py")
-    print("  2. Teams 開発者ポータルで OAuth client registration を作成")
+    print("  1. 上記 admin consent が ❌/❓ の場合、テナント管理者に URL を共有して同意を得る")
+    print("  2. python .github/skills/cowork/scripts/register_mcp_client.py")
+    print("  3. Teams 開発者ポータルで OAuth client registration を作成")
+    print("  4. python .github/skills/cowork/scripts/diagnose_cowork_connector.py で総合確認")
     return 0
 
 


### PR DESCRIPTION
Fixes #330

スキル cowork を追加/更新します。

## 変更内容
- Dataverse MCP コネクタが「アップロードは成功するが動作しない」原因のひとつだった、**テナント管理者の事前同意(admin consent)の欠如**に対応
  - scripts/setup_entra_oauth_graph.py: サービスプリンシパル確認/作成 + admin consent 状態チェック(Step 4/5)を追加
  - scripts/diagnose_cowork_connector.py(新規): アプリ登録/admin consent/allowedmcpclients の3層を一括診断
  - SKILL.md: Step 3/4 に admin consent の説明・診断コマンドの案内を追記、Step 6 に書き込み系ツール追加漏れの注意を追記
  - eferences/troubleshooting.md: 新規エントリ #22 を追加。あわせて既存の重複した『## 15.』見出しの整理と、それに伴う以降の番号振り直し(#16〜#21)、および diagnose_dlp_block.py 内の参照番号更新も実施
- validate_skill.py PASS
- マージ順: 単独 PR（他のオープン PR と無関係なら番号順で可）