### PR TITLE
code-apps: レスポンシブ崩れを正常系フローで防ぐ（骨格テンプレート・predeploy 自動検出・CardHeader 修正）

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -141,6 +141,8 @@ Code Apps 開発は **設計 → 初回デプロイ → データソース接続
 
 > **CRUD 画面は [CRUD UI 標準パターン](references/crud-ui-pattern.md) に必ず従う**: 一覧は行／カード全体をクリックして詳細を開く（目アイコン等の小さなクリック領域は使わない）、詳細の編集はモーダルではなくインライン編集モード、行内の削除・クイック操作は `e.stopPropagation()`、削除確認はブラウザの `confirm()` ではなくモーダル（`useConfirm()` / AlertDialog）。**指示がなくても、テーブルごとに「一覧・詳細（インライン編集）・作成・削除」を標準実装すること。**
 
+> **画面の骨格は [デザインシステム](references/design-pattern.md#ページの骨格新規画面はここから書き始める) からコピーして書き始める**: マルチカラムは `grid-cols-[minmax(0,1fr)_...]`（素の `1fr` は使わない）＋**直接の子すべてに `min-w-0`**、長文は `break-words` ではなく `[overflow-wrap:anywhere]`、コード・表・JSON は `overflow-x-auto` で閉じ込める。`min-w-0` は後付けすると必ず抜けるため最初から書く。`npm run predeploy` のチェック 7 が抜けを警告する。
+
 > **設計で提示する内容**: 選択テンプレート、画面一覧（ページ名・ルート）、各画面のコンポーネント構成、カラム定義、Lookup 名前解決方法（`_xxx_value` + `useMemo` Map）、ナビゲーション構造。
 
 > **大前提（ソリューション運用）**: Dataverse テーブル・Code Apps・Power Automate・Copilot Studio は同一ソリューション内に開発し、`.env` の `SOLUTION_NAME` / `PUBLISHER_PREFIX` を全フェーズで統一する。詳細は [`standard` スキル](../standard/SKILL.md)。

--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -514,6 +514,7 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 | [チェックリスト採点パターン](references/checklist-scoring-pattern.md) | 点検・監査系業務の判定トグル・スコア自動計算（対象外を分母から除外）・テンプレート一括生成・親レコードへのスコア同期 |
 | [クロス集計マトリクスパターン](references/cross-tab-pattern.md) | 2 軸の組み合わせ件数をヒート色付きピボット表で俯瞰（行列自動生成・合計行/列・追加依存なし） |
 | [縦タイムライン/ステッパーパターン](references/timeline-stepper-pattern.md) | 順序を持つ項目の進行状態を縦に可視化（done/current/problem/pending・行ごとに操作ボタン差込可・追加依存なし） |
+| [一覧ペイン（マスター詳細）パターン](references/master-detail-pane-pattern.md) | 詳細画面の左にレコード一覧を常駐させて遷移しないで切り替え（Dataverse 側検索・デバウンス・見切れ防止の落とし穴表） |
 | [構築リファレンス](references/build-reference.md) | ビルド・デプロイの詳細手順・vite.config.ts 必須設定・TypeScript エラー対処 |
 | [npm CLI リファレンス](references/cli-reference.md) | `npx power-apps` 全コマンド（0.13.0 検証済み）・`push -s` の GUID 要件・`refresh-data-source` / `add-dataverse-api` / `auth-switch` |
 | [ソリューション ALM](references/solution-alm.md) | 接続参照バインド・`almMode` と初回 push・コンポーネント種別・共有時の権限モデル |

--- a/.github/skills/code-apps/references/design-pattern.md
+++ b/.github/skills/code-apps/references/design-pattern.md
@@ -213,6 +213,45 @@ UI コンポーネントの実装先となる Code Apps も同一ソリューシ
 - `shrink-0` でアイコン等の固定幅要素が縮まないようにする
 - `flex-1 min-w-0` で可変幅テキスト領域を確保
 
+### `minmax(0,1fr)` を書いても子要素に `min-w-0` が要る
+
+`grid-cols-[minmax(0,2fr)_minmax(0,1fr)]` が効くのは**トラック**の伸長抑止まで。
+グリッドアイテム自身は `min-width: auto` のままなので、min-content がトラックより広いと
+アイテムがトラックを突き破り、ページ全体が横スクロールしてレスポンシブが崩れる。
+
+```tsx
+{/* NG: 長い本文やコード例を入れた途端に画面幅を超える */}
+<div className="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+  <Card>...</Card>
+  <div className="space-y-4">...</div>
+</div>
+
+{/* OK: アイテム側にも min-w-0 */}
+<div className="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+  <Card className="min-w-0">...</Card>
+  <div className="min-w-0 space-y-4">...</div>
+</div>
+```
+
+### 折り返しは `break-words` ではなく `[overflow-wrap:anywhere]`
+
+`break-words`（= `overflow-wrap: break-word`）は**描画時にだけ**折り返す。
+min-content 幅の計算では無視されるため、長い URL や識別子を含む本文は
+親の幅を押し広げ続ける。幅を詰めたいときは `anywhere` を使う。
+
+| クラス | 描画時に折り返す | min-content を縮める | 用途 |
+| --- | --- | --- | --- |
+| `break-words` | ○ | **×** | 幅が固定済みの場所 |
+| `[overflow-wrap:anywhere]` | ○ | ○ | 可変幅カラムに流し込む本文 |
+| `break-all` | ○ | ○ | JSON・ID など単語境界が無い文字列 |
+
+`<pre>` は `overflow-x-auto` を付けるとスクロールコンテナになり min-content が 0 になるため、
+表・コードブロックはこちらでも防げる。
+
+**長文を流し込む画面での確認手順**: 一番長い本文を持つレコードを開き、
+ブラウザ幅を 1280 → 768 → 375 と狭めて横スクロールバーが出ないことを見る。
+平均的なレコードだけで確認すると必ず見落とす。
+
 ## コンポーネント選定ガイド
 
 | やりたいこと | 推奨コンポーネント |

--- a/.github/skills/code-apps/references/design-pattern.md
+++ b/.github/skills/code-apps/references/design-pattern.md
@@ -135,6 +135,42 @@ UI コンポーネントの実装先となる Code Apps も同一ソリューシ
 2. **テキスト省略（truncate）を前提にする**。テーブル名・作業指示書名等の長い文字列は `truncate` で `...` 省略。クリックで詳細表示
 3. **マルチカラムレイアウト**: モバイル=1カラムずつ表示（ステップ切替）、デスクトップ=`grid grid-cols-N`
 4. **カード内テキストは必ず幅制約する**。`min-w-0` + `overflow-hidden` + `truncate` のチェーンを Card → CardContent → flex → text 要素まで通す
+5. **横スクロールバーを 1 本も出さない**。`grid` / `flex` の**直接の子には必ず `min-w-0`** を付け、
+   長文は `[overflow-wrap:anywhere]`、幅の読めない塊（コード・表・JSON）は `overflow-x-auto` で閉じ込める
+
+### ページの骨格（新規画面はここから書き始める）
+
+崩れてから直すのではなく、最初からこの形で書く。`min-w-0` は後付けすると必ず抜ける。
+
+```tsx
+// 1 カラム（一覧・フォーム）
+<div className="space-y-6">
+  <PageHeader />
+  <Card className="min-w-0">...</Card>
+</div>
+
+// 2 カラム（詳細画面：本文 + サイドパネル）
+<div className="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+  <Card className="min-w-0">{/* 本文 */}</Card>
+  <div className="min-w-0 space-y-4">{/* サイドパネル */}</div>
+</div>
+
+// 一覧ペイン + 詳細（マスター詳細）
+<div className="grid gap-4 lg:grid-cols-[280px_minmax(0,1fr)]">
+  <div className="hidden lg:sticky lg:top-4 lg:block lg:self-start">
+    <ListPane />
+  </div>
+  <div className="min-w-0">{children}</div>
+</div>
+```
+
+**サイズ指定の使い分け**:
+
+| 書き方 | 意味 | 使う場面 |
+| --- | --- | --- |
+| `minmax(0,1fr)` | トラックが min-content 未満まで縮める | 可変幅カラム（ほぼ常にこれ） |
+| `280px` / `320px` | 固定幅 | ナビ・一覧ペイン・メタ情報パネル |
+| `1fr`（素） | min-content 以下に縮まない | **使わない**（長文で必ず溢れる） |
 
 ### ScrollArea 使用禁止（マルチカラム・truncate 併用時）
 

--- a/.github/skills/code-apps/references/design-pattern.md
+++ b/.github/skills/code-apps/references/design-pattern.md
@@ -84,6 +84,52 @@ Code Apps の画面を設計・実装する。
 Dataverse テーブル・Code Apps・Power Automate フロー・Copilot Studio エージェントは **すべて同一のソリューション内** に含める。
 UI コンポーネントの実装先となる Code Apps も同一ソリューションに所属する。
 
+## 名前とナビは最初から汎用にする
+
+ソリューションとして配布する可能性が少しでもあるなら、**最初の 1 画面目から固有名詞を入れない**。
+後からの改名はファイル横断になり、必ずどこか 1 箇所が取り残される。
+
+| 場所 | 値 | 見える場所 |
+|---|---|---|
+| `.env` `VITE_CODEAPPS_APP_NAME` | アプリ表示名 | サイドバー・ヘッダー |
+| `.env` `VITE_CODEAPPS_DOCUMENT_TITLE` | ブラウザタブ | ブラウザタブ・履歴 |
+| `power.config.json` `appDisplayName` | Power Apps 上の名前 | メーカー ポータル・ソリューション |
+| `.env` `VITE_CODEAPPS_THEME_STORAGE_KEY` | localStorage キー | （不可視） |
+
+- **上 3 つは必ず同時に変える。** 片方だけ直すと、ポータルとアプリ内で名前が食い違う
+  （`predeploy` のチェック 8 が検出する）。
+- **UI 文言に固有名詞を直書きしない。** チャットの話者ラベルや空状態の文言に
+  製品名・エージェント名を埋め込むと、`.env` を変えても画面に旧名が残る。
+  役割名（「エージェント」「担当者」）で書く。
+- ソリューション名・パブリッシャー接頭辞は**変えない**。変えるとテーブルの論理名が全部ずれる。
+  表示名だけを汎用化すればよい。
+
+**ナビは 5 項目を超えたらグループ化する。** `NAV_SECTIONS` は最初からセクション配列なので、
+タイトルを分けるだけで済む。「概要（ダッシュボード・推移）」「業務」「マスタ」の 3 層が基本形。
+
+```ts
+// src/config.ts — 用途で分けておくと、機能追加時に入れ先が迷わない
+const overviewItems: NavItem[] = [
+  { key: "dashboard", label: "ダッシュボード", path: "/dashboard" },
+  { key: "trend", label: "推移", path: "/trend" },
+]
+const operationItems: NavItem[] = [
+  { key: "items", label: "一覧", path: "/items" },
+]
+const masterItems: NavItem[] = [
+  { key: "rules", label: "ルール", path: "/rules" },
+]
+
+export const NAV_SECTIONS: NavSection[] = [
+  { title: "概要", items: overviewItems },
+  { title: "業務", items: operationItems },
+  { title: "マスタ", items: masterItems },
+]
+```
+
+> マスタ系（ルール・区分・宛先）を業務画面と同じ列に並べると、使う人が毎回探す。
+> 進めるうちに必ず増えるので、**1 項目しか無くてもセクションを分けておく**。
+
 ## 技術スタック
 
 | レイヤー | 技術 |

--- a/.github/skills/code-apps/references/master-detail-pane-pattern.md
+++ b/.github/skills/code-apps/references/master-detail-pane-pattern.md
@@ -1,0 +1,237 @@
+# 一覧ペイン（マスター詳細）パターン
+
+詳細画面の左側にレコード一覧を常駐させ、ページ遷移せずに次のレコードへ切り替えられるようにするパターン。
+レビュー・査閲・問い合わせ対応など、**複数レコードを次々に見比べる業務**で使う。
+
+一覧ページ（テーブル）は俯瞰・絞り込み用、一覧ペインは詳細を見ながらの移動用。両者は併存させる。
+
+```
+┌──────────────┬────────────────────────────────┐
+│ 一覧ペイン     │ 詳細                             │
+│ [検索  ]      │  タイトル / バッジ                 │
+│ ─────────    │ ┌────────────┬──────────┐      │
+│ ▸ 項目 A ←現在 │ │ 本文        │ サイド      │      │
+│ ▸ 項目 B      │ └────────────┴──────────┘      │
+│ ▸ 項目 C      │                                │
+└──────────────┴────────────────────────────────┘
+```
+
+## 正常系フロー
+
+### Step 1. クエリキーとフィルターを lib に集約する
+
+一覧ページと一覧ペインが**同じキーで同じデータを引く**ようにする。キーがずれると同じ内容を 2 回取得し、
+片方だけ古いまま残る。
+
+```typescript
+// lib/items.ts
+export const ITEMS_KEY = ["items"]
+
+export type ItemFilter = { search: string; owner: string }
+export const EMPTY_ITEM_FILTER: ItemFilter = { search: "", owner: "" }
+
+export function itemsQueryKey(filter: ItemFilter = EMPTY_ITEM_FILTER) {
+  return [...ITEMS_KEY, filter.search, filter.owner]
+}
+```
+
+### Step 2. 検索は Dataverse 側で行う（クライアント側 filter にしない）
+
+取得済みの配列を `Array.filter()` で絞ると、`top` の範囲外にある古いレコードが永久に検索に掛からない。
+`$filter` の `contains()` で サーバー側に投げる。
+
+**OData の文字列リテラルは単一引用符で囲み、エスケープはシングルクォートの 2 重化のみ。**
+ユーザー入力を素通しすると `$filter` 式を壊される。必ずエスケープ関数を通す。
+
+```typescript
+// OData string literals are single quoted, and doubling the quote is the only escape there is.
+function quote(value: string): string {
+  return value.replace(/'/g, "''")
+}
+
+function buildFilter({ search, owner }: ItemFilter): string | undefined {
+  const clauses: string[] = []
+  if (owner) clauses.push(`${F.owner} eq '${quote(owner)}'`)
+
+  const term = search.trim()
+  if (term) {
+    const t = quote(term)
+    clauses.push(`(contains(${F.title},'${t}') or contains(${F.body},'${t}'))`)
+  }
+  return clauses.length > 0 ? clauses.join(" and ") : undefined
+}
+
+export async function listItems(
+  filter: ItemFilter = EMPTY_ITEM_FILTER,
+  top = 500,
+): Promise<Item[]> {
+  const rows = await DataverseService.ListRecords(ENTITY_SET, {
+    select: Object.values(F),
+    filter: buildFilter(filter),
+    orderBy: `${F.createdOn} desc`,
+    top,
+  })
+  return rows.map(toItem)
+}
+```
+
+> **複数行テキスト（memo）列にも `contains()` は使える。** 実装前に 1 度 Web API を直接叩いて確認しておく。
+
+### Step 3. 一覧ペインを実装する
+
+**スクロール領域に `ScrollArea` を使わない。** 詳細は Step 6 の落とし穴表を参照。
+
+```tsx
+// components/item-nav.tsx
+import { useEffect, useMemo, useState } from "react"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
+import { Link } from "react-router-dom"
+import { Loader2, List, Search } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { EMPTY_ITEM_FILTER, itemsQueryKey, listItems } from "@/lib/items"
+
+export function ItemNav({ currentId }: { currentId: string }) {
+  const [search, setSearch] = useState("")
+  const [term, setTerm] = useState("")
+
+  // Every keystroke would otherwise be a Dataverse round trip.
+  useEffect(() => {
+    const timer = setTimeout(() => setTerm(search.trim()), 400)
+    return () => clearTimeout(timer)
+  }, [search])
+
+  const filter = useMemo(() => ({ ...EMPTY_ITEM_FILTER, search: term }), [term])
+  const { data, isLoading, isFetching } = useQuery({
+    queryKey: itemsQueryKey(filter),
+    queryFn: () => listItems(filter),
+    placeholderData: keepPreviousData, // 検索中に一覧が空へ飛ばない
+  })
+
+  const items = data ?? []
+
+  return (
+    <aside className="flex h-[calc(100dvh-9rem)] min-w-0 flex-col overflow-hidden rounded-lg border bg-card">
+      {/* ヘッダー: shrink-0 相当（flex 子のデフォルト） */}
+      <div className="flex items-center gap-2 border-b px-3 py-2">
+        <List className="size-4 shrink-0 text-muted-foreground" />
+        <span className="text-sm font-medium">一覧</span>
+        <span className="ml-auto text-xs text-muted-foreground">{items.length}</span>
+      </div>
+
+      {/* 検索 */}
+      <div className="relative border-b p-2">
+        <Search className="absolute left-4 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="検索"
+          className="h-8 pl-7 pr-7 text-xs"
+        />
+        {isFetching && (
+          <Loader2 className="absolute right-4 top-1/2 size-3.5 -translate-y-1/2 animate-spin text-muted-foreground" />
+        )}
+      </div>
+
+      {/* ScrollArea だと truncate が効かないので素の div でスクロールさせる */}
+      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
+        {isLoading ? (
+          <p className="px-3 py-4 text-xs text-muted-foreground">読み込み中...</p>
+        ) : items.length === 0 ? (
+          <p className="px-3 py-4 text-xs text-muted-foreground">該当する項目がありません</p>
+        ) : (
+          <ul className="p-1">
+            {items.map((item) => (
+              <li key={item.id}>
+                <Link
+                  to={`/items/${item.id}`}
+                  className={`block rounded-md px-2 py-2 text-xs ${
+                    item.id === currentId ? "bg-primary/10 font-medium" : "hover:bg-muted"
+                  }`}
+                >
+                  {/* 1 行 1 情報。横に並べない */}
+                  <div className="truncate">{item.title}</div>
+                  <p className="mt-0.5 line-clamp-2 break-words text-muted-foreground">
+                    {item.body || "(なし)"}
+                  </p>
+                  <div className="mt-1 text-[10px] text-muted-foreground">
+                    {formatDateTime(item.createdOn)}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </aside>
+  )
+}
+```
+
+### Step 4. 詳細ページに shell として組み込む
+
+ローディング中・エラー時にもペインが消えないよう、**3 状態すべてを同じ shell で包む**。
+ペインだけ先に描画されるので、詳細の読み込み中も他レコードへ移動できる。
+
+```tsx
+export default function ItemDetail() {
+  const { id = "" } = useParams()
+  const { data, isLoading, isError } = useQuery({ ... })
+
+  const shell = (children: React.ReactNode) => (
+    <div className="grid gap-4 lg:grid-cols-[280px_minmax(0,1fr)]">
+      {/* sticky で詳細をスクロールしてもペインが画面内に残る */}
+      <div className="hidden lg:sticky lg:top-4 lg:block lg:self-start">
+        <ItemNav currentId={id} />
+      </div>
+      {/* minmax(0,1fr) と min-w-0 の両方が要る。片方だけだと詳細側がはみ出す */}
+      <div className="min-w-0">{children}</div>
+    </div>
+  )
+
+  if (isLoading) return shell(<LoadingSkeletonList count={3} />)
+  if (isError || !data) return shell(<ErrorState />)
+  return shell(<div className="space-y-6">...</div>)
+}
+```
+
+### Step 5. 詳細側の内部グリッドは 1 段階広いブレークポイントへ送る
+
+ペインが 280px を占めるため、詳細側に残る幅は従来より狭い。
+詳細内の 2 段組を `lg:` のままにすると中間サイズで潰れる。**`xl:` に上げる。**
+
+```tsx
+// ❌ ペイン導入前のまま → lg で詳細が窮屈
+<div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+
+// ✅ ペインぶんの幅を考慮
+<div className="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+```
+
+`lg` 未満ではペインを `hidden` にし、詳細を全幅で見せる（モバイルは一覧ページから遷移する導線）。
+
+### Step 6. 落とし穴チェック
+
+| # | 症状 | 原因 | 対処 |
+|---|------|------|------|
+| 1 | **文字が見切れる／横にはみ出す** | `ScrollArea` の内部 Viewport が `display: table` + 水平スクロール許容で、`truncate` の前提である幅制約を無効化する | `ScrollArea` をやめ `div` + `overflow-y-auto overflow-x-hidden` にする |
+| 2 | 名前がほぼ表示されない | 名前と日時を 1 行に同居させ、固定幅の日時に幅を奪われた | **1 行 1 情報**。日時は独立行へ落とす |
+| 3 | スクロールバーが出ない／下が切れる | flex 子のデフォルト `min-height: auto` でスクロール領域がコンテンツ高さまで膨張 | 親に `overflow-hidden`、スクロール領域に `flex-1 min-h-0` |
+| 4 | 古いレコードが検索に出ない | 取得済み配列をクライアント側で `filter` している | `$filter` の `contains()` でサーバー側検索（Step 2） |
+| 5 | 検索のたびに画面がちらつく／空になる | `placeholderData` 未指定 | `placeholderData: keepPreviousData` |
+| 6 | 打鍵ごとに Dataverse 呼び出し | デバウンスなし | 400ms デバウンス（Step 3） |
+| 7 | 一覧ページとペインで内容が食い違う | クエリキーが別 | `itemsQueryKey()` を共有（Step 1） |
+| 8 | 長い URL や英数字連続で横スクロールが出る | `line-clamp` だけでは分割されない | `break-words` を併用 |
+
+**実装後の目視確認**（ブラウザ幅を狭めて 1 回ずつ）:
+
+- [ ] ペイン内の長い名前が `...` で省略され、横スクロールバーが出ない
+- [ ] 詳細を下までスクロールしてもペインが追従して見えている
+- [ ] 検索語を入れると件数が変わり、スピナーが出て、結果が空でも文言が出る
+- [ ] `lg` 未満でペインが消え、詳細が全幅になる
+- [ ] ペインの項目をクリックすると詳細だけ差し替わり、ペインの位置が保たれる
+
+## 関連
+
+- [デザインシステム](design-pattern.md) の「ScrollArea 使用禁止（マルチカラム・truncate 併用時）」「truncate チェーン」
+- [CRUD UI 標準パターン](crud-ui-pattern.md) の「一覧の検索・フィルター・重要列」
+- [トラブルシューティング](troubleshooting.md) の「Radix ScrollArea が flex-1 だけではスクロールしない」

--- a/.github/skills/code-apps/references/pre-deploy-review.md
+++ b/.github/skills/code-apps/references/pre-deploy-review.md
@@ -204,6 +204,28 @@ Get-ChildItem -Path "src" -Recurse -Include "*.ts","*.tsx" -File |
 - `key` prop でコンポーネントを再マウントする（ScrollArea がリセットされ先頭から表示）
 - ScrollArea の Viewport ref を取得して `viewport.scrollTop = viewport.scrollHeight` で制御する
 
+### 5c. ScrollArea + truncate 併用チェック
+
+`ScrollArea` の内部 Viewport は水平方向の膨張を許容するため、配下の `truncate` / `line-clamp` が効かない。
+サイドリスト・一覧ペイン・カードリストなど**幅が制約された領域でテキスト省略を使う場合は `ScrollArea` を使わない**。
+
+> **実際に発生した障害（2026-08-12）:**
+> 詳細画面の左に置いた一覧ペインを `ScrollArea` で組んだところ、相手名・本文が枠からはみ出して見切れた。
+> `div` + `overflow-y-auto overflow-x-hidden` に置き換えて解消。
+
+**チェック方法:**
+
+```bash
+# ScrollArea と truncate / line-clamp が同居しているファイルを検出
+Get-ChildItem -Path "src" -Recurse -Include "*.tsx" -File |
+  Where-Object { (Get-Content $_ -Raw) -match '<ScrollArea' -and (Get-Content $_ -Raw) -match 'truncate|line-clamp' } |
+  ForEach-Object { $_.FullName }
+```
+
+**対処:** `<ScrollArea className="...">` → `<div className="... overflow-y-auto overflow-x-hidden">`。
+flex 内なら `flex-1 min-h-0` を付け、親に `overflow-hidden` を指定する。
+詳細は [一覧ペイン（マスター詳細）パターン](master-detail-pane-pattern.md)。
+
 ### 5a. React フック規則チェック
 
 React のフック規則違反（条件付きフック呼び出し）は本番でのみクラッシュすることがある（React error #310）。

--- a/.github/skills/code-apps/references/pre-deploy-review.md
+++ b/.github/skills/code-apps/references/pre-deploy-review.md
@@ -235,14 +235,11 @@ flex 内なら `flex-1 min-h-0` を付け、親に `overflow-hidden` を指定�
 > 詳細画面の右カラムに改善提案の `<pre>` を追加したところ、`minmax(0,1fr)` を指定していたにもかかわらず
 > ページ幅に収まらなくなった。アイテム（`Card` と `div`）に `min-w-0` を足して解消。
 
-**チェック方法:**
+**チェック方法:** `scripts/pre-deploy-check.mjs` のチェック 7 が自動で警告する（`npm run predeploy`）。
 
-```bash
-# grid-cols-[...] を使っているファイルを列挙し、直後の子要素に min-w-0 があるか目視で確認する
-Get-ChildItem -Path "src" -Recurse -Include "*.tsx" -File |
-  Select-String -Pattern 'grid-cols-\[' |
-  ForEach-Object { "$($_.Path):$($_.LineNumber)  $($_.Line.Trim())" }
-```
+- 7a: `grid-cols-[...]` に素の `1fr` がある（`minmax(0,1fr)` にする）
+- 7b: 明示トラックのグリッド直下の子要素に `min-w-0` が無い
+- 7c: `ScrollArea` と `truncate` / `line-clamp` の併用
 
 **対処:** グリッド/フレックスの**直接の子**すべてに `min-w-0` を付ける。
 本文の折り返しは `break-words` ではなく `[overflow-wrap:anywhere]`（`break-words` は min-content を縮めない）。

--- a/.github/skills/code-apps/references/pre-deploy-review.md
+++ b/.github/skills/code-apps/references/pre-deploy-review.md
@@ -226,6 +226,29 @@ Get-ChildItem -Path "src" -Recurse -Include "*.tsx" -File |
 flex 内なら `flex-1 min-h-0` を付け、親に `overflow-hidden` を指定する。
 詳細は [一覧ペイン（マスター詳細）パターン](master-detail-pane-pattern.md)。
 
+### 5d. グリッドアイテムの `min-w-0` 欠落チェック
+
+`grid-cols-[minmax(0,...)]` はトラックしか縛らない。アイテム側の `min-width: auto` が残っていると、
+長い本文やコード例を入れた瞬間にアイテムがトラックを突き破り、ページ全体が横スクロールする。
+
+> **実際に発生した障害（2026-08-12）:**
+> 詳細画面の右カラムに改善提案の `<pre>` を追加したところ、`minmax(0,1fr)` を指定していたにもかかわらず
+> ページ幅に収まらなくなった。アイテム（`Card` と `div`）に `min-w-0` を足して解消。
+
+**チェック方法:**
+
+```bash
+# grid-cols-[...] を使っているファイルを列挙し、直後の子要素に min-w-0 があるか目視で確認する
+Get-ChildItem -Path "src" -Recurse -Include "*.tsx" -File |
+  Select-String -Pattern 'grid-cols-\[' |
+  ForEach-Object { "$($_.Path):$($_.LineNumber)  $($_.Line.Trim())" }
+```
+
+**対処:** グリッド/フレックスの**直接の子**すべてに `min-w-0` を付ける。
+本文の折り返しは `break-words` ではなく `[overflow-wrap:anywhere]`（`break-words` は min-content を縮めない）。
+確認は最長のレコードを開いた状態で 1280 → 768 → 375px と幅を狭めて行う。
+詳細は [デザインパターン](design-pattern.md)。
+
 ### 5a. React フック規則チェック
 
 React のフック規則違反（条件付きフック呼び出し）は本番でのみクラッシュすることがある（React error #310）。

--- a/.github/skills/code-apps/scripts/pre-deploy-check.mjs
+++ b/.github/skills/code-apps/scripts/pre-deploy-check.mjs
@@ -209,6 +209,29 @@ if (fs.existsSync(srcPath)) {
   }
 }
 
