### PR TITLE
fix(dataverse): Basic Userを分離したセキュリティロール設計に変更

### DIFF
--- a/.github/skills/dataverse/references/security-role-deploy-reference.md
+++ b/.github/skills/dataverse/references/security-role-deploy-reference.md
@@ -88,9 +88,8 @@ ROLE_DEFINITIONS = [
 1. **ルートビジネスユニット取得** — `businessunits` から `parentbusinessunitid eq null` で取得
 2. **ソリューション内テーブル一覧取得** — `solutioncomponents` + `EntityDefinitions` で自動検出（SchemaName 取得必須）
 3. **テーブル権限 ID 取得** — `privileges` テーブルから `prv{Verb}{SchemaName}` パターンで検索
-3.5. **Basic User ロールの全権限取得** — `RetrieveRolePrivilegesRole(RoleId={id})` で約 480 権限を取得（カスタムロールの土台）
 4. **ロールのべき等作成** — 名前 + BU で検索 → 更新 or 新規作成
-5. **権限設定（Basic User + カスタム）** — Basic User 権限を dict にコピー → カスタムテーブル権限で上書き/追加 → 最初のバッチは `ReplacePrivilegesRole` で全置換、2 バッチ目以降は `AddPrivilegesRole` で追加
+5. **対象機能のテーブル権限設定** — `ROLE_DEFINITIONS` に明示した権限だけを組み立て → 最初のバッチは `ReplacePrivilegesRole` で全置換、2 バッチ目以降は `AddPrivilegesRole` で追加
 6. **ソリューション含有検証** — `AddSolutionComponent` (ComponentType=20)
 7. **モデル駆動型アプリ関連付け**（オプション）— `appmoduleroles_association`
 
@@ -98,3 +97,24 @@ ROLE_DEFINITIONS = [
 # 実行
 python ./deploy_security_role.py
 ```
+
+## ユーザー・チームへの割り当て
+
+利用者または利用者チームへ次の2ロールを別々に割り当てる:
+
+1. **Basic User** — Dataverse の標準機能に必要な権限
+2. **カスタムロール** — 対象機能のテーブル CRUD と必要な Append / AppendTo / Assign / Share
+
+この2ロールを割り当てる手順を配布手順書へ必ず記載する。カスタムロールだけでは標準機能が不足し、
+Basic User だけでは対象機能のカスタムテーブルへアクセスできない。
+
+### 既存ロールを移行する順序
+
+旧方式で Basic User の権限をコピー済みのカスタムロールを更新する場合は、次の順序を守る:
+
+1. 対象ユーザー/チームへ Basic User を先に割り当てる
+2. `deploy_security_role.py` を実行し、カスタムロールを対象機能のテーブル権限だけで全置換する
+3. 対象ユーザーで標準機能と対象機能の両方を確認する
+
+手順1より先にスクリプトを実行すると、全置換の時点で Basic User 由来の権限が失われ、
+利用中のユーザーが一時的に標準機能へアクセスできなくなる。

--- a/.github/skills/dataverse/references/security-role-troubleshooting.md
+++ b/.github/skills/dataverse/references/security-role-troubleshooting.md
@@ -15,20 +15,6 @@
   → SchemaName で 0 件の場合は LogicalName で再検索するフォールバックが有効
 ```
 
-### RetrieveRolePrivilegesRole の戻り値フォーマット
-
-```
-戻り値の RolePrivileges 配列の各要素:
-  {
-    "PrivilegeId": "xxxxxxxx-xxxx-...",   # 大文字始まりキー
-    "Depth": "Local",                      # 文字列（Basic/Local/Deep/Global）
-    "BusinessUnitId": "...",
-    "PrivilegeName": "prvRead..."
-  }
-
-→ dict に変換する際は PrivilegeId キー（大文字 P）で統一する
-```
-
 ### ロール作成時に 403 Forbidden
 
 ```
@@ -73,10 +59,32 @@
     geek_Priority: { Read: "Global", AppendTo: "Global", 他は全て None }
 ```
 
-### ReplacePrivilegesRole が失敗する場合のフォールバック
+### 別テナントへのソリューション import で権限深度エラー
 
 ```
-原因: 環境やロール状態によって ReplacePrivilegesRole がエラーになるケースがある
-対策: ReplacePrivilegesRole 失敗時は AddPrivilegesRole にフォールバック
-      スクリプトで try/except で切り替え処理を実装済み
+症状: The privilege <name> with id = <id> can't have depth = Basic, RoleId = ...
+原因: コピー元環境の Basic User 権限をカスタムロールへ取り込むと、配布先環境の
+  canbebasic/canbelocal/canbedeep/canbeglobal と一致しないことがある
+対策: カスタムロールには対象機能のテーブル権限だけを設定する
+  利用者にはカスタムロールと Basic User を別々に割り当てる
+恒久対策: deploy_security_role.py の validate_role_definitions() が extra_privileges を拒否し、
+      Basic User の権限を取得・コピーしない
+```
+
+### ReplacePrivilegesRole が失敗する
+
+```
+原因: 環境やロール状態によって権限の全置換が拒否されている
+対策: エラー内容と各 privilege の許容深度を確認してから再実行する
+禁止: AddPrivilegesRole へのフォールバック
+  既存ロールに Basic User 由来の権限が残り、対象機能だけに絞れなくなるため
+```
+
+### 100件を超える権限設定が途中で失敗する
+
+```
+症状: 最初の ReplacePrivilegesRole は成功したが、2バッチ目以降の AddPrivilegesRole が失敗する
+影響: ロールは最初の100件までが設定された中間状態になる
+対策: エラー原因を解消して同じスクリプトを再実行する
+  最初に ReplacePrivilegesRole が再実行されるため、最終的に定義どおりの権限へ収束する
 ```

--- a/.github/skills/dataverse/references/security-role.md
+++ b/.github/skills/dataverse/references/security-role.md
@@ -38,14 +38,13 @@ Dataverse テーブル・Code Apps・Power Automate フロー・Copilot Studio �
 
 | 項目                       | 内容                                                                   |
 | -------------------------- | ---------------------------------------------------------------------- |
-| ベースロール               | Basic User のコピーから開始（確定ルール。変更不可）                     |
+| 権限の範囲                 | 対象機能で使用するテーブル権限だけを明示（Basic User はコピーしない）   |
 | ロール名                   | 日本語表示名（ロール名に日本語 OK）                                    |
 | ロール説明                 | ロールの目的を簡潔に記述                                               |
 | テーブル権限               | テーブルごとのCRUD権限と深度（Basic/Local/Deep/Global）                 |
 | マスタテーブルの AppendTo  | Lookup 先マスタには必ず AppendTo を付与（読み取り専用でも）            |
-| その他の権限               | 特殊権限（prvExportToExcel, prvBulkDelete 等）が必要か                  |
 | モデル駆動型アプリ関連付け | 作成済みの AppModule に関連付けるか                                     |
-| ユーザー割り当て           | Copilot Studio エージェントに必要か、特定チームか                       |
+| ユーザー割り当て           | カスタムロールと Basic User の両方を割り当てる対象ユーザー/チーム       |
 
 ```
 セキュリティロール: 設計提示 → ユーザー承認 → デプロイスクリプト実行
@@ -109,11 +108,11 @@ TableSchemaName: テーブルのスキーマ名（prefix 含む。例: geek_Proj
 | 2      | Deep    | ユーザーのBU + 子BU のレコード                     |
 | 3      | Global  | 組織全体のレコード                                 |
 
-### 権限設定は AddPrivilegesRole アクションで
+### 権限設定は ReplacePrivilegesRole で全置換する
 
 ```python
-# Bound Action: POST roles({role_id})/Microsoft.Dynamics.CRM.AddPrivilegesRole
-api_post(f"roles({role_id})/Microsoft.Dynamics.CRM.AddPrivilegesRole", {
+# Bound Action: POST roles({role_id})/Microsoft.Dynamics.CRM.ReplacePrivilegesRole
+api_post(f"roles({role_id})/Microsoft.Dynamics.CRM.ReplacePrivilegesRole", {
     "Privileges": [
         {
             "PrivilegeId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
@@ -124,46 +123,47 @@ api_post(f"roles({role_id})/Microsoft.Dynamics.CRM.AddPrivilegesRole", {
 })
 ```
 
-> **注意**: `AddPrivilegesRole` は既存の権限に **追加** する。全置換する場合は `ReplacePrivilegesRole` を使う。
+> **注意**: 最初のバッチは必ず `ReplacePrivilegesRole` で全置換する。
+> `AddPrivilegesRole` は100件を超える場合の2バッチ目以降にだけ使用する。単独で使うと、
+> 既存ロールに Basic User 由来の権限が残るため禁止する。
 
-### 確定ルール（必須）: Basic User ロールの権限をコピーして土台にする
+### 確定ルール（必須）: 対象機能のテーブル権限だけを設定する
 
 ```
-**カスタムセキュリティロールは必ず Basic User のコピーから開始すること**
+**カスタムセキュリティロールへ Basic User の権限をコピーしないこと**
 
-ゼロから作成すると、プラットフォーム標準権限（メール送信・ダッシュボード表示・
-検索・ユーザー設定・ビュー切替等の約 480 権限）が欠落し、
-ユーザーがアプリを正常に使えなくなる。
+カスタムロールには、その機能で使用するテーブルの Create / Read / Write / Delete と、
+Lookup・所有権操作に必要な Append / AppendTo / Assign / Share だけを明示する。
 
-✅ Basic User（旧 Common Data Service User）の全権限を取得
-   → カスタムテーブル権限を上乗せ → ReplacePrivilegesRole で一括設定
-❌ 空のロールにカスタムテーブル権限だけ追加
-   → 標準機能（ダッシュボード・検索・ビュー切替等）が動かない
+✅ カスタムロール: 対象機能のテーブル権限だけ
+✅ 利用者: カスタムロール + Basic User を別々に割り当て
+❌ Basic User の約 480 権限をカスタムロールへコピー
+    → 環境ごとの許容深度差により、別テナントへのソリューション import が失敗することがある
 
-このルールは管理者・ユーザー・閲覧者のいずれのロールにも適用する。
+Dataverse のロール権限は加算されるため、標準機能に必要な権限は Basic User 側から得る。
+このルールは管理者・ユーザー・閲覧者のいずれのカスタムロールにも適用する。
 ```
 
 #### 実装パターン
 
 ```python
-# 1. Basic User ロールの権限を取得
-result = api_get(f"RetrieveRolePrivilegesRole(RoleId={basic_user_role_id})")
-base_privileges = result["RolePrivileges"]  # [{PrivilegeId, Depth}, ...]
-
-# 2. ベースをコピーし、カスタムテーブル権限で上書き/追加
-priv_dict = {p["PrivilegeId"]: p for p in base_privileges}
+# 対象機能のテーブル権限だけを組み立てる
+priv_dict = {}
 priv_dict[custom_priv_id] = {"PrivilegeId": custom_priv_id, "Depth": "Global"}
 
-# 3. 最初のバッチは ReplacePrivilegesRole で全置換、
-#    2 バッチ目以降は AddPrivilegesRole で追加
+# 最初のバッチは ReplacePrivilegesRole で全置換、2 バッチ目以降は追加
 api_post(f"roles({role_id})/Microsoft.Dynamics.CRM.ReplacePrivilegesRole",
          {"Privileges": first_batch})
 api_post(f"roles({role_id})/Microsoft.Dynamics.CRM.AddPrivilegesRole",
          {"Privileges": remaining_batch})
 ```
 
-> **Basic User の検索**: `name eq 'Basic User' or name eq 'Common Data Service User'` で両方の名前を検索（環境による揺れ対応）。
-> **RetrieveRolePrivilegesRole**: Function でルートBU上の Basic User ロール権限を取得。環境の Basic User は約 480 権限を持つ。
+> **割り当て手順を配布手順書へ明記する**: 新しい環境で利用者または利用者チームへ、カスタムロールと
+> `Basic User`（旧 `Common Data Service User`）の両方を割り当てる。Basic User の割り当てがないと、
+> ダッシュボード・検索・ユーザー設定・ビュー切替などの標準機能が動作しない場合がある。
+
+> **対象テーブルを絞る**: `table_privileges` には対象機能で使うテーブルを明示する。
+> `"*"` は、ソリューション内の全テーブルがその機能に属する場合だけ使用する。
 
 ### AddPrivilegesRole のバッチ分割（100 件制限）
 
@@ -228,16 +228,11 @@ for verb in TABLE_VERBS:
 | task           | Task                | タスク                   |
 | note           | Annotation          | 注記                     |
 
-### その他の特殊権限（テーブルに紐付かない）
+### テーブルに紐付かない特殊権限
 
-```
-prvExportToExcel     → Excel エクスポート
-prvBulkDelete        → 一括削除
-prvGoOffline         → オフラインモード
-prvPrint             → 印刷
-prvPublishDuplicateRule → 重複検出ルール公開
-prvReadSharePointData   → SharePoint データ読み取り
-```
+`prvExportToExcel` や `prvBulkDelete` などの特殊権限は、このカスタムロールへ追加しない。
+標準機能に必要な権限は Basic User から得る。追加要件がある場合は、対象機能のテーブル権限とは
+分離して別ロールとして設計し、複数テナント間で許容深度が一致することを検証する。
 
 ### ソリューション含有の検証
 

--- a/.github/skills/dataverse/scripts/deploy_security_role.py
+++ b/.github/skills/dataverse/scripts/deploy_security_role.py
@@ -4,8 +4,8 @@
 Dataverse Web API を使用してカスタムセキュリティロールを作成し、
 ソリューション内テーブルに対する権限を自動設定する。
 
-★ Basic User ロールの権限をコピーして土台にし、
-  カスタムテーブル権限を上乗せする方式。
+★ カスタムロールには対象機能のテーブル権限だけを設定する。
+★ 利用者には Basic User ロールを別途割り当てる。
 ★ ROLE_DEFINITIONS をプロジェクトに合わせて書き換えてください。
 
 手順:
@@ -65,9 +65,6 @@ API = f"{DATAVERSE_URL}/api/data/v9.2"
 #
 # Verb: Create, Read, Write, Delete, Append, AppendTo, Assign, Share
 #
-# extra_privileges:
-#   テーブルに紐付かない特殊権限の名前リスト（オプション）
-
 ROLE_DEFINITIONS = [
     {
         "name": "{ソリューション名} 管理者",
@@ -84,7 +81,6 @@ ROLE_DEFINITIONS = [
                 "Share": "Global",
             },
         },
-        "extra_privileges": [],
     },
     {
         "name": "{ソリューション名} ユーザー",
@@ -122,7 +118,6 @@ ROLE_DEFINITIONS = [
                 "Share": None,
             },
         },
-        "extra_privileges": [],
     },
     {
         "name": "{ソリューション名} 閲覧者",
@@ -139,12 +134,43 @@ ROLE_DEFINITIONS = [
                 "Share": None,
             },
         },
-        "extra_privileges": [],
     },
 ]
 
 # テーブル操作の Verb 一覧
 TABLE_VERBS = ["Create", "Read", "Write", "Delete", "Append", "AppendTo", "Assign", "Share"]
+VALID_DEPTHS = {"Basic", "Local", "Deep", "Global", None}
+
+
+def validate_role_definitions(role_definitions):
+    """対象テーブル権限だけが明示されていることを API 呼び出し前に検証する。"""
+    if not role_definitions:
+        raise ValueError("ROLE_DEFINITIONS にロールを1件以上定義してください")
+
+    for role_def in role_definitions:
+        role_name = role_def.get("name", "<名称未設定>")
+        if "extra_privileges" in role_def:
+            raise ValueError(
+                f"ロール '{role_name}' の extra_privileges は使用できません。"
+                "カスタムロールには対象機能のテーブル権限だけを設定してください"
+            )
+
+        table_privileges = role_def.get("table_privileges")
+        if not table_privileges:
+            raise ValueError(f"ロール '{role_name}' に table_privileges を定義してください")
+
+        for table_name, permissions in table_privileges.items():
+            unknown_verbs = set(permissions) - set(TABLE_VERBS)
+            if unknown_verbs:
+                raise ValueError(
+                    f"ロール '{role_name}' のテーブル '{table_name}' に未対応の操作があります: "
+                    f"{', '.join(sorted(unknown_verbs))}"
+                )
+            for verb, depth in permissions.items():
+                if depth not in VALID_DEPTHS:
+                    raise ValueError(
+                        f"ロール '{role_name}' の {table_name}.{verb} に無効な深度が指定されています: {depth}"
+                    )
 
 
 # ── 認証 ──────────────────────────────────────────────────
@@ -322,59 +348,6 @@ def get_table_privileges(tables):
     return priv_map
 
 
-# ── Step 3.5: Basic User ロールの権限を取得 ──────────────
-
-def get_basic_user_privileges(root_bu_id):
-    """Basic User ロール（旧 Common Data Service User）の全権限を取得する。
-    新しいカスタムロールの土台として使用する。"""
-    print("\n=== Step 3.5: Basic User ロールの権限取得 ===")
-
-    # Basic User を検索（名前の揺れに対応）
-    for role_name in ["Basic User", "Common Data Service User"]:
-        roles = api_get("roles", {
-            "$filter": f"name eq '{role_name}' and _businessunitid_value eq {root_bu_id}",
-            "$select": "roleid,name",
-        })
-        if roles.get("value"):
-            break
-
-    if not roles.get("value"):
-        print("  ⚠️ Basic User ロールが見つかりません。空の権限セットで続行します。")
-        return []
-
-    base_role = roles["value"][0]
-    base_role_id = base_role["roleid"]
-    print(f"  ベースロール: {base_role['name']} ({base_role_id})")
-
-    # RetrieveRolePrivilegesRole で権限一覧を取得
-    try:
-        result = api_get(f"RetrieveRolePrivilegesRole(RoleId={base_role_id})")
-        priv_list = result.get("RolePrivileges", [])
-        print(f"  Basic User の権限数: {len(priv_list)}")
-        return priv_list
-    except requests.HTTPError as e:
-        print(f"  ⚠️ RetrieveRolePrivilegesRole 失敗: {e}")
-        # フォールバック: roleprivileges_association で取得
-        print("  → roleprivileges_association で再試行...")
-        try:
-            privs = api_get(f"roles({base_role_id})/roleprivileges_association", {
-                "$select": "privilegeid,name",
-            })
-            # roleprivileges_association は privilege エンティティを返す
-            # Depth 情報がないので Local をデフォルトにする
-            fallback_list = []
-            for p in privs.get("value", []):
-                fallback_list.append({
-                    "PrivilegeId": p["privilegeid"],
-                    "Depth": "Local",
-                })
-            print(f"  フォールバック権限数: {len(fallback_list)}")
-            return fallback_list
-        except requests.HTTPError as e2:
-            print(f"  ⚠️ フォールバックも失敗: {e2}")
-            return []
-
-
 # ── Step 4: ロールのべき等作成 ────────────────────────────
 
 def ensure_role(role_def, root_bu_id):
@@ -425,27 +398,15 @@ def ensure_role(role_def, root_bu_id):
     return role_id
 
 
-# ── Step 5: 権限設定（Basic User + カスタムテーブル権限）──
+# ── Step 5: 対象機能のテーブル権限設定 ────────────────────
 
-def set_role_privileges(role_id, role_def, tables, priv_map, base_privileges):
-    """Basic User の権限を土台にして、カスタムテーブル権限を上乗せする。
-    ReplacePrivilegesRole で全権限を一括設定する。"""
+def set_role_privileges(role_id, role_def, tables, priv_map):
+    """対象機能のテーブル権限だけを ReplacePrivilegesRole で設定する。"""
     role_name = role_def["name"]
     print(f"\n  === 権限設定: {role_name} ===")
 
-    # 1. Basic User の権限をベースにコピー（PrivilegeId → {PrivilegeId, Depth} の dict）
+    # 1. 対象機能のテーブル権限だけを保持する
     priv_dict = {}
-    for p in base_privileges:
-        pid = p.get("PrivilegeId") or p.get("privilegeId")
-        if pid:
-            priv_dict[pid] = {
-                "PrivilegeId": pid,
-                "Depth": p.get("Depth", "Local"),
-            }
-
-    print(f"    Basic User ベース権限数: {len(priv_dict)}")
-
-    # 2. カスタムテーブル権限を上乗せ（上書きまたは追加）
     table_privs = role_def.get("table_privileges", {})
     default_privs = table_privs.get("*", {})
 
@@ -465,7 +426,7 @@ def set_role_privileges(role_id, role_def, tables, priv_map, base_privileges):
                 continue  # 権限 ID が見つからない
 
             if depth is None:
-                # 明示的に None → この権限を除去（Basic User にあっても削除）
+                # 明示的に None → この権限を付与しない
                 priv_dict.pop(priv_id, None)
             else:
                 # 上書きまたは新規追加
@@ -477,34 +438,17 @@ def set_role_privileges(role_id, role_def, tables, priv_map, base_privileges):
 
     print(f"    カスタムテーブル権限追加/上書き: {custom_added}")
 
-    # 3. extra_privileges（テーブルに紐付かない特殊権限）
-    extra = role_def.get("extra_privileges", [])
-    if extra:
-        filter_parts = [f"name eq '{name}'" for name in extra]
-        filter_str = " or ".join(filter_parts)
-        try:
-            extra_privs = api_get("privileges", {
-                "$filter": filter_str,
-                "$select": "privilegeid,name",
-            })
-            for p in extra_privs.get("value", []):
-                priv_dict[p["privilegeid"]] = {
-                    "PrivilegeId": p["privilegeid"],
-                    "Depth": "Global",
-                }
-                print(f"    特殊権限: {p['name']}")
-        except requests.HTTPError as e:
-            print(f"    ⚠️ 特殊権限の取得失敗: {e}")
-
     privileges_list = list(priv_dict.values())
-    print(f"    合計権限数: {len(privileges_list)}（Basic User + カスタム）")
+    print(f"    合計権限数: {len(privileges_list)}（対象機能のテーブル権限のみ）")
 
     if not privileges_list:
-        print("    ⚠️ 設定する権限がありません")
-        return
+        raise ValueError(
+            f"ロール '{role_name}' に設定可能なテーブル権限がありません。"
+            "既存権限を残さないため処理を中止します"
+        )
 
-    # 4. ReplacePrivilegesRole で全権限を一括設定
-    #    （Basic User の権限 + カスタム権限が一度に反映される）
+    # 2. ReplacePrivilegesRole で全権限を一括設定
+    #    既存ロールに残る Basic User 由来の権限もここで除去する
     #    大量の権限を一度に送ると失敗する場合があるのでバッチ分割
     batch_size = 100
     first_batch = True
@@ -530,20 +474,9 @@ def set_role_privileges(role_id, role_def, tables, priv_map, base_privileges):
         except requests.HTTPError as e:
             err_text = e.response.text if e.response else str(e)
             print(f"    ⚠️ バッチ {i // batch_size + 1} 失敗: {err_text[:300]}")
-            # ReplacePrivilegesRole が失敗したら AddPrivilegesRole にフォールバック
-            if first_batch:
-                print("    → AddPrivilegesRole にフォールバック...")
-                first_batch = False
-                try:
-                    api_post(
-                        f"roles({role_id})/Microsoft.Dynamics.CRM.AddPrivilegesRole",
-                        {"Privileges": batch},
-                        include_solution=False,
-                    )
-                    print(f"    ✅ フォールバック成功: {len(batch)} 権限を追加")
-                except requests.HTTPError as e2:
-                    err_text2 = e2.response.text if e2.response else str(e2)
-                    print(f"    ⚠️ フォールバックも失敗: {err_text2[:300]}")
+            raise RuntimeError(
+                "権限の全置換に失敗しました。既存の Basic User 由来権限が残る可能性があるため処理を中止します"
+            ) from e
 
 
 # ── Step 6: ソリューション含有検証 ────────────────────────
@@ -601,6 +534,8 @@ def associate_with_app(role_ids):
 # ── メイン ────────────────────────────────────────────────
 
 def main():
+    validate_role_definitions(ROLE_DEFINITIONS)
+
     print("=" * 60)
     print("  カスタムセキュリティロール デプロイ")
     print(f"  ソリューション: {SOLUTION_NAME}")
@@ -619,15 +554,12 @@ def main():
     # Step 3: 権限 ID 取得
     priv_map = get_table_privileges(tables)
 
-    # Step 3.5: Basic User ロールの権限を取得（カスタムロールの土台）
-    base_privileges = get_basic_user_privileges(root_bu_id)
-
-    # Step 4-5: ロール作成 → 権限設定（Basic User + カスタム）
+    # Step 4-5: ロール作成 → 対象機能のテーブル権限設定
     print("\n=== Step 4-5: ロール作成 & 権限設定 ===")
     role_ids = []
     for role_def in ROLE_DEFINITIONS:
         role_id = ensure_role(role_def, root_bu_id)
-        set_role_privileges(role_id, role_def, tables, priv_map, base_privileges)
+        set_role_privileges(role_id, role_def, tables, priv_map)
         role_ids.append((role_id, role_def["name"]))
 
     # Step 6: ソリューション含有検証
@@ -641,6 +573,7 @@ def main():
     print("  ✅ カスタムセキュリティロールのデプロイ完了")
     for role_id, role_name in role_ids:
         print(f"    {role_name}: {role_id}")
+    print("  利用者には Basic User ロールも別途割り当ててください")
     print("=" * 60)
 
 

--- a/.github/skills/dataverse/scripts/test_deploy_security_role.py
+++ b/.github/skills/dataverse/scripts/test_deploy_security_role.py
@@ -1,0 +1,123 @@
+"""deploy_security_role の権限定義と payload をローカルで検証する。"""
+
+import ast
+import pathlib
+import types
+import unittest
+
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("deploy_security_role.py")
+
+
+def load_test_targets(api_post):
+    tree = ast.parse(SCRIPT_PATH.read_text(encoding="utf-8"))
+    target_nodes = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id in {"TABLE_VERBS", "VALID_DEPTHS"}
+            for target in node.targets
+        ):
+            target_nodes.append(node)
+        if isinstance(node, ast.FunctionDef) and node.name in {
+            "validate_role_definitions",
+            "set_role_privileges",
+        }:
+            target_nodes.append(node)
+
+    namespace = {
+        "api_post": api_post,
+        "requests": types.SimpleNamespace(HTTPError=FakeHttpError),
+    }
+    module = ast.Module(body=target_nodes, type_ignores=[])
+    exec(compile(module, str(SCRIPT_PATH), "exec"), namespace)
+    return namespace
+
+
+class FakeHttpError(Exception):
+    response = None
+
+
+class DeploySecurityRoleTests(unittest.TestCase):
+    def setUp(self):
+        self.calls = []
+        self.targets = load_test_targets(
+            lambda path, body, include_solution=True: self.calls.append(
+                (path, body, include_solution)
+            )
+        )
+
+    def test_explicit_table_privilege_is_valid(self):
+        self.targets["validate_role_definitions"]([
+            {
+                "name": "Feature User",
+                "table_privileges": {"sample_Feature": {"Read": "Global"}},
+            }
+        ])
+
+    def test_legacy_extra_privileges_key_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self.targets["validate_role_definitions"]([
+                {
+                    "name": "Legacy User",
+                    "table_privileges": {"sample_Feature": {"Read": "Global"}},
+                    "extra_privileges": [],
+                }
+            ])
+
+    def test_payload_contains_only_explicit_table_privileges(self):
+        self.targets["set_role_privileges"](
+            "role-id",
+            {
+                "name": "Feature User",
+                "table_privileges": {
+                    "sample_Feature": {"Read": "Global", "Write": None}
+                },
+            },
+            [{"schema_name": "sample_Feature"}],
+            {"sample_Feature": {"Read": "read-id", "Write": "write-id"}},
+        )
+
+        self.assertEqual(1, len(self.calls))
+        self.assertTrue(self.calls[0][0].endswith("ReplacePrivilegesRole"))
+        self.assertEqual(
+            {"Privileges": [{"PrivilegeId": "read-id", "Depth": "Global"}]},
+            self.calls[0][1],
+        )
+
+    def test_empty_resolved_privileges_are_rejected(self):
+        with self.assertRaises(ValueError):
+            self.targets["set_role_privileges"](
+                "role-id",
+                {
+                    "name": "Feature User",
+                    "table_privileges": {"sample_Feature": {"Read": None}},
+                },
+                [{"schema_name": "sample_Feature"}],
+                {"sample_Feature": {"Read": "read-id"}},
+            )
+
+    def test_replace_failure_does_not_fall_back_to_add(self):
+        calls = []
+
+        def failing_api_post(path, body, include_solution=True):
+            calls.append(path)
+            raise FakeHttpError("replace failed")
+
+        targets = load_test_targets(failing_api_post)
+        with self.assertRaises(RuntimeError):
+            targets["set_role_privileges"](
+                "role-id",
+                {
+                    "name": "Feature User",
+                    "table_privileges": {"sample_Feature": {"Read": "Global"}},
+                },
+                [{"schema_name": "sample_Feature"}],
+                {"sample_Feature": {"Read": "read-id"}},
+            )
+
+        self.assertEqual(1, len(calls))
+        self.assertTrue(calls[0].endswith("ReplacePrivilegesRole"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
- カスタムセキュリティロールを対象機能のテーブル権限だけに限定
- Basic User の権限コピーを廃止し、利用者へ別ロールとして割り当てる設計へ変更
- 既存のコピー済み権限を残さないため、ReplacePrivilegesRole 失敗時は処理を中止
- 既存ロールの安全な移行順序と複数テナント配布時のトラブルシューティングを追加
- 権限定義と送信 payload を検証する回帰テストを追加

## 検証
- \python .github/skills/update-skills/scripts/validate_skill.py .github/skills/dataverse\
- \python -B -m unittest discover -s .github/skills/dataverse/scripts -p test_deploy_security_role.py -v\（5件成功）
- \git diff --check\

Closes #348