### PR TITLE
sdk-update(power-automate): Node.js 20+ prerequisite, auth diagnostics

### DIFF
--- a/.github/skills/power-automate/SKILL.md
+++ b/.github/skills/power-automate/SKILL.md
@@ -46,7 +46,7 @@ MCP が利用できない環境では Dataverse Web API（workflow テーブル�
 
 ### 1. 前提
 
-- Node.js 18+
+- Node.js 20+（FlowAgent v3.0.0 以降は MCP SDK v2 のため Node.js 18 では起動できない）
 - git（`microsoft/power-platform-skills` の `plugins/power-automate` を取得するために使用）
 - Azure CLI（`az login` — MCP サーバー自身の認証に必要。`auth_helper.py` とは別の資格情報ストア）
 
@@ -57,7 +57,7 @@ MCP が利用できない環境では Dataverse Web API（workflow テーブル�
 
 | 処理 | 内容 |
 |---|---|
-| Node.js 確認 | 18+ でなければ中断 |
+| Node.js 確認 | 20+ でなければ中断 |
 | az login 確認 | `az account list` で対象テナントの既存キャッシュを確認 → あれば `az account set` のみ（対話不要）。無い場合のみ案内を表示 |
 | auth_helper 認証 | Dataverse / Flow API トークンを取得・キャッシュ（Python スクリプト用） |
 | プラグイン取得 | `microsoft/power-platform-skills` を git スパースチェックアウトで `~/.power-platform-skills` に取得（マシン全体で共有・自動更新） |

--- a/.github/skills/power-automate/references/flow-agent-mcp.md
+++ b/.github/skills/power-automate/references/flow-agent-mcp.md
@@ -3,7 +3,8 @@
 ## 概要
 
 FlowAgent MCP SERVER は `server/mcp.mjs`（自己完結型 ESM バンドル）で動作する
-Node.js 18+ の MCP サーバー。VS Code の GitHub Copilot Chat（エージェントモード）から
+Node.js 20+ の MCP サーバー（v3.0.0 以降は MCP SDK v2 化に伴い Node.js 18 では起動しない）。
+VS Code の GitHub Copilot Chat（エージェントモード）から
 Power Automate クラウドフローを自然言語で構築・編集・デバッグできる。
 
 > ★ このプラグイン本体は元々 Claude Code / GitHub Copilot CLI 向けの `/plugin marketplace add`
@@ -20,7 +21,7 @@ Power Automate クラウドフローを自然言語で構築・編集・デバ�
 
 | 要件 | 確認コマンド |
 |---|---|
-| Node.js 18+ | `node --version` |
+| Node.js 20+ | `node --version` |
 | git（プラグイン本体の取得に使用） | `git --version` |
 | Python 3 + azure-identity + python-dotenv | `pip install -r .github/skills/standard/scripts/requirements.txt` |
 | Azure CLI（MCP サーバーの認証） | `az --version` |
@@ -47,7 +48,7 @@ python .github/skills/power-automate/scripts/setup_flow_mcp.py
 
 スクリプトは次の処理を自動で行う:
 
-1. Node.js 18+ を確認する
+1. Node.js 20+ を確認する
 2. `az account list` で対象テナントの既存キャッシュを確認する
    - 既にキャッシュ済みなら `az account set` だけで切り替え（対話不要）
    - 無い場合のみ `az login --tenant {id}` の案内を表示（★ いきなりログインを迫らない）
@@ -141,6 +142,18 @@ python .github/skills/power-automate/scripts/setup_flow_mcp.py [オプション]
 | `manage-desktop-flows` | デスクトップフロー（RPA）の一覧・実行 |
 | `route-environments` | 環境の解決・ルーティング |
 
