### PR TITLE
skill(agent365): ログを最初から取れる状態にする

### DIFF
--- a/.github/skills/agent365/SKILL.md
+++ b/.github/skills/agent365/SKILL.md
@@ -391,6 +391,10 @@ az webapp log tail -g $env:AZURE_RESOURCE_GROUP -n $env:AGENT_WEBAPP_NAME
 を流したまま Teams でエージェントにメッセージを送り、応答が返ることを確認する。
 [検証チェックリスト](#検証チェックリスト)を上から確認する。
 
+> 何も流れてこないときはログ設定が無効になっている。起動時にしか出ないログを取るには
+> **`log tail` を先に繋いでから restart する**必要がある。手順は
+> [references/self-hosted-agent.md](references/self-hosted-agent.md) 手順 7。
+
 応答が返るようになったら、中身の作り込みは
 [references/agent-brain.md](references/agent-brain.md) に従って進める
 （**ID 面は凍結し、アプリ面だけを回す**）。実データを扱わせる場合は同ファイル §6（Dataverse MCP）へ。

--- a/.github/skills/agent365/references/self-hosted-agent.md
+++ b/.github/skills/agent365/references/self-hosted-agent.md
@@ -37,7 +37,7 @@ python scripts/provision_selfhost.py --write .env
 |---|---|---|
 | ユーザー割り当てマネージド ID | Azure Bot の ID | `msaAppType=UserAssignedMSI` |
 | Azure Bot + MsTeams チャネル | Teams チャネル登録 | `az bot create` は廃止 API 版のため `az rest --method PUT`（`api-version=2022-09-15`）を使う。`acceptedTerms=True` は **PUT でのみ**保持される |
-| App Service プラン + Web アプリ | Agents SDK アプリの実行環境 | Linux / `DOTNETCORE:8.0`。**B1 以上 + Always On**（スクリプトが自動で有効化する） |
+| App Service プラン + Web アプリ | Agents SDK アプリの実行環境 | Linux / `DOTNETCORE:8.0`。**B1 以上 + Always On**（スクリプトが自動で有効化する）。ファイル システム ログも同時に有効化される |
 
 - **Free / Shared（F1・D1）は使えない。** Always On が無いため、リクエストが 20 分来ないと
   アプリがアンロードされ、**`BackgroundService` が丸ごと止まる**。受信トレイ監視（B6）も
@@ -91,6 +91,13 @@ appsettings.json      下記の agentic 設定
     "Enabled": true,
     "Audiences": [ "${A365_AGENT_BLUEPRINT_ID}", "${AZURE_BOT_MSA_APP_ID}" ],
     "TenantId": "${AZURE_TENANT_ID}"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Agents.Authentication.Msal": "Warning",
+      "System.Net.Http.HttpClient": "Warning"
+    }
   }
 }
 ```
@@ -101,6 +108,7 @@ appsettings.json      下記の agentic 設定
 | `ClientId` | **ブループリント appId** | Bot の `msaAppId` ではない |
 | `Scopes` | `5a807f24-c9de-44ee-a3a7-329e88a00ffc/.default` | Messaging Bot API Application（固定値） |
 | `TokenValidation:Audiences` | ブループリント appId ＋ Bot の `msaAppId` | 前者が Agent 365 の 401 を解消する要 |
+| `Logging:LogLevel` | MSAL と `HttpClient` を `Warning` に落とす | 既定のままだと**トークン取得 1 回あたり数十行**が出て、自作の `ILogger` 出力がスクロールで流れて読めない。手順 6 の切り分け中だけ `Information` に戻す |
 
 Bot の appId とブループリント appId を別コネクションに分けたい場合は
 `ConnectionSettings.AlternateBlueprintConnectionName` で 2 コネクション構成にできる
@@ -168,3 +176,29 @@ Teams に応答が返れば完了。ログの読み方:
 | `AADSTS82001 ... not permitted to request app-only tokens` | **無視してよい**（agentic アプリの仕様） |
 | `AADSTS65001 ... has not consented` | 手順 6 が未実施 |
 | `Only IConfidentialClientApplication ... is supported for Agentic.` | 手順 3 の `AuthType` が confidential client になっていない |
+
+#### 起動時のログを取る
+
+`BackgroundService` の登録内容など、**起動時に一度だけ出るログ**はこちらの手順でないと取れない。
+
+1. **ログが有効か確かめる**。既定では無効で、`az webapp log tail` に何も出ない。
+
+   ```powershell
+   az webapp log config -g $env:AZURE_RESOURCE_GROUP -n $env:AGENT_WEBAPP_NAME `
+     --application-logging filesystem --docker-container-logging filesystem --level information
+   ```
+
+2. **`log tail` を先に繋いでから restart する**。逆にすると起動ログは取り逃す。
+   `az` はファイルにリダイレクトすると出力をバッファするので、別プロセスで走らせる。
+
+   ```powershell
+   $p = Start-Process cmd.exe -ArgumentList '/c',"az webapp log tail -g $env:AZURE_RESOURCE_GROUP -n $env:AGENT_WEBAPP_NAME > tail.txt 2>&1" -WindowStyle Hidden -PassThru
+   Start-Sleep -Seconds 15
+   az webapp restart -g $env:AZURE_RESOURCE_GROUP -n $env:AGENT_WEBAPP_NAME
+   Start-Sleep -Seconds 150   # コンテナ起動は 1～2 分かかる
+   Stop-Process -Id $p.Id -Force
+   Select-String -Path tail.txt -Pattern 'Worker|Schedule|Mailbox'
+   ```
+
+`az webapp log download` は**アーカイブ済みのファイルしか返さない**（直近の起動は入らない）。
+Kudu の VFS API で直接読むのも、SCM の基本認証が無効なテナントでは 401 になる（→ [troubleshooting.md](troubleshooting.md) #33）。

