### PR TITLE
fix(code-apps): scaffold 直後に詰まる CLI/env の不整合を解消

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -222,8 +222,9 @@ npx power-apps init --environment-id {ENVIRONMENT_ID} --display-name "AppName"
 # Step 4: .env.example を .env にコピーしてテーマ固有の値を設定
 
 # Step 5: 初回ビルド＆デプロイ — ★必ず -s を付ける（almMode が Solution になるのは初回 push だけ）
+#         push に --environment-id はない（power.config.json の environmentId を見る）
 npm run build
-npx power-apps push --environment-id {ENVIRONMENT_ID} --solution-id {SOLUTION_ID}
+npx power-apps push --solution-id {SOLUTION_ID}
 
 # Step 6: Dataverse コネクタを 1 回追加（全テーブル共通・接続参照バインド）
 npx power-apps add-data-source --api-id shared_commondataserviceforapps \
@@ -240,7 +241,7 @@ npm run predeploy
 
 # 再ビルド＆デプロイ（反復）
 npm run build
-npx power-apps push --environment-id {ENVIRONMENT_ID}
+npx power-apps push
 ```
 
 > **Step 5 の `--solution-id` は後戻りできない**: 初回の `power-apps push --solution-id` がアプリを `almMode: Solution` にするのは
@@ -261,7 +262,7 @@ npx power-apps push --environment-id {ENVIRONMENT_ID}
 | `python scripts/setup_connection_reference.py` | auth_helper（PAC プロファイル再利用） | なし | ✅ 標準（init の前に実行） |
 | `npx power-apps auth-status` / `auth-switch --account {UPN}` | Power Apps npm CLI | アクティブアカウントを明示 | ✅ テナント切り替え時に必須 |
 | `npx power-apps init --environment-id {ID} --display-name "Name"` | Power Apps npm CLI | 上記で確認 | ✅ 標準 |
-| `npx power-apps push --environment-id {ID} --solution-id {GUID}` | Power Apps npm CLI | 上記で確認 | ✅ 標準（**初回から GUID 必須**） |
+| `npx power-apps push --solution-id {GUID}` | Power Apps npm CLI | 上記で確認 | ✅ 標準（**初回から GUID 必須**。`--environment-id` は **ない**） |
 | `npx power-apps add-data-source --api-id shared_commondataserviceforapps -cr {CR} -s {SOLUTION_ID} --resource-name commondataserviceforapps --org-url {url}` | Power Apps npm CLI + 接続参照 | `npx power-apps login` が別キャッシュ | ✅ 標準（ALM 対応） |
 | `npx power-apps add-data-source ... --connection-id {id}` | Power Apps npm CLI + 接続 | 同上 | △ ソリューションに入らない（PoC のみ） |
 | `pac code *` | PAC CLI プロファイル | npm CLI と別キャッシュ | △ npm CLI で解決できない場合のみの移行時代替 |

--- a/.github/skills/code-apps/references/.env.example
+++ b/.github/skills/code-apps/references/.env.example
@@ -8,7 +8,9 @@ DATAVERSE_URL=https://<org>.crm.dynamics.com
 TENANT_ID=00000000-0000-0000-0000-000000000000
 
 # 環境 ID（Power Platform 管理センター > 環境 > 環境 ID）
+# scripts/pre-deploy-check.mjs は ENV_ID を必須キーとして見るため、両方を同じ値で置く。
 ENVIRONMENT_ID=00000000-0000-0000-0000-000000000000
+ENV_ID=00000000-0000-0000-0000-000000000000
 
 # 対象ソリューションの一意名（`pac solution list` の SolutionUniqueName）
 SOLUTION_NAME=YourSolutionUniqueName

--- a/.github/skills/code-apps/references/build-reference.md
+++ b/.github/skills/code-apps/references/build-reference.md
@@ -212,8 +212,9 @@ export default defineConfig({
 
 ```bash
 # npm CLI 0.13.0 を使用。Step 1 で取得したソリューション GUID を渡す
+# push に --environment-id はない（power.config.json の environmentId を見る）
 npm run build
-npx power-apps push --environment-id {ENVIRONMENT_ID} --solution-id {SOLUTION_ID}
+npx power-apps push --solution-id {SOLUTION_ID}
 ```
 
 > **`-s` は初回 push でしか効かない（検証済 2026-06-15）**
@@ -466,7 +467,7 @@ export const statusColors: Record<RecordStatus, string> = {
 
 ```bash
 npm run build
