### PR TITLE
[sdk-update] Add Code Apps CLI share workflow

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -6,6 +6,8 @@ triggers:
   - "Code Apps"
   - "power-apps init"
   - "power-apps push"
+  - "power-apps share"
+  - "Code Apps 共有"
   - "add-data-source"
   - "DataverseService"
   - "Tailwind"
@@ -112,7 +114,8 @@ Code Apps 開発は **設計 → 初回デプロイ → データソース接続
         ⑨ MicrosoftDataverseService + *WithOrganization ラッパーを実装
           │
 [§4 改善デプロイ]
-        ⑩ src/ 実装 → npm run deploy（power-apps push を反復）
+  ⑩ src/ 実装 → npm run deploy（power-apps push を反復）
+  ⑪ 最終 push 後に power-apps share（利用者は play、共同開発者だけ edit）
 ```
 
 ### この後の章構成
@@ -256,7 +259,15 @@ npm run predeploy
 # 再ビルド＆デプロイ（反復）
 npm run build
 npx power-apps push
+
+# Step 8: 最終 push 後に共有（カンマ区切りで複数指定可）
+npx power-apps share --environment-id {ENVIRONMENT_ID} \
+  --principal "${CODE_APP_PLAY_PRINCIPALS}" \
+  --access play --non-interactive --json
 ```
