### PR TITLE
[sdk-update] Code Apps telemetry template observability (#309)

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -143,7 +143,7 @@ Code Apps 開発は **設計 → 初回デプロイ → データソース接続
 
 > **画面の骨格は [デザインシステム](references/design-pattern.md#ページの骨格新規画面はここから書き始める) からコピーして書き始める**: マルチカラムは `grid-cols-[minmax(0,1fr)_...]`（素の `1fr` は使わない）＋**直接の子すべてに `min-w-0`**、長文は `break-words` ではなく `[overflow-wrap:anywhere]`、コード・表・JSON は `overflow-x-auto` で閉じ込める。`min-w-0` は後付けすると必ず抜けるため最初から書く。`npm run predeploy` のチェック 7 が抜けを警告する。
 
-> **設計で提示する内容**: 選択テンプレート、画面一覧（ページ名・ルート）、各画面のコンポーネント構成、カラム定義、Lookup 名前解決方法（`_xxx_value` + `useMemo` Map）、ナビゲーション構造。
+> **設計で提示する内容**: 選択テンプレート、画面一覧（ページ名・ルート）、各画面のコンポーネント構成、カラム定義、Lookup 名前解決方法（`_xxx_value` + `useMemo` Map）、ナビゲーション構造、テレメトリの転送先と監視する SLI（転送しない場合も明記）。
 
 > **大前提（ソリューション運用）**: Dataverse テーブル・Code Apps・Power Automate・Copilot Studio は同一ソリューション内に開発し、`.env` の `SOLUTION_NAME` / `PUBLISHER_PREFIX` を全フェーズで統一する。詳細は [`standard` スキル](../standard/SKILL.md)。
 
@@ -187,6 +187,11 @@ Code Apps 開発は **設計 → 初回デプロイ → データソース接続
 ```
 
 デプロイ前は `npm run predeploy`（`.env`・`power.config.json` を自動検証）→ `npm run deploy`（predeploy + build + push を一括実行）。
+
+テンプレートは `src/lib/telemetry.ts` を含み、起動時に `initializeLogger` を登録する。既定では外部送信せず、
+クエリ文字列・フラグメント・GUID を除去したメトリクスだけを `code-apps:telemetry` イベントへ出力する。
+Application Insights 等へ転送する場合は custom sink と CSP の `connect-src` を合わせて設計する
+（[テレメトリ / 可観測性パターン](references/telemetry-pattern.md)）。
 
 ### 標準ワークフロー
 
@@ -556,7 +561,7 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 | [setup_connection_reference.py](scripts/setup_connection_reference.py) | 接続参照をソリューションに用意する（既存流用ファースト→Web API で新規作成）。Step 1 で実行 |
 | [pre-deploy-check.mjs](scripts/pre-deploy-check.mjs) | `.env` / `power.config.json` / モック実行基盤の本番混入を検証（`npm run predeploy`）。プロジェクト直下の `scripts/` にコピーして使う |
 | [inspect_table_metadata.py](scripts/inspect_table_metadata.py) | 既存テーブルの EntitySetName / 主キー / 列 / 参照先 / 選択肢を調査（既存テーブル接続時は実装前に必須） |
-| [validate_sample.py](scripts/validate_sample.py) | `samples/` 配下が欠落なくビルドできる状態か検証（必須ファイル・import 先の実在・秘匿情報・SDK の使い方） |
+| [validate_sample.py](scripts/validate_sample.py) | `samples/` 配下の完全性と generic-base のテレメトリ契約を検証（必須ファイル・import 先の実在・秘匿情報・SDK の使い方） |
 | [sync_dataverse_client.py](scripts/sync_dataverse_client.py) | [templates/dataverse-client.ts](templates/dataverse-client.ts) を `samples/` 配下の全コピーへ反映（SDK の破壊的変更への追従はこの 1 ファイルを直して配布） |
 | [scaffold_from_cache.ps1](scripts/scaffold_from_cache.ps1) | キャッシュからのテンプレート scaffold |
 | [toggle_table_lang.py](scripts/toggle_table_lang.py) | 旧方式の `pac code add-data-source` 向けにテーブル表示名を一時的に英語化 |

--- a/.github/skills/code-apps/references/design-templates.md
+++ b/.github/skills/code-apps/references/design-templates.md
@@ -59,6 +59,13 @@ Code Apps は Google Fonts 禁止（外部通信・CSP の制約）。テンプ�
 `--badge-beginner` / `--badge-intermediate` / `--badge-advanced` / `--badge-administrator` / `--badge-developer` は
 **ステータスの意味（色の記号性）を担う**ため、テンプレートを切り替えても変更しない。
 
+### 可観測性 UI は意味色を固定する
+
+テレメトリを運用ダッシュボードへ表示する場合、正常値は `--primary`、注意値（3 秒超のネットワーク要求等）は
+`--badge-intermediate`、失敗値（`successfulAppLaunch: false` / HTTP 400 以上等）は `--destructive` を使う。
+色だけに依存せず、状態ラベルまたはアイコンを併記する。収集・PII サニタイズは
+[テレメトリ / 可観測性パターン](telemetry-pattern.md) に従う。
+
 ### 適用対象の変数一覧
 
 各テンプレートは以下の変数を上書きする:

--- a/.github/skills/code-apps/references/telemetry-pattern.md
+++ b/.github/skills/code-apps/references/telemetry-pattern.md
@@ -1,10 +1,10 @@
 # Code Apps テレメトリ / 可観測性パターン
 
-Power Apps SDK（`@microsoft/power-apps@1.2.7`）の `telemetry` サブパスは、
+Power Apps SDK（`@microsoft/power-apps@1.2.7` 以降、現行テンプレート `1.2.13` で再検証）の `telemetry` サブパスは、
 アプリのロード性能とネットワーク要求の**構造化メトリクス**を公開している。
 「遅い」「たまに落ちる」といった曖昧な報告を、計測値に基づいて切り分けるために導入する。
 
-> **参考**: `dist/telemetry/index.d.ts` / `dist/telemetry/Metrics.types.d.ts` / `dist/telemetry/Performance.d.ts`（SDK 1.2.7 で確認）
+> **参考**: `dist/telemetry/index.d.ts` / `dist/telemetry/LoggerManager.d.ts` / `dist/telemetry/Metrics.types.d.ts` / `dist/telemetry/Performance.d.ts`
 
 ## SDK エクスポート一覧
 
@@ -21,11 +21,15 @@ export type {
 // @microsoft/power-apps/telemetry（Performance.d.ts）
 export declare function getAppLoadedPerformanceData(): object;
 
+// @microsoft/power-apps/telemetry（LoggerManager.d.ts）
+export declare function initializeLogger(logger: ILogger): Promise<void>;
+
 // @microsoft/power-apps/app（Config.d.ts）
 export declare function setConfig(config: { logger?: ILogger }): void;
 ```
 
-`setConfig` は `@microsoft/power-apps/app` サブパスからインポートする（`telemetry` サブパスではない点に注意）。
+`setConfig({ logger })` も利用できるが、内部で `initializeLogger(logger)` を待機せずに呼び出す簡略 API。
+初期化完了や失敗を扱う場合は、`@microsoft/power-apps/telemetry` の `initializeLogger` を直接 `await` する。
 
 ## 受け口の実装（`ILogger.logMetric` を判別共用体で分岐）
 
@@ -33,9 +37,9 @@ export declare function setConfig(config: { logger?: ILogger }): void;
 `ILogger.logMetric` 実装内で種別を分岐し、それぞれの `xxxMetricData` を扱う。
 
 ```typescript
-// src/lib/telemetry.ts
-import { setConfig } from "@microsoft/power-apps/app";
-import type { ILogger, Metric } from "@microsoft/power-apps/telemetry";
+// src/lib/telemetry.ts（完全な実装は下記 generic-base を参照）
+import { initializeLogger } from "@microsoft/power-apps/telemetry";
+import type { Metric } from "@microsoft/power-apps/telemetry";
 
 function handleMetric(metric: Metric): void {
   switch (metric.type) {
@@ -56,16 +60,16 @@ function handleMetric(metric: Metric): void {
   }
 }
 
-const logger: ILogger = {
-  logMetric: (metric: Metric) => handleMetric(metric),
-};
-
-export function initializeTelemetry(): void {
-  setConfig({ logger });
+export async function initializeTelemetry(): Promise<void> {
+  await initializeLogger({ logMetric: (metric: Metric) => handleMetric(metric) });
 }
 ```
 
-`initializeTelemetry()` はアプリのエントリーポイント（`main.tsx` 等）で、他の初期化処理より前に 1 回だけ呼び出す。
+完全な実装は [generic-base のテレメトリ雛形](../templates/generic-base/src/lib/telemetry.ts) を正とする。
+`initializeTelemetry()` はアプリのエントリーポイント（`main.tsx` 等）で 1 回だけ呼び出す。
+テレメトリ初期化の失敗で UI 描画を止めない場合は `void initializeTelemetry().catch(...)` とし、失敗を別経路で記録する。
+汎用ベーステンプレートは、外部送信を行わず、サニタイズ済みメトリクスを `code-apps:telemetry` の
+`CustomEvent` として公開する。転送先を実装するときは custom sink に差し替える。
 
 ## SLI（Service Level Indicator）としての `sessionLoadSummary`
 
@@ -104,6 +108,13 @@ function sanitizeUrl(url: string): string {
     const parsed = new URL(url, window.location.origin);
     // クエリ文字列は丸ごと除去（$filter・$select 等に PII が含まれ得るため）
     parsed.search = "";
+    parsed.hash = "";
+    parsed.pathname = parsed.pathname
+      .replace(/\([^/)]+\)/g, "([id])")
+      .replace(
+        /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+        "[id]",
+      );
     return parsed.toString();
   } catch {
     return "[invalid-url]";
@@ -113,7 +124,7 @@ function sanitizeUrl(url: string): string {
 
 - **クエリ文字列（`?...`）は送信しない**。`$filter=emailaddress1 eq 'user@example.com'` のようにメールアドレスや
   レコード ID（GUID）がそのまま載るため。
-- パス部分に GUID が含まれる場合（例: `/api/data/v9.2/contacts(guid)`）も、必要に応じて `[id]` 等にマスクする。
+- パス部分の OData キー（GUID、代替キー等。例: `/api/data/v9.2/contacts(key)`）も、sink 到達前に `[id]` へマスクする。
 - `sessionLoadSummary` にはユーザー識別情報は含まれないが、独自にログへユーザー ID を付加する場合は
   [ユーザー識別](user-identity.md) の `systemuserid` をそのまま送らず、ハッシュ化するなど別途検討する。
 

--- a/.github/skills/code-apps/scripts/validate_sample.py
+++ b/.github/skills/code-apps/scripts/validate_sample.py
@@ -85,6 +85,7 @@ SDK_PATTERNS = [
 SDK_SURFACE_DIRS = ("src/lib", "src/services", "src/providers")
 
 TEMPLATE_PACKAGE = Path(__file__).resolve().parent.parent / "templates" / "generic-base" / "package.json"
+TEMPLATE_ROOT = TEMPLATE_PACKAGE.parent
 TEMPLATE_PACKAGE_JSON = json.loads(TEMPLATE_PACKAGE.read_text(encoding="utf-8"))
 POWER_APPS_SDK_VERSION = TEMPLATE_PACKAGE_JSON["dependencies"]["@microsoft/power-apps"]
 POWER_APPS_CLI_VERSION = TEMPLATE_PACKAGE_JSON["devDependencies"]["@microsoft/power-apps-cli"]
@@ -195,6 +196,31 @@ def check_template_snapshot() -> list[str]:
     return errors
 
 
+def check_generic_template_telemetry() -> list[str]:
+    telemetry_path = TEMPLATE_ROOT / "src" / "lib" / "telemetry.ts"
+    main_path = TEMPLATE_ROOT / "src" / "main.tsx"
+    if not telemetry_path.is_file():
+        return ["generic-base に src/lib/telemetry.ts がありません"]
+
+    telemetry = telemetry_path.read_text(encoding="utf-8")
+    main = main_path.read_text(encoding="utf-8") if main_path.is_file() else ""
+    required_patterns = {
+        "initializeLogger によるロガー登録": "initializeLogger({",
+        "クエリ文字列の除去": "parsed.search = ''",
+        "フラグメントの除去": "parsed.hash = ''",
+        "OData キーのマスク": "ODATA_KEY_PATTERN",
+        "パス内 GUID のマスク": "RECORD_ID_PATTERN",
+    }
+    errors = [
+        f"generic-base のテレメトリに {label} がありません"
+        for label, pattern in required_patterns.items()
+        if pattern not in telemetry
+    ]
+    if "initializeTelemetry()" not in main:
+        errors.append("generic-base の src/main.tsx で initializeTelemetry() を呼び出していません")
+    return errors
+
+
 def scan_sdk_usage(sample: Path) -> list[str]:
     found: list[str] = []
     for path in sample.rglob("*"):
@@ -236,6 +262,12 @@ def main() -> int:
     base = Path(__file__).resolve().parent.parent / "samples"
     targets = [Path(a).resolve() for a in sys.argv[1:]] or sorted(p for p in base.iterdir() if p.is_dir())
 
+    template_errors = check_generic_template_telemetry()
+    if template_errors:
+        print("\n❌ generic-base telemetry")
+        for error in template_errors:
+            print(f"   • {error}")
+
     snapshot_errors = check_template_snapshot()
     if snapshot_errors:
         print("\n❌ template-snapshot")
@@ -254,7 +286,7 @@ def main() -> int:
             print(f"✅ {sample.name}")
 
     print(f"\n{len(targets) - failed}/{len(targets)} サンプルが OK")
-    return 1 if failed or snapshot_errors else 0
+    return 1 if failed or template_errors or snapshot_errors else 0
 
 
 if __name__ == "__main__":

--- a/.github/skills/code-apps/templates/generic-base/README.md
+++ b/.github/skills/code-apps/templates/generic-base/README.md
@@ -17,6 +17,7 @@ npx degit geekfujiwara/CodeAppsDevelopmentStandard/.github/skills/code-apps/temp
 | ビルド構成 | `vite.config.ts` / `plugins/plugin-power-apps.ts` / `tsconfig*.json` / `eslint.config.js` |
 | スタイル | `styles/index.pcss`（Ocean Blue 既定） / `src/index.css` / `components.json` |
 | 検証 | `scripts/pre-deploy-check.mjs`（`npm run predeploy`） |
+| 可観測性 | `src/lib/telemetry.ts`（`initializeLogger`、PII サニタイズ済み `code-apps:telemetry` イベント） |
 | 共通 UI | `src/components/ui/**`（shadcn プリミティブ） |
 | 汎用コンポーネント | `form-modal` / `list-table` / `loading-skeleton` / `mode-toggle` / `sidebar` / `sidebar-layout` / `stage-path` |
 | レイアウト | `src/pages/_layout.tsx` / `src/pages/not-found.tsx` |
@@ -29,6 +30,13 @@ npx degit geekfujiwara/CodeAppsDevelopmentStandard/.github/skills/code-apps/temp
   — `npx power-apps add-data-source` が生成する `src/generated/services/MicrosoftDataverseService.ts` を
   ラップする形で実装する（[build-reference.md](../../references/build-reference.md) Step 6）
 - 業務の型・選択肢定義（`src/types/`）
+
+## テレメトリの転送
+
+起動性能とネットワーク要求は `window` の `code-apps:telemetry` イベントへ出力されます。
+Application Insights 等へ転送するときは `initializeTelemetry(customSink)` に差し替え、
+送信先を CSP の `connect-src` に追加してください。URL は sink 到達前にクエリ文字列、フラグメント、GUID を除去します。
+詳細は [テレメトリ / 可観測性パターン](../../references/telemetry-pattern.md) を参照してください。
 
 ## 取得後の手順
 

--- a/.github/skills/code-apps/templates/generic-base/src/lib/telemetry.ts
+++ b/.github/skills/code-apps/templates/generic-base/src/lib/telemetry.ts
@@ -1,0 +1,64 @@
+import { initializeLogger } from '@microsoft/power-apps/telemetry'
+import type {
+  Metric,
+  NetworkRequestMetricData,
+  SessionLoadSummaryMetricData,
+} from '@microsoft/power-apps/telemetry'
+
+const ODATA_KEY_PATTERN = /\([^/)]+\)/g
+const RECORD_ID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi
+
+export const TELEMETRY_EVENT_NAME = 'code-apps:telemetry'
+
+export type SanitizedMetric =
+  | {
+      type: 'sessionLoadSummary'
+      data: SessionLoadSummaryMetricData
+    }
+  | {
+      type: 'networkRequest'
+      data: NetworkRequestMetricData
+    }
+
+export type TelemetrySink = (metric: SanitizedMetric) => void
+
+const dispatchTelemetryEvent: TelemetrySink = (metric) => {
+  window.dispatchEvent(new CustomEvent(TELEMETRY_EVENT_NAME, { detail: metric }))
+}
+
+export function sanitizeTelemetryUrl(url: string): string {
+  try {
+    const parsed = new URL(url, window.location.origin)
+    parsed.search = ''
+    parsed.hash = ''
+    parsed.pathname = parsed.pathname
+      .replace(ODATA_KEY_PATTERN, '([id])')
+      .replace(RECORD_ID_PATTERN, '[id]')
+    return parsed.toString()
+  } catch {
+    return '[invalid-url]'
+  }
+}
+
+function sanitizeMetric(metric: Metric): SanitizedMetric {
+  if (metric.type === 'networkRequest') {
+    return {
+      type: metric.type,
+      data: {
+        ...metric.data,
+        url: sanitizeTelemetryUrl(metric.data.url),
+      },
+    }
+  }
+
+  return {
+    type: metric.type,
+    data: metric.data,
+  }
+}
+
+export async function initializeTelemetry(sink: TelemetrySink = dispatchTelemetryEvent): Promise<void> {
+  await initializeLogger({
+    logMetric: (metric) => sink(sanitizeMetric(metric)),
+  })
+}

--- a/.github/skills/code-apps/templates/generic-base/src/main.tsx
+++ b/.github/skills/code-apps/templates/generic-base/src/main.tsx
@@ -3,8 +3,10 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { CODEAPPS_DOCUMENT_TITLE } from '@/config'
+import { initializeTelemetry } from '@/lib/telemetry'
 
 document.title = CODEAPPS_DOCUMENT_TITLE
+void initializeTelemetry().catch(() => undefined)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## 概要

マージ済みの #325 で追加されたテレメトリガイドを、実際に利用できるテンプレートと検証へ拡張します。

- generic-base に `initializeLogger` ベースのテレメトリ雛形と起動時登録を追加
- sink 到達前に URL のクエリ、フラグメント、GUID、OData キーをマスク
- 既定 sink は外部送信せず、サニタイズ済み `code-apps:telemetry` CustomEvent を発行
- SDK 1.2.13 で `initializeLogger` と `setConfig` の関係を再検証し、ガイドを更新
- デザインテンプレートに可観測性 UI の意味色ルールを追加
- `validate_sample.py` に generic-base テレメトリ契約の恒久チェックを追加

## 検証

- generic-base `npm run build`: PASS
- generic-base `npm run lint`: PASS
- サニタイズ機能 4 ケース: PASS
- `validate_sample.py`: 21/21 PASS
- `validate_skill.py code-apps`: PASS
- `validate_skill.py --all`: 18/18 PASS
- `git diff --check`: PASS

Closes #309