+// 8. 表示名が 3 箇所で食い違っていないか（改名時の取り残し）
+if (fs.existsSync(envPath) && fs.existsSync(configPath)) {
+  const envContent = fs.readFileSync(envPath, "utf-8");
+  const readEnv = (key) => envContent.match(new RegExp(`^${key}=(.+)$`, "m"))?.[1].trim();
+  const appName = readEnv("VITE_CODEAPPS_APP_NAME");
+  const docTitle = readEnv("VITE_CODEAPPS_DOCUMENT_TITLE");
+  let displayName;
+  try {
+    displayName = JSON.parse(fs.readFileSync(configPath, "utf-8")).appDisplayName;
+  } catch {
+    displayName = undefined;
+  }
+
+  const names = [appName, docTitle, displayName].filter(Boolean);
+  if (names.length > 1 && new Set(names).size > 1) {
+    console.warn("⚠ アプリ表示名が箇所によって違います:");
+    console.warn(`  .env VITE_CODEAPPS_APP_NAME       : ${appName ?? "(未設定)"}`);
+    console.warn(`  .env VITE_CODEAPPS_DOCUMENT_TITLE : ${docTitle ?? "(未設定)"}`);
+    console.warn(`  power.config.json appDisplayName  : ${displayName ?? "(未設定)"}`);
+    console.warn("  → 意図的な使い分けでなければ揃えてください（改名時の直し忘れ）。");
+  }
+}
+
 // 結果出力
 if (errors.length > 0) {
   console.error("\n❌ デプロイ前チェック失敗:\n");

--- a/.github/skills/code-apps/scripts/pre-deploy-check.mjs
+++ b/.github/skills/code-apps/scripts/pre-deploy-check.mjs
@@ -153,6 +153,62 @@ if (fs.existsSync(distPath)) {
   }
 }
 