+
+共有対象のユーザー／サービスプリンシパル、`edit` の最小権限ルール、CI/CD 例は
+[npm CLI リファレンスの `share`](references/cli-reference.md#share)を参照する。
 
 > **Step 5 の `--solution-id` は後戻りできない**: 初回の `power-apps push --solution-id` がアプリを `almMode: Solution` にするのは
 > **`appId` 未割当の初回 push のみ**。`almMode: Environment` で作ってしまったアプリは、後から `-s` を付けて
@@ -532,7 +543,7 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 | [一覧ペイン（マスター詳細）パターン](references/master-detail-pane-pattern.md) | 詳細画面の左にレコード一覧を常駐させて遷移しないで切り替え（Dataverse 側検索・デバウンス・見切れ防止の落とし穴表） |
 | [AI 評価ルールのマスタ化パターン](references/ai-evaluation-master-pattern.md) | LLM の判定基準をテーブルに出してアプリから編集・ジョブ行キューで過去データを再評価・根拠ハイライトと改善提案（OData キーの URL エンコード落とし穴） |
 | [構築リファレンス](references/build-reference.md) | ビルド・デプロイの詳細手順・vite.config.ts 必須設定・TypeScript エラー対処 |
-| [npm CLI リファレンス](references/cli-reference.md) | SDK 1.2.13 / CLI 0.15.3 検証済み・最新版への更新方針・`push -s` の GUID 要件・`create-connection` / `refresh-data-source` / `auth-switch` |
+| [npm CLI リファレンス](references/cli-reference.md) | SDK 1.2.13 / CLI 0.15.3 検証済み・最新版への更新方針・`push -s` の GUID 要件・`share` の最小権限運用・`create-connection` / `refresh-data-source` / `auth-switch` |
 | [ソリューション ALM](references/solution-alm.md) | 接続参照バインド・`almMode` と初回 push・コンポーネント種別・共有時の権限モデル |
 | [データソースパターン](references/data-source-patterns.md) | 生成サービス・dataSourcesInfo・TanStack React Query（旧/native パターン含む）・外部システムの資産を Dataverse にミラーして読む |
 | [モックデータ開発パターン](references/mock-data-pattern.md) | 開発限定の `createMockDataExecutor` 導入・本番バンドル混入防止・SDK 1.2.7 の取得専用制約 |
@@ -561,6 +572,7 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 | [setup_connection_reference.py](scripts/setup_connection_reference.py) | 接続参照をソリューションに用意する（既存流用ファースト→Web API で新規作成）。Step 1 で実行 |
 | [pre-deploy-check.mjs](scripts/pre-deploy-check.mjs) | `.env` / `power.config.json` / モック実行基盤の本番混入を検証（`npm run predeploy`）。プロジェクト直下の `scripts/` にコピーして使う |
 | [inspect_table_metadata.py](scripts/inspect_table_metadata.py) | 既存テーブルの EntitySetName / 主キー / 列 / 参照先 / 選択肢を調査（既存テーブル接続時は実装前に必須） |
+| [validate_cli_reference.py](scripts/validate_cli_reference.py) | テンプレート採用版の `power-apps share --help` と CLI リファレンスの主要オプション・実行例が一致することを検証 |
 | [validate_sample.py](scripts/validate_sample.py) | `samples/` 配下の完全性と generic-base のテレメトリ契約を検証（必須ファイル・import 先の実在・秘匿情報・SDK の使い方） |
 | [sync_dataverse_client.py](scripts/sync_dataverse_client.py) | [templates/dataverse-client.ts](templates/dataverse-client.ts) を `samples/` 配下の全コピーへ反映（SDK の破壊的変更への追従はこの 1 ファイルを直して配布） |
 | [scaffold_from_cache.ps1](scripts/scaffold_from_cache.ps1) | キャッシュからのテンプレート scaffold |

--- a/.github/skills/code-apps/references/.env.example
+++ b/.github/skills/code-apps/references/.env.example
@@ -15,6 +15,9 @@ ENV_ID=00000000-0000-0000-0000-000000000000
 # 対象ソリューションの一意名（`pac solution list` の SolutionUniqueName）
 SOLUTION_NAME=YourSolutionUniqueName
 
+# 対象ソリューションの ID（`npx power-apps push --solution-id` に渡す GUID）
+SOLUTION_ID=00000000-0000-0000-0000-000000000000
+
 # 発行者プレフィックス（`pac solution list` の PublisherUniqueName に紐づくプレフィックス）
 PUBLISHER_PREFIX=your
 
@@ -24,3 +27,11 @@ DATAVERSE_CONNECTION_ID=
 
 # Code App の App ID（`pac code list` / power.config.json の appId）
 APP_ID=00000000-0000-0000-0000-000000000000
+
+# Code App 共有先（メールアドレスまたは Entra object ID をカンマ区切りで指定）
+# 通常利用者／実行主体は play。edit は共同開発者など必要な主体だけを別管理する。
+CODE_APP_PLAY_PRINCIPALS=user@contoso.com,{USER_OBJECT_ID},{SERVICE_PRINCIPAL_OBJECT_ID}
+CODE_APP_EDIT_PRINCIPALS={DEVELOPER_USER_OBJECT_ID}
+
+# Power Apps CLI のクラウド。通常テナントは public
+POWER_APPS_CLOUD=public

--- a/.github/skills/code-apps/references/cli-reference.md
+++ b/.github/skills/code-apps/references/cli-reference.md
@@ -18,6 +18,7 @@ Code Apps 用 npm CLI（`npx power-apps`）の全コマンド一覧。
 - [全コマンド一覧](#全コマンド一覧)
 - [グローバルオプション](#グローバルオプション)
 - [アプリライフサイクル](#アプリライフサイクル)
+- [アプリ共有](#アプリ共有)
 - [データソース](#データソース)
 - [Dataverse API（アクション／関数）](#dataverse-apiアクション関数)
 - [探索系（list-\*）](#探索系list-)
@@ -58,8 +59,10 @@ npm install -D @microsoft/power-apps-cli@latest
 npm ls @microsoft/power-apps @microsoft/power-apps-cli
 npx power-apps --help
 npx power-apps push --help
+npx power-apps share --help
 npm run build
 python .github/skills/code-apps/scripts/validate_sample.py
+python .github/skills/code-apps/scripts/validate_cli_reference.py
 ```
 
 `validate_sample.py` は `templates/generic-base/package.json` を基準に全サンプルの SDK / CLI 範囲を検証する。
@@ -71,6 +74,7 @@ python .github/skills/code-apps/scripts/validate_sample.py
 |---|---|
 | `init` | コードアプリの初期化（`power.config.json` 生成） |
 | `push` | 環境へ発行 |
+| `share` | 現在のコードアプリをユーザー／サービスプリンシパルへ共有 |
 | `run` | ローカルサーバー起動（接続をローカル読み込み） |
 | `add-data-source` | データソース追加 |
 | `refresh-data-source` | データソースのスキーマ／生成コード再取得 |
@@ -156,6 +160,77 @@ npx power-apps run --port 8080 --local-app-url http://localhost:3000
 ```
 
 `-p, --port` / `-l, --local-app-url` を指定できる。
+
+## アプリ共有
+
+### `share`
+
+現在の `power.config.json` が指す Code App を、ユーザーまたはサービスプリンシパルへ共有する。
+**通常利用者は既定の `play`** とし、共同開発者やデプロイ主体など編集が必要な principal に限って
+`--access edit` を明示する。閲覧・実行だけの主体へ `edit` を付与しない。
+
+| オプション | 説明 |
+|---|---|
+| `-p, --principal <principal>` | メールアドレスまたは Entra object ID。カンマ区切りで複数指定でき、object ID はユーザー／サービスプリンシパルのどちらも指定可能 |
+| `--access <access>` | `play`（既定）または `edit`。最小権限のため通常は `play` |
+| `-e, --environment-id <environment-id>` | 共有先の環境 ID。CI/CD と複数環境運用では必ず明示 |
+| `--cloud <cloud>` | `public`（既定）/ `usgov` / `usgovhigh` / `usgovdod` / `china` |
+| `--non-interactive` | 確認プロンプトを出さない。CI/CD では必須 |
+| `--json` | 結果を機械可読な JSON で出力。CI/CD では必須 |
+
+```bash
+# ユーザーのメールアドレス（--access 省略時も play）
+npx power-apps share --principal user@contoso.com
+
+# ユーザーの Entra object ID
+npx power-apps share --principal {USER_OBJECT_ID} --access play
+
+# サービスプリンシパルの Entra object ID（application/client ID ではない）
+npx power-apps share --principal {SERVICE_PRINCIPAL_OBJECT_ID} --access play
+
+# 複数主体を 1 回で共有
+npx power-apps share \
+	--principal "user@contoso.com,{USER_OBJECT_ID},{SERVICE_PRINCIPAL_OBJECT_ID}" \
+	--access play
+
+# 共同開発者だけ edit を明示
+npx power-apps share --principal {DEVELOPER_USER_OBJECT_ID} --access edit
+```
+
+#### push 後の CI/CD 標準
+
+共有はデプロイ成功後にだけ実行する。環境ごとの principal 一覧は CI/CD の環境変数または変数グループで管理し、
+リポジトリへ実値をコミットしない。商用クラウドでは `--cloud public` を省略できるが、ソブリンクラウドでは
+対象値を明示する。
+
+```bash
+# Bash を使う CI runner 向け（PowerShell runner では行継続と環境変数構文を読み替える）
+set -euo pipefail
+
+npx power-apps push \
+	--environment-id "${ENVIRONMENT_ID}" \
+	--solution-id "${SOLUTION_ID}"
+
+npx power-apps share \
+	--environment-id "${ENVIRONMENT_ID}" \
+	--cloud "${POWER_APPS_CLOUD:-public}" \
+	--principal "${CODE_APP_PLAY_PRINCIPALS}" \
+	--access play \
+	--non-interactive \
+	--json > share-result.json
+```
+
+`CODE_APP_PLAY_PRINCIPALS` はメールアドレス／object ID のカンマ区切りとする。`edit` 対象が必要な場合は
+`CODE_APP_EDIT_PRINCIPALS` を別変数にし、空でない場合だけ 2 回目の `share --access edit` を実行する。
+`--environment-id` は push と share で同じ値を渡し、別環境への共有を防ぐ。
+
+CLI help と本節の整合は次で検証する。スクリプトはテンプレートの
+`@microsoft/power-apps-cli` バージョンを読み、実際の `share --help` に主要オプションがあることと、
+本節に全オプション・ユーザー／サービスプリンシパル例・自動化例があることを確認する。
+
+```bash
+python .github/skills/code-apps/scripts/validate_cli_reference.py
+```
 
 ## データソース
 
@@ -312,7 +387,7 @@ npx power-apps telemetry --disable
 | `pac code list-tables` | `power-apps list-tables` | |
 | `pac code list-sql-stored-procedures` | `power-apps list-sqlStoredProcedures` | ハイフンとキャメルケースの違いに注意 |
 | `pac code list-connection-references` | `power-apps list-connection-references` | |
-| （なし） | `refresh-data-source` / `find-dataverse-api` / `add-dataverse-api` / `add-flow` / `remove-flow` / `list-flows` / `list-connections` / `list-connectors` / `list-environment-variables` / `create-connection` / `auth-*` | npm CLI のみ |
+| （なし） | `share` / `refresh-data-source` / `find-dataverse-api` / `add-dataverse-api` / `add-flow` / `remove-flow` / `list-flows` / `list-connections` / `list-connectors` / `list-environment-variables` / `create-connection` / `auth-*` | npm CLI のみ |
 
 > 本スキルの標準は npm CLI。実行前に `auth-status` / `auth-switch` で対象テナントの
 > アカウントを明示する。`pac code` は npm CLI で解消できない場合のみ移行時の代替手段として使う。

--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -1927,3 +1927,22 @@ api_post("PublishAllXml", {})
 
 `geek_evaljobs` を `requestedon desc` で数件引き、`status` / `targetcount` / `donecount` が
 進むことを見る。`donecount` が止まったまま `modifiedon` だけ古くなっていれば、ワーカーが死んでいる。
+
+---
+
+## 41. `power-apps share` が principal／権限／環境エラーになる（検証済 2026-08-17）
+
+### 症状・原因・対処
+
+| 症状 | 主な原因 | 対処 |
+|---|---|---|
+| principal が存在しない、または解決できない | メールアドレスの誤記、別テナントのユーザー、サービスプリンシパルの application/client ID を指定した | 対象テナントのユーザーメールまたは Entra **object ID** を使う。サービスプリンシパルも object ID を指定する |
+| 共有操作が forbidden／権限不足になる | CLI のアクティブアカウントにアプリ共有権限がない | `npx power-apps auth-status` で主体を確認し、アプリ所有者または共有可能な権限を持つアカウントへ `auth-switch` する |
+| コマンドは成功したが意図した環境で共有されない、またはアプリが見つからない | `power.config.json` と対象環境が違う、push と share で `--environment-id` が不一致 | push と share の両方に同じ `--environment-id` を明示し、実行前に `auth-status` と `power.config.json` を確認する |
+| `--access` が拒否される、または過剰な編集権限を付けた | `play` / `edit` 以外を指定した、通常利用者へ `edit` を指定した | 値は `play` または `edit` のみ。既定は `play` とし、`edit` は共同開発者など必要な主体だけに分離する |
+
+CI/CD では `--non-interactive --json` を付け、終了コードが 0 のときだけ後続処理へ進む。
+principal 一覧を環境別変数として管理し、開発環境の object ID を本番環境へ流用しない。
+
+**恒久対策済み**: [CLI リファレンスの `share`](cli-reference.md#share) に最小権限・環境明示・自動化の
+標準を集約し、`scripts/validate_cli_reference.py` が CLI help と主要オプション／実行例の整合を検証する。

--- a/.github/skills/code-apps/scripts/validate_cli_reference.py
+++ b/.github/skills/code-apps/scripts/validate_cli_reference.py
@@ -1,0 +1,138 @@
+"""Validate the Code Apps CLI reference against the published ``share --help``.
+
+Usage:
+  python validate_cli_reference.py
+  python validate_cli_reference.py --help-file path/to/share-help.txt
+
+The default path executes the exact CLI version pinned by generic-base. The
+``--help-file`` option supports offline validation and failure-path tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+    sys.stderr.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+REFERENCE_FILE = SKILL_ROOT / "references" / "cli-reference.md"
+TEMPLATE_PACKAGE = SKILL_ROOT / "templates" / "generic-base" / "package.json"
+
+HELP_PATTERNS = {
+    "share command description": r"Share the current Power Apps code app with users or service principals\.",
+    "principal": r"--principal <principal>",
+    "access": r"--access <access>",
+    "environment": r"--environment-id <environment-id>",
+    "cloud": r"--cloud <cloud>",
+    "non-interactive": r"--non-interactive",
+    "JSON output": r"--json",
+    "play/edit values": r"play \(default\) or edit",
+}
+
+REFERENCE_PATTERNS = {
+    "principal option": r"--principal <principal>",
+    "access option": r"--access <access>",
+    "environment option": r"--environment-id <environment-id>",
+    "cloud option": r"--cloud <cloud>",
+    "non-interactive option": r"--non-interactive",
+    "JSON option": r"--json",
+    "user email example": r"power-apps share --principal user@contoso\.com",
+    "user object ID example": r"power-apps share --principal \{USER_OBJECT_ID\}",
+    "service principal example": r"power-apps share --principal \{SERVICE_PRINCIPAL_OBJECT_ID\}",
+    "multiple principals example": (
+        r"--principal\s+[\"']user@contoso\.com,\{USER_OBJECT_ID\},\{SERVICE_PRINCIPAL_OBJECT_ID\}[\"']"
+    ),
+    "least-privilege play guidance": r"通常利用者は既定の `play`",
+    "explicit edit example": r"--principal \{DEVELOPER_USER_OBJECT_ID\} --access edit",
+    "push before share automation": r"power-apps push[\s\S]+power-apps share",
+}
+
+
+def pinned_cli_version() -> str:
+    package = json.loads(TEMPLATE_PACKAGE.read_text(encoding="utf-8"))
+    version = package["devDependencies"]["@microsoft/power-apps-cli"]
+    return version.lstrip("~^")
+
+
+def run_share_help() -> str:
+    npx = shutil.which("npx")
+    if not npx:
+        raise RuntimeError("npx が見つかりません。Node.js 22 以上をインストールしてください。")
+
+    version = pinned_cli_version()
+    command = [
+        npx,
+        "--yes",
+        "--package",
+        f"@microsoft/power-apps-cli@{version}",
+        "power-apps",
+        "share",
+        "--help",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise RuntimeError(f"share --help の取得に失敗しました (exit {result.returncode}): {detail}")
+    return result.stdout
+
+
+def share_section(reference: str) -> str:
+    match = re.search(r"^### `share`\s*$([\s\S]*?)(?=^## |\Z)", reference, re.MULTILINE)
+    if not match:
+        raise RuntimeError("cli-reference.md に `### `share`` 節がありません。")
+    return match.group(1)
+
+
+def missing_patterns(text: str, patterns: dict[str, str]) -> list[str]:
+    return [label for label, pattern in patterns.items() if not re.search(pattern, text)]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--help-file", type=Path, help="保存済み share --help 出力を使用する")
+    parser.add_argument("--reference-file", type=Path, default=REFERENCE_FILE, help="検証する CLI リファレンス")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        help_text = args.help_file.read_text(encoding="utf-8") if args.help_file else run_share_help()
+        reference = args.reference_file.read_text(encoding="utf-8")
+        section = share_section(reference)
+    except (OSError, KeyError, RuntimeError, json.JSONDecodeError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    errors = [f"CLI help にありません: {label}" for label in missing_patterns(help_text, HELP_PATTERNS)]
+    errors.extend(
+        f"cli-reference.md の share 節にありません: {label}"
+        for label in missing_patterns(section, REFERENCE_PATTERNS)
+    )
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    source = str(args.help_file) if args.help_file else f"@microsoft/power-apps-cli@{pinned_cli_version()}"
+    print(f"OK: share CLI help and documentation are aligned ({source})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### 目的

Code Apps CLI 0.15.x の `power-apps share` を、デプロイ後の標準共有手順として Code Apps スキルへ追加します。

### 変更内容

- ユーザーのメールアドレス、ユーザーの Entra object ID、サービスプリンシパルの Entra object ID、カンマ区切りの複数 principal の例を追加
- 通常利用者は既定の `play`、共同開発者など必要な主体だけ `edit` とする最小権限ルールを明記
- CI/CD で `power-apps push` の成功後、同じ環境 ID に対して `power-apps share --non-interactive --json` を実行する例を追加
- CLI 0.15.3 の `share --help` を実行し、主要オプションと文書例の整合を検証する `validate_cli_reference.py` を追加
- 検証器が必須フィールドの欠落時に失敗することも確認
- principal の解決失敗、共有権限不足、対象環境違い、無効または過剰な access の対処を troubleshooting に追加

### 検証

- `validate_cli_reference.py`: CLI 0.15.3 の実 help に対して成功
- 検証器の失敗系: 必須 help フィールド欠落を検出して終了コード 1
- `validate_skill.py .github/skills/code-apps`: 成功
- `validate_skill.py --all`: 18/18 成功
- `validate_sample.py`: 21/21 成功
- `git diff --check`: 成功

関連するオープン PR はなく、マージ順の依存関係はありません。

Closes #352