-npx power-apps push --environment-id {ENVIRONMENT_ID}
+npx power-apps push
 ```
 
 ### Step 8.1: ビルド後検証 — Circular chunk 警告チェック（必須）

--- a/.github/skills/code-apps/references/cli-reference.md
+++ b/.github/skills/code-apps/references/cli-reference.md
@@ -29,10 +29,14 @@ Code Apps 用 npm CLI（`npx power-apps`）の全コマンド一覧。
 
 ## 導入と実行方法
 
-`@microsoft/power-apps`（SDK）の依存として自動的に入るため、**単体インストールは不要**。
+`@microsoft/power-apps`（SDK）の依存として `node_modules` には入るが、
+**npm は直接依存の bin しか `node_modules/.bin` にリンクしない**ため、
+`@microsoft/power-apps` だけを依存に持つ状態で `npx power-apps` を実行すると
+`npm error could not determine executable to run` になる（検証済 2026-08-10）。
+**devDependencies に明示的に入れる**こと。
 
 ```bash
-npm install            # @microsoft/power-apps 経由で CLI も入る
+npm install -D @microsoft/power-apps-cli
 npx power-apps --help
 ```
 
@@ -82,8 +86,9 @@ Node.js **22 以上**が必要（`engines: { "node": ">=22" }`）。
 > `--cloud` は日本国内の通常テナントでは指定不要。GCC / DoD / 21Vianet 環境でのみ使用する。
 
 > [!WARNING]
-> CLI 0.13.0 の help は `--environment-id` を全コマンドに表示するが、`add-data-source` / `list-codeapps` は
-> 実行時に `unknown option '--environment-id'` として拒否する（2026-08-03 実測）。これらは先に `init` で
+> CLI 0.13.0 の help は `--environment-id` を全コマンドに表示するが、`push` / `add-data-source` / `list-codeapps` は
+> 実行時に `unknown option '--environment-id'` として拒否する（push は 2026-08-10 実測、他は 2026-08-03 実測）。
+> これらは先に `init` で
 > `power.config.json` を生成し、そこに保存された `environmentId` を使用する。
 
 ## アプリライフサイクル

--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -1775,3 +1775,63 @@ python <skill>/scripts/check_code_apps_environment.py --environment-id <env-guid
 
 `--environment-id` のように引数で渡せるものは引数を優先する。
 
+
+---
+
+## 36. Dataverse の JSON 列をそのまま描画して "Minified React error #31" で落ちる（検証済 2026-08-10）
+
+### 症状
+
+一覧は表示できるのに、行をクリックして詳細モーダルを開いた瞬間に画面が真っ白になる。
+
+```
+Minified React error #31; Objects are not valid as a React child
+(found: object with keys {path})
+```
+
+### 原因
+
+Memo 列に格納した JSON を `JSON.parse` した結果を、そのまま JSX に埋め込んでいる。
+生成元によって同じフィールドが文字列だったりオブジェクトだったりするため、
+サンプルデータでは動いても本番データで落ちる。
+（例: ツール呼び出しの `arguments` が `"{\"path\":\"...\"}"` のときと `{ path: "..." }` のときがある）
+
+### 対処
+
+描画の直前で必ず文字列へ正規化するヘルパーを通す。列の型を信用しない。
+
+```typescript
+export function formatToolArguments(value: unknown): string {
+  if (value === null || value === undefined) return ""
+  if (typeof value === "string") return value
+  try { return JSON.stringify(value) } catch { return String(value) }
+}
+```
+
+型定義側も `arguments?: unknown` にしておくと、生の値を JSX へ渡した時点で
+TypeScript が気付いてくれる。
+
+---
+
+## 37. `power-apps push` 後もブラウザが古いバンドルを表示する（検証済 2026-08-10）
+
+### 症状
+
+ビルドと push は成功しているのに、プレイヤーで開くと修正前の挙動のまま。
+画面上部に「このアプリの古いバージョンを使用しています。更新してください」の
+バナーが出ることがある。
+
+### 原因
+
+Power Apps プレイヤーが直前のバンドルをキャッシュしている。
+
+### 対処
+
+バナーの「更新」を押すか、プレイヤー URL を再読み込みする。
+Playwright で検証する場合は `page.reload()` ではなく `page.goto(playerUrl)` の方が確実。
+
+なお、プレイヤーはアプリを **入れ子の iframe**
+（`*.environment.api.powerplatformusercontent.com`）で描画するため、
+自動操作は `page.frameLocator(...)` 経由で行う。
+行クリックが "element is not stable" でタイムアウトするときは
+`.click({ force: true })`、同名ボタンが複数あるときは `{ exact: true }` を使う。

--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -1687,3 +1687,91 @@ const payload = serializeMultiSelectPicklistFields(formState, MULTISELECT_FIELDS
 
 → 関連: [データソースパターン](data-source-patterns.md#multiselectpicklist複数選択列)、
 [コンポーネントカタログ](component-catalog.md#multiselectpicklist-の選択-ui)
+
+---
+
+## 34. scaffold 直後に詰まる 3 点（検証済 2026-08-10）
+
+`generic-base` を degit して `npm install` した直後、手順どおりに進めても止まる箇所が 3 つある。
+いずれもコードの問題ではなく、テンプレート／ドキュメント側の不整合。
+
+### 34.1 `npx power-apps` が `could not determine executable to run`
+
+```
+npm error could not determine executable to run
+```
+
+`@microsoft/power-apps-cli` は `@microsoft/power-apps` の**推移的依存**であり、
+npm は**直接依存の bin しか `node_modules/.bin` にリンクしない**。
+そのため SDK だけを依存に持つ状態では `npx power-apps` が解決できない。
+
+```bash
+npm install -D @microsoft/power-apps-cli
+```
+
+`templates/generic-base/package.json` には devDependency として追加済み。
+古いテンプレートから作ったプロジェクトでは手動で足す。
+
+### 34.2 `npx power-apps push --environment-id` が `unknown option`
+
+```
+error: unknown option '--environment-id'
+```
+
+`push` に `--environment-id` は**ない**。環境は `power.config.json` の `environmentId` から決まる。
+
+```bash
+npx power-apps push --solution-id {SOLUTION_ID_GUID}   # 初回
+npx power-apps push                                     # 2 回目以降
+```
+
+同じ理由で `add-data-source` / `list-codeapps` も `--environment-id` を拒否する。
+→ [CLI リファレンス](cli-reference.md#グローバルオプション)
+
+### 34.3 `npm run predeploy` が `.env の ENV_ID が未設定` で落ちる
+
+`scripts/pre-deploy-check.mjs` の必須キーは **`ENV_ID`** だが、
+`references/.env.example` は `ENVIRONMENT_ID` を案内している。
+両方を同じ値で `.env` に置くのが確実。
+
+```env
+ENVIRONMENT_ID=00000000-0000-0000-0000-000000000000
+ENV_ID=00000000-0000-0000-0000-000000000000
+```
+
+---
+
+## 35. Python ヘルパースクリプトが `.env` を読まない／`UnicodeEncodeError` で落ちる（検証済 2026-08-10）
+
+### 症状
+
+```
+DATAVERSE_URL が .env に設定されていません（または --environment-id を指定）
+```
+
+プロジェクト直下に `.env` があり、そこで `cd` しているのに読まれない。
+
+```
+UnicodeEncodeError: 'cp932' codec can't encode character '\u2705' in position 0
+```
+
+### 原因
+
+- `check_code_apps_environment.py` などは **スクリプト自身の親ディレクトリ**を遡って `.env` を探す
+  （`for _p in _SCRIPT_DIR.parents:`）。カレントディレクトリは見ない。
+  スキルをリポジトリ外から参照して実行すると、プロジェクトの `.env` に到達しない。
+- 日本語 Windows の既定コンソールは cp932 なので、`✅` / `⚠️` を含む出力で例外になる。
+
+### 対処
+
+プロセス環境変数として渡し、出力エンコーディングを UTF-8 に固定する。
+
+```powershell
+$env:DATAVERSE_URL  = "https://<org>.crm.dynamics.com"
+$env:TENANT_ID      = "<tenant-guid>"
+$env:PYTHONIOENCODING = "utf-8"
+python <skill>/scripts/check_code_apps_environment.py --environment-id <env-guid>
+```
+
+`--environment-id` のように引数で渡せるものは引数を優先する。
+

--- a/.github/skills/code-apps/templates/generic-base/package.json
+++ b/.github/skills/code-apps/templates/generic-base/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@microsoft/power-apps-cli": "^0.13.0",
     "@types/node": "^24.6.0",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",


### PR DESCRIPTION
実際に generic-base から Code App を 1 本作って本番環境にデプロイした際に詰まった箇所を反映。

- generic-base に `@microsoft/power-apps-cli` を devDependency として追加。SDK の推移的依存のままだと npm が bin をリンクせず `npx power-apps` が `could not determine executable to run` になる。
- `npx power-apps push` の `--environment-id` を全ドキュメントから削除。CLI 0.13.0 は `unknown option` で拒否する（環境は power.config.json から解決）。
- `references/.env.example` に `ENV_ID` を追加。`scripts/pre-deploy-check.mjs` の必須キーは `ENVIRONMENT_ID` ではなく `ENV_ID`。
- troubleshooting に #34（scaffold 直後の 3 点）と #35（Python ヘルパーが .env を見つけない / cp932 の UnicodeEncodeError）を追加。

`validate_skill.py .github/skills/code-apps` は OK。