+// 7. レイアウト崩れ（横スクロール）を招く書き方が無いか
+if (fs.existsSync(srcPath)) {
+  const layoutWarnings = [];
+  const pending = [srcPath];
+
+  while (pending.length > 0) {
+    const currentPath = pending.pop();
+    for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
+      const entryPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith(".tsx")) continue;
+
+      const content = fs.readFileSync(entryPath, "utf-8");
+      const rel = path.relative(root, entryPath);
+      const lines = content.split("\n");
+
+      lines.forEach((line, i) => {
+        const at = `${rel}:${i + 1}`;
+
+        // 7a. grid-cols に素の 1fr（min-content 以下に縮まないため長文で溢れる）
+        const cols = line.match(/grid-cols-\[[^\]]*\]/g) ?? [];
+        for (const col of cols) {
+          if (/(^|[[_])\d*fr/.test(col.replace(/minmax\([^)]*\)/g, ""))) {
+            layoutWarnings.push(`${at} ${col} に素の fr があります → minmax(0,1fr) にしてください。`);
+          }
+        }
+
+        // 7b. 明示トラックのグリッド直下の子要素に min-w-0 が無い（トラックを突き破って横スクロールになる）
+        if (cols.length > 0) {
+          const child = lines[i + 1] ?? "";
+          const isElement = /^\s*<[A-Za-z]/.test(child);
+          const hasSizing = /min-w-0|w-\d|w-\[/.test(child);
+          if (isElement && !hasSizing) {
+            layoutWarnings.push(`${at} のグリッド直下の子要素に min-w-0 がありません。`);
+          }
+        }
+
+        // 7c. ScrollArea と truncate の併用（Viewport が横に膨らみ省略が効かない）
+        if (line.includes("<ScrollArea") && /truncate|line-clamp/.test(content)) {
+          layoutWarnings.push(`${at} ScrollArea と truncate/line-clamp が同居しています → div + overflow-y-auto overflow-x-hidden に置き換えてください。`);
+        }
+      });
+    }
+  }
+
+  if (layoutWarnings.length > 0) {
+    console.warn(`⚠ レスポンシブが崩れる可能性のある箇所が ${layoutWarnings.length} 件あります:`);
+    for (const w of layoutWarnings.slice(0, 20)) console.warn(`  ${w}`);
+    if (layoutWarnings.length > 20) console.warn(`  ... 他 ${layoutWarnings.length - 20} 件`);
+    console.warn("  → references/design-pattern.md「レスポンシブファースト設計原則」を参照。");
+  }
+}
+
 // 結果出力
 if (errors.length > 0) {
   console.error("\n❌ デプロイ前チェック失敗:\n");

--- a/.github/skills/code-apps/templates/generic-base/scripts/pre-deploy-check.mjs
+++ b/.github/skills/code-apps/templates/generic-base/scripts/pre-deploy-check.mjs
@@ -153,6 +153,85 @@ if (fs.existsSync(distPath)) {
   }
 }
 