+## 認証・ID の診断ツール（v3.0.4+）
+
+FlowAgent は Azure CLI（`az`）のサインイン ID をそのまま使う。意図しないアカウントで
+認証されていると、原因が分かりにくい権限エラーや DNS エラーとして表面化する。
+以下のツールで可視化・復旧できる。
+
+| ツール | 使うタイミング |
+|---|---|
+| `whoami` | 認証系のエラーが出たらまず実行。有効な `az` アカウント、CLI プロファイルのパス（`AZURE_CONFIG_DIR` 反映）、解決済みクラウド、トークンキャッシュの場所、トークンが実際に持つテナントを表示する |
+| `reconnect` | `az login` / `az account set` でアカウントを切り替えた後、または古いトークンで 401/403 が出るとき。キャッシュされたトークンを破棄して再取得する |
+| `doctor` | 総合チェック（CLI の有無・サインイン状態・config dir・クラウド・トークン取得・トークンと `az` ID の一致・現在の環境・環境への到達性）を一括診断し、それぞれに具体的な対処を提示する |
+
 ## よくあるトラブル
 
 ### セットアップスクリプトが `DATAVERSE_URL が未設定` で終了する
@@ -149,11 +162,11 @@ python .github/skills/power-automate/scripts/setup_flow_mcp.py [オプション]
 
 ### `Node.js が見つかりません` エラー
 
-Node.js 18+ をインストールする。`node --version` で確認。
+Node.js 20+ をインストールする。`node --version` で確認。
 
 ### `FlowAgent プラグインが見つかりません` エラー
 
-1. `git` と Node.js 18+ がインストールされているか確認する（`git --version` / `node --version`）
+1. `git` と Node.js 20+ がインストールされているか確認する（`git --version` / `node --version`）
 2. 手動で取得する場合:
    ```bash
    git clone --depth 1 --filter=blob:none --sparse https://github.com/microsoft/power-platform-skills.git ~/.power-platform-skills

--- a/.github/skills/power-automate/scripts/setup_flow_mcp.py
+++ b/.github/skills/power-automate/scripts/setup_flow_mcp.py
@@ -81,10 +81,10 @@ _PLUGIN_ROOT_CANDIDATES: list[Path] = [
 
 
 def check_node() -> None:
-    """Node.js 18+ が存在するかを確認する。"""
+    """Node.js 20+ が存在するかを確認する（FlowAgent v3.0.0+ の MCP SDK v2 要件）。"""
     node = shutil.which("node")
     if not node:
-        print("❌ Node.js が見つかりません。Node.js 18+ をインストールしてください。", file=sys.stderr)
+        print("❌ Node.js が見つかりません。Node.js 20+ をインストールしてください。", file=sys.stderr)
         sys.exit(1)
     result = subprocess.run(
         ["node", "--version"],
@@ -93,9 +93,9 @@ def check_node() -> None:
     version_str = result.stdout.strip()  # 例: "v20.11.0"
     try:
         major = int(version_str.lstrip("v").split(".")[0])
-        if major < 18:
+        if major < 20:
             print(
-                f"❌ Node.js {version_str} は古すぎます（18+ が必要）。",
+                f"❌ Node.js {version_str} は古すぎます（20+ が必要）。",
                 file=sys.stderr,
             )
             sys.exit(1)


### PR DESCRIPTION
Addresses the power-automate items tracked in #361 and #367 (upstream microsoft/power-platform-skills).

## Changes
- **v3.0.0 (478e4f4)**: MCP SDK v2 stateless protocol requires Node.js >=20. Bumped the documented prerequisite (SKILL.md, references/flow-agent-mcp.md) and the version check in scripts/setup_flow_mcp.py from 18+ to 20+.
- **v3.0.4 (0d03f0b)**: adds whoami/reconnect/doctor auth-identity diagnostics. Documented in references/flow-agent-mcp.md for troubleshooting stale az CLI identity / token cache issues.

## Reviewed, no change needed
- **code-apps** (dual pa/power-apps CLI binary, npm version bumps): already covered by #365 (no file overlap with this PR).
- **mobile-apps**: skill already exists; its pinned template predates the upstream expo-haptics feature+revert, so it never referenced haptics — no drift to fix. CLI version bump also covered by #365.
- **power-pages** bootstrap-migrate skill: classic-site only, out of scope for our Code Site skill.
- **canvas-apps**: out of scope per policy (no AI-assisted canvas app development).

## Merge order
No file overlap with #365 — can merge independently in either order.

Closes portions of #361 and #367 related to power-automate; will close both issues with a summary comment once this and #365 are merged.