### PR TITLE
[sdk-update] Complete Code Apps server-side paging guidance

### DIFF
--- a/.github/skills/code-apps/references/data-source-patterns.md
+++ b/.github/skills/code-apps/references/data-source-patterns.md
@@ -224,25 +224,39 @@ export interface Customer { [key: string]: unknown; geek_customerid: string; }
 
 ```typescript
 // hooks/useRecordsPage.ts
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 
-export function useRecordsPage(page: number, pageSize = 20) {
+export function useRecordsPage(page: number, pageSize = 20, filter?: string) {
+  const queryClient = useQueryClient();
+  const countKey = ["records", "count", filter] as const;
+
   return useQuery({
-    queryKey: ["records", "page", page, pageSize],
+    queryKey: ["records", "page", page, pageSize, filter],
     queryFn: async () => {
-      const result = await client.retrieveMultipleRecordsAsync<Record>("{prefix}_records", {
+      const cachedCount = queryClient.getQueryData<number>(countKey);
+      const result = await client.retrieveMultipleRecordsAsync<Record<string, unknown>>("{prefix}_records", {
         top: pageSize,
         skip: (page - 1) * pageSize,
-        // 総件数は初回のみ取得すれば十分（下記「総件数は初回のみ取得」参照）。
-        // ページ移動のたびに再取得しない場合は page === 1 のときだけ count: true を渡す。
-        count: page === 1,
+        filter,
+        count: cachedCount === undefined,
       });
       if (!result.success) throw result.error;
-      return { rows: result.data ?? [], count: result.count };
+      if (result.count !== undefined) queryClient.setQueryData(countKey, result.count);
+      return { rows: result.data ?? [], count: result.count ?? cachedCount };
     },
     placeholderData: keepPreviousData, // ページ切替時に前ページの内容を表示したまま次を取得
   });
 }
+```
+
+`data.count` をページャの総件数に使う。検索条件を変えると `countKey` も変わるため、新しい条件では
+再度 `count: true` が送られ、同じ条件でのページ移動ではキャッシュ済み件数が再利用される。
+
+```typescript
+const totalCount = pageQuery.data?.count;
+const totalPages = totalCount === undefined || totalCount >= 5000
+  ? undefined
+  : Math.ceil(totalCount / pageSize);
 ```
 
 ### 5000 件上限の扱い
@@ -266,13 +280,27 @@ export function useRecordsPage(page: number, pageSize = 20) {
 - 検索・フィルタ条件を絞らずに全件を対象にする一覧画面
 - 総ページ数の表示が必須要件ではない（「次へ」「前へ」のみで十分な）画面
 
-`skipToken` はレスポンスの `nextLink`（またはページング情報）から取得し、次リクエストの `skip` の代わりに使う。
-ページ番号ボタンは表示せず、「次へ」ボタンの有効/無効のみで制御する。
+SDK はレスポンスの `@odata.nextLink` から抽出したトークンを `result.skipToken` として返す。
+次リクエストでは `skip` の代わりにその値を `skipToken` へ渡す。
+
+```typescript
+const result = await client.retrieveMultipleRecordsAsync<Record<string, unknown>>("{prefix}_records", {
+  top: pageSize,
+  skipToken: currentSkipToken,
+});
+if (!result.success) throw result.error;
+
+const nextSkipToken = result.skipToken;
+const hasNextPage = nextSkipToken !== undefined;
+```
+
+ページ番号ボタンは表示せず、「次へ」ボタンは `result.skipToken` の有無で制御する。「前へ」も必要なら、
+ページごとに使用した `skipToken` を履歴として保持する。
 
 ### 総件数は初回のみ取得してキャッシュする
 
 `count: true` は毎回 `@odata.count` 集計コストが乗るため、**ページ移動のたびに再取得しない**。
-初回ロード時（`page === 1` または検索条件変更時）のみ `count: true` を送り、以降のページ取得は
+初回ロード時（キャッシュに総件数がない場合）と検索条件変更時のみ `count: true` を送り、以降のページ取得は
 `count: false`（省略）にして、取得済みの総件数を state / React Query キャッシュに保持する。
 `keepPreviousData`（TanStack Query）を併用し、ページ切替時の画面ちらつきも防ぐ。
 

--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -1635,8 +1635,8 @@ npx power-apps list-connections --environment-id {ENVIRONMENT_ID} --json
 1. `count === 5000` のときは実件数として表示せず「5000+ 件」「5000 件以上」と明示する。
 2. レコード数が 5000 件を超える可能性がある画面では、総件数ページャ（ページ番号 + 総ページ数）ではなく
    `skipToken` による「次へ」方式に切り替える。総ページ数を前提にした UI を作らない。
-3. `count: true` は初回取得（`page === 1` または検索条件変更時）のみ送り、以降のページ取得では省略して
-   取得済みの総件数を再利用する（React Query の `keepPreviousData` と併用）。
+3. `count: true` は総件数キャッシュがない場合（初回取得または検索条件変更時）のみ送り、以降のページ取得では
+  省略して取得済みの総件数を再利用する（React Query の `keepPreviousData` と併用）。
 
 > **恒久対策済み**: `data-source-patterns.md` の「ページングと総件数」節に、
 > `count: true` の実装例・5000 件上限の UI 表現・`skipToken` への切り替え基準・


### PR DESCRIPTION
### 概要
本PRは、コードアプリにおけるサーバーサイドページングおよび総件数取得パターンに関する詳細なガイドを追加・拡充するものです。

### PR #324 ベースラインの要約
先行のPR #324 では、一覧画面の実装パターンやトラブルシューティングに関する共通ガイダンスの骨子となるベースライン（一覧表示におけるページングやDataverseでのページ移動コスト削減など）を提示していました。本PRはこれを更に高精度化し、具体的なコード事例と具体的な挙動のケーススタディを追加しています。

### 詳細・変更点説明
1. **総件数キャッシュの再利用 (Count Cache Reuse):**
   React Query（`useQueryClient`, `keepPreviousData`）を組み合わせ、同じ検索条件でのページ移動では初回に取得した件数を再利用するコードパターンを提示しました。不要な `count: true` の再クエリを防ぎます。
2. **5000件上限のハンドリング (totalPages Handling at 5000 Cap):**
   `totalCount === undefined || totalCount >= 5000` の場合には `totalPages` を `undefined` とし、明確に「ページ情報不明または5000件以上」として扱うためのロジックを提示しました。
3. **`result.skipToken` の直接利用 (Direct result.skipToken usage):**
   5000件を超える可能性がある一覧画面での推奨アプローチとして、SDKの `result.skipToken` を直接 `skipToken: currentSkipToken` として渡して制御する「次へ」ボタンの実装パターンを追加しました。
4. **トラブルシューティングとの整合 (Troubleshooting Alignment):**
   `troubleshooting.md` における、総件数 5000 件上限時の対策、キャッシュ利用等の説明文を更新し、`data-source-patterns.md` で追加された具現化コード・対応策と完全な整合性を取りました。

### 動作検証
- **個別検証 (Targeted Validation):** `code-apps` スキルの検証をパスしました。
- **全体検証 (All-skills Validation):** 18 passed, 0 failed

### マージ・並行PR状況
- 他に未マージのオープンなPRはありません。
- マージ順序に関する別PRとの依存関係もありません。

Closes #311