+// 7. レイアウト崩れ（横スクロール）を招く書き方が無いか
+if (fs.existsSync(srcPath)) {
+  const layoutWarnings = [];
+  const pending = [srcPath];
+
+  while (pending.length > 0) {
+    const currentPath = pending.pop();
+    for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
+      const entryPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith(".tsx")) continue;
+
+      const content = fs.readFileSync(entryPath, "utf-8");
+      const rel = path.relative(root, entryPath);
+      const lines = content.split("\n");
+
+      lines.forEach((line, i) => {
+        const at = `${rel}:${i + 1}`;
+
+        // 7a. grid-cols に素の 1fr（min-content 以下に縮まないため長文で溢れる）
+        const cols = line.match(/grid-cols-\[[^\]]*\]/g) ?? [];
+        for (const col of cols) {
+          if (/(^|[[_])\d*fr/.test(col.replace(/minmax\([^)]*\)/g, ""))) {
+            layoutWarnings.push(`${at} ${col} に素の fr があります → minmax(0,1fr) にしてください。`);
+          }
+        }
+
+        // 7b. 明示トラックのグリッド直下の子要素に min-w-0 が無い（トラックを突き破って横スクロールになる）
+        if (cols.length > 0) {
+          const child = lines[i + 1] ?? "";
+          const isElement = /^\s*<[A-Za-z]/.test(child);
+          const hasSizing = /min-w-0|w-\d|w-\[/.test(child);
+          if (isElement && !hasSizing) {
+            layoutWarnings.push(`${at} のグリッド直下の子要素に min-w-0 がありません。`);
+          }
+        }
+
+        // 7c. ScrollArea と truncate の併用（Viewport が横に膨らみ省略が効かない）
+        if (line.includes("<ScrollArea") && /truncate|line-clamp/.test(content)) {
+          layoutWarnings.push(`${at} ScrollArea と truncate/line-clamp が同居しています → div + overflow-y-auto overflow-x-hidden に置き換えてください。`);
+        }
+      });
+    }
+  }
+
+  if (layoutWarnings.length > 0) {
+    console.warn(`⚠ レスポンシブが崩れる可能性のある箇所が ${layoutWarnings.length} 件あります:`);
+    for (const w of layoutWarnings.slice(0, 20)) console.warn(`  ${w}`);
+    if (layoutWarnings.length > 20) console.warn(`  ... 他 ${layoutWarnings.length - 20} 件`);
+    console.warn("  → references/design-pattern.md「レスポンシブファースト設計原則」を参照。");
+  }
+}
+
+// 8. 表示名が 3 箇所で食い違っていないか（改名時の取り残し）
+if (fs.existsSync(envPath) && fs.existsSync(configPath)) {
+  const envContent = fs.readFileSync(envPath, "utf-8");
+  const readEnv = (key) => envContent.match(new RegExp(`^${key}=(.+)$`, "m"))?.[1].trim();
+  const appName = readEnv("VITE_CODEAPPS_APP_NAME");
+  const docTitle = readEnv("VITE_CODEAPPS_DOCUMENT_TITLE");
+  let displayName;
+  try {
+    displayName = JSON.parse(fs.readFileSync(configPath, "utf-8")).appDisplayName;
+  } catch {
+    displayName = undefined;
+  }
+
+  const names = [appName, docTitle, displayName].filter(Boolean);
+  if (names.length > 1 && new Set(names).size > 1) {
+    console.warn("⚠ アプリ表示名が箇所によって違います:");
+    console.warn(`  .env VITE_CODEAPPS_APP_NAME       : ${appName ?? "(未設定)"}`);
+    console.warn(`  .env VITE_CODEAPPS_DOCUMENT_TITLE : ${docTitle ?? "(未設定)"}`);
+    console.warn(`  power.config.json appDisplayName  : ${displayName ?? "(未設定)"}`);
+    console.warn("  → 意図的な使い分けでなければ揃えてください（改名時の直し忘れ）。");
+  }
+}
+
 // 結果出力
 if (errors.length > 0) {
   console.error("\n❌ デプロイ前チェック失敗:\n");

--- a/.github/skills/code-apps/templates/generic-base/src/components/ui/card.tsx
+++ b/.github/skills/code-apps/templates/generic-base/src/components/ui/card.tsx
@@ -20,7 +20,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[minmax(0,1fr)_auto] [.border-b]:pb-6",
         className
       )}
       {...props}