--- a/.github/skills/agent365/references/troubleshooting.md
+++ b/.github/skills/agent365/references/troubleshooting.md
@@ -604,3 +604,32 @@ F1 には 1 日 60 CPU 分のクォータもあり、超えるとその日はア
 
 **恒久対策済み**: `templates/MessageHtml.template.cs` の `LinkLabel()` / `Shorten()`。
 表示文字の 60 文字打ち切りが HTML エンティティを割らないようにする処理も同時に入れた。
+
+## 41. `az webapp log tail` に何も出ない / 自分のログが見つからない
+
+**症状**: 不具合の切り分けにログを見ようとしたら、何も流れてこない。
+あるいは MSAL の出力ばかりで、`ILogger` に書いたはずの行が見当たらない。
+
+**原因は 3 つある**。
+
+1. **App Service のログ設定が既定で無効**。有効化しないとストリームは空のまま。
+
+   ```powershell
+   az webapp log config -g $env:AZURE_RESOURCE_GROUP -n $env:AGENT_WEBAPP_NAME `
+     --application-logging filesystem --docker-container-logging filesystem --level information
+   ```
+
+2. **MSAL と `HttpClient` の既定ログが多すぎる**。トークン取得 1 回で数十行出るため、
+   自作のログが端末のスクロール バックから押し出される。`appsettings.json` の
+   `Logging:LogLevel` で両方 `Warning` に落とす（→ [self-hosted-agent.md](self-hosted-agent.md) 手順 3）。
+
+3. **見たい行が起動時にしか出ない**のに、`restart` の後から `log tail` を繋いでいる。
+   `log tail` を先に繋いでから restart し、コンテナ起動（1〜2 分）を待ち切る。
+   `az` はファイルへリダイレクトすると出力をバッファするので、別プロセスで走らせる
+   （手順は [self-hosted-agent.md](self-hosted-agent.md) 手順 7）。
+
+`az webapp log download` はアーカイブ済みのファイルしか返さず、直近の起動は入らない。
+Kudu の VFS API で直接読む手も、SCM の基本認証が無効なテナントでは 401 になる（→ #33）。
+
+**恒久対策済み**: `scripts/provision_selfhost.py` が Web アプリ作成時にファイル システム ログを
+有効化する。必要になってから慌てて設定しても、**その時点より前のログは残っていない**。

--- a/.github/skills/agent365/scripts/provision_selfhost.py
+++ b/.github/skills/agent365/scripts/provision_selfhost.py
@@ -129,6 +129,10 @@ def main() -> int:
         host = webapp["defaultHostName"]
         endpoint = f"https://{host}/api/messages"
         az("webapp", "config", "set", "-g", rg, "-n", app_name, "--always-on", "true", "-o", "none")
+        # Off by default; without this `az webapp log tail` shows nothing when you finally need it.
+        az("webapp", "log", "config", "-g", rg, "-n", app_name,
+           "--application-logging", "filesystem", "--docker-container-logging", "filesystem",
+           "--level", "information", "-o", "none")
         az("webapp", "identity", "assign", "-g", rg, "-n", app_name,
            "--identities", uami_resource_id, "-o", "none")
 


### PR DESCRIPTION
PR #339 のデプロイ検証で詰まった点を反映する。
**不具合そのものではなく、不具合を見つける手段が無かった**という教訓。

## 起きたこと

#339 で `ScheduleWorker` に起動ログを追加した。デプロイ後にそれを確認しようとしたが、
**ログを 1 行読むまでに 8 回試行した。**

| 詰まった点 | 実際の挙動 |
|---|---|
| `az webapp log tail` に何も出ない | App Service のログ設定が**既定で無効**。有効化するまでストリームは空 |
| 有効化しても自分のログが見つからない | MSAL と `HttpClient` の既定ログが多すぎて、トークン取得 1 回で数十行。端末のスクロール バックから押し出される |
| `restart` してから tail を繋いだ | 見たい行は**起動時にしか出ない**。既に流れ終わっていた |
| ファイルへリダイレクトしたら 0 バイト | `az` は非 TTY だと出力をバッファする。別プロセスで走らせる必要がある |
| `az webapp log download` を試した | アーカイブ済みのファイルしか返さず、直近の起動は入らない |
| Kudu の VFS API を試した | SCM の基本認証が無効なテナントでは 401（既知・#33） |

最終的に取れたログはこれで、**登録内容と次回実行時刻がその場で分かる**:

```
info: <Agent>.ScheduleWorker[0]
      Schedule worker checking every 60s
