### PR TITLE
skill(spec-builder): spec/input への取り込みは移動（元ファイル削除）とすることを明記

### DIFF
--- a/.github/skills/spec-builder/SKILL.md
+++ b/.github/skills/spec-builder/SKILL.md
@@ -51,6 +51,7 @@ spec/                          ← スキル専用ディレクトリ
 - 既定 checklist: `spec/.cache/conversion-checklist.json`
 - `--input` / `--staging` / `--docs`（互換: `--output`）/ `--checklist` を指定した場合はそのパスを優先する
 - `spec/input/` に変換対象が見つからない場合、`scripts/convert_documents.py` はワークスペース・フォルダ全体をスキャンし、変換候補になりうるファイルがないか確認する。候補が見つかった場合は一覧を提示するので、`spec/input/` へ移動するか `--input` で対象パスを指定する
+- 「`spec/input/` へ移動する」とは**元の場所のファイルを削除するまでを含む**。`spec/input/` へコピーしただけで元ファイルを残すと、ワークスペース上に同一内容のファイルが重複し混乱の元になる。コピー→取り込み確認後は元ファイルを削除すること
 
 ## 処理フロー
 

--- a/.github/skills/spec-builder/references/conversion-guide.md
+++ b/.github/skills/spec-builder/references/conversion-guide.md
@@ -57,7 +57,7 @@ powershell -ExecutionPolicy Bypass -File run_windows.ps1
 - pending JSON: checklist と同じ `spec/.cache/` に自動配置
 
 `spec/input/` に変換対象がない場合、`convert_documents.py` はワークスペース・フォルダ全体をスキャンし、変換候補になりうるファイル（対応拡張子）がないか確認する。見つかった場合は候補一覧を提示するので、`spec/input/` に移動するか `--input` で対象パスを指定する。
-
+**「移動」は元ファイルの削除まで含む。** `spec/input/` へコピーした後、元の場所のファイルを残したままにしない（重複ファイルがワークスペースに残るのを防ぐため）。
 オプション（checklist のパスを変えると pending JSON も同じディレクトリに移動する）:
 
 ```bash


### PR DESCRIPTION
スキル `spec-builder` を追加/更新します。

- validate_skill.py PASS
- マージ順: 単独 PR（他のオープン PR と無関係なら番号順で可）