### PR DESCRIPTION
## 目的

Code Apps のレスポンシブ崩れ（横スクロール・テキスト見切れ）を、**壊れてから直す**のではなく **最初から崩れない書き方が標準になる**ようにスキルを更新する。

実案件（Meena Eval）で連続して踏んだ 2 件が発端。

- 詳細画面の一覧ペインを `ScrollArea` で組み、`truncate` が効かず相手名・本文が見切れた
- 詳細画面の右カラムに長文と `<pre>` を追加したところ、`grid-cols-[minmax(0,2fr)_minmax(0,1fr)]` を指定していたのにページ幅を超えた

いずれも「トラックだけ縛ってアイテム側の `min-width: auto` を残していた」「`break-words` が min-content 幅を縮めないことを知らなかった」という同じ根に行き着く。

## 変更内容

### 1. 正常系フロー化（最初からこう書く）

- `references/design-pattern.md`
  - レスポンシブ基本ルールに 5.「横スクロールバーを 1 本も出さない」を追加
  - **「ページの骨格（新規画面はここから書き始める）」**を新設。1 カラム / 2 カラム / マスター詳細の 3 パターンを、`min-w-0` 込みでコピペできる形にした
  - サイズ指定の使い分け表（`minmax(0,1fr)` / 固定 px / 素の `1fr` は使わない）