info: <Agent>.ScheduleWorker[0]
      Schedule <id> '<タイトル>' 平日 08:00 → chat <宛先>; next run 2026-08-07 (Fri) 08:00 JST
```

これが読めるかどうかで、「登録されていない」のか「動いていない」のかの切り分け時間が変わる。

## 変更

| ファイル | 内容 |
|---|---|
| `scripts/provision_selfhost.py` | Web アプリ作成時に `az webapp log config --application-logging filesystem --docker-container-logging filesystem --level information` を実行（**恒久対策**） |
| `references/self-hosted-agent.md` 手順 3 | `appsettings.json` に `Logging:LogLevel` を追加。MSAL と `HttpClient` を `Warning` に落とす |
| `references/self-hosted-agent.md` 手順 7 | 「起動時のログを取る」を追加。tail を先に繋いでから restart する手順、`az` のバッファ回避、`log download` / Kudu が使えない理由 |
| `references/troubleshooting.md` #41 | 3 つの原因と対処 |
| `SKILL.md` Step 13 | 何も流れてこないときの参照先を注記 |

**恒久対策を作成時に寄せたのは、必要になってから設定しても手遅れだから。**
ログ設定は「有効化した時点より前」を残さない。障害が起きてから有効化しても、
その障害のログは取れない。

## 検証

- `validate_skill.py --all` → 18/18 ✅
- `python -m py_compile provision_selfhost.py` → OK
- 秘匿情報スキャン → CLEAN
- 手順 7 に書いたコマンド列は実機で実行し、上記のログ取得に成功している
