### PR TITLE
chore: .env 派生ファイルと世代付き生成 config を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,11 @@ dist/
 Thumbs.db
 
 # Environment
+# .env.before-xxx のような派生ファイルを取りこぼさないため接尾辞を含めて除外する
 .env
-.env.local
-.env.*.local
+.env.*
+!.env.example
+!*.env.example
 
 # Authentication cache (auth_helper.py)
 .auth_record.json
@@ -62,7 +64,7 @@ __pycache__/
 # agent365 (PoC scaffold under agents/sales-copilot-nova — generated/secret artifacts)
 agents/**/agent.yaml
 teams/*.zip
-a365.generated.config.json
+a365.generated.config*.json
 .a365-auth.json
 auth-token.json
 *token-cache*


### PR DESCRIPTION
## 背景

公開リポジトリの履歴監査中に、リポジトリ直下に `.env.before-mina`（実テナント値・資格情報を含む）が **未追跡かつ .gitignore 対象外** で存在していたことを検出した。

原因は `.env` の除外が完全一致のみで、`.env.before-xxx` のような派生ファイル名を取りこぼしていたこと。同様に `a365.generated.config.<suffix>.json` も除外対象外だった。`git add -A` 一回で公開リポジトリに混入しうる状態。

※ 実際の混入は履歴を含めて 0 件（GitHub Secret Scanning のアラートも 0 件、Push Protection 有効）。本 PR は再発防止のみ。

## 変更

- `.env.local` / `.env.*.local` → `.env.*` に拡張
- `.env.example` は否定パターンで追跡対象に残す
- `a365.generated.config.json` → `a365.generated.config*.json`

## 検証

`git check-ignore -v --no-index` で確認済み。

| ファイル | 判定 |
|---|---|
| `.env.before-mina` / `.env.local` | 除外される |
| `a365.generated.config.before-newblueprint-20260731-055608-471.json` | 除外される |
| `.env.example`（ルート・各スキル配下） | 除外されない（従来どおり追跡） |

追跡ファイルへの影響なし。