- `SKILL.md` 設計フェーズに、骨格テンプレートから書き始める旨を CRUD 標準パターンと並ぶ規範として追記

### 2. 自動検出（抜けたら気づける）

`scripts/pre-deploy-check.mjs` にチェック 7 を追加。`npm run predeploy` で警告する。

- 7a: `grid-cols-[...]` に素の `1fr` がある → `minmax(0,1fr)` にする
- 7b: 明示トラックのグリッド直下の子要素に `min-w-0` が無い
- 7c: `ScrollArea` と `truncate` / `line-clamp` の併用

実アプリ（15 ページ）に掛けて誤検出が出ないことを確認済み。当初 `flex` も対象にしたところ 47 件のノイズになったため、実害のある明示トラックのグリッドに絞っている。

### 3. テンプレート本体の修正

`templates/generic-base` の `CardHeader` が shadcn 既定の `grid-cols-[1fr_auto]` のままで、CardAction を持つカードの長いタイトルが溢れる状態だった。`minmax(0,1fr)_auto` に修正。**新規アプリはこの時点でレスポンシブが通る。**

### 4. 落とし穴の明文化

- `references/pre-deploy-review.md` に「5c. ScrollArea + truncate 併用チェック」「5d. グリッドアイテムの `min-w-0` 欠落チェック」
- `references/master-detail-pane-pattern.md` を新規追加（一覧ペインの正常系：検索・キーボード操作・幅制約）
- `break-words` / `[overflow-wrap:anywhere]` / `break-all` の比較表（**`break-words` は描画時にしか折り返さず min-content を縮めない**）

## 確認

- `python .github/skills/update-skills/scripts/validate_skill.py .github/skills/code-apps` → ✅
- 更新後の `pre-deploy-check.mjs` を実アプリで実行 → 検出 2 件（いずれも真の不具合）→ 修正後 0 件
- 修正版を本番デプロイし、詳細画面が 1280 / 768 / 375px で横スクロールしないことを確認
