### PR TITLE
standard: auth_helper を Azure スコープ対応にし azure_helper を追加

### DIFF
--- a/.github/skills/standard/SKILL.md
+++ b/.github/skills/standard/SKILL.md
@@ -45,7 +45,7 @@ triggers:
 |---|---|
 | [Power Platform 開発標準](references/power-platform-development-standard.md) | 設計原則・Phase 別手順・チェックリストをまとめた全体ガイド |
 | [インタラクティブ環境セットアップ](references/interactive-setup.md) | PAC CLI + Dataverse API で `.env` を対話的に構成する手順（**プロジェクト開始時に最初に参照**） |
-| [認証リファレンス](references/auth-patterns.md) | auth_helper.py の詳細実装・認証パターン |
+| [認証リファレンス](references/auth-patterns.md) | auth_helper.py の詳細実装・認証パターン（Dataverse / Flow / **ARM・Azure SQL・Graph・自前 API** のスコープ一覧を含む） |
 | [.env サンプル](references/.env.example) | 全フェーズ共通の `.env` テンプレート（各テーマで `.env` にコピーして値を設定） |
 | [Dataverse MCP 登録](references/dataverse-mcp-setup.md) | VS Code / Copilot から Dataverse を直接操作する MCP サーバー登録手順（upsert_skill 等） |
 | [ブラウザ自動化方針](references/browser-automation.md) | ブラウザ起動前に **AskUserQuestion で Edge プロファイルを確認**し、回答前は操作しない。ポータル操作は **VS Code 統合 Playwright ブラウザ**（`playwright-browser_navigate` / `playwright-browser_click` / `playwright-browser_type` / `playwright-browser_handle_dialog` 等）を使う。Playwright MCP サーバー・Playwright 単体ブラウザのインストール・起動は禁止 |
@@ -145,6 +145,7 @@ Phase 1（設計）の最初に必ず `architecture` を参照し、IT に詳し
 |---|---|
 | インタラクティブセットアップ | PAC CLI + Dataverse API で `.env` を対話的に構成。環境選択・パブリッシャー/ソリューション選択を AskUserQuestion で進行。詳細は [インタラクティブ環境セットアップ](references/interactive-setup.md) |
 | 共通認証 | `auth_helper.py` による 2 層キャッシュ認証（デバイスコードを繰り返さない）。詳細は [認証リファレンス](references/auth-patterns.md) |
+| Azure リソース操作 | `scripts/azure_helper.py`（ARM / Graph / Azure SQL / 自前 API）。**`az login` 前提の手順は書かない** — 対話が必要でテナント列挙のハングやセッション失効により非対話完走が崩れるため |
 | `.env` パラメータ | 全フェーズ共通の環境変数（`DATAVERSE_URL` / `TENANT_ID` / `SOLUTION_NAME` / `PUBLISHER_PREFIX` 等）の一元管理 |
 | ソリューション運用 | 全コンポーネントを同一ソリューションに含める。`SOLUTION_NAME` / `PUBLISHER_PREFIX` を全フェーズで統一 |
 

--- a/.github/skills/standard/references/auth-patterns.md
+++ b/.github/skills/standard/references/auth-patterns.md
@@ -41,6 +41,37 @@ from auth_helper import flow_api_call
 flow_api_call("GET", f"/providers/Microsoft.ProcessSimple/environments/{env_id}/flows")
 ```
 
+## Azure リソース操作も auth_helper で行う（`az login` 不要）
+
+`get_token(scope=...)` は Dataverse 以外の任意のスコープに使える。**Azure CLI / Azure PowerShell に依存した手順は書かない**。
+`az login` は対話が必要なうえ、テナント列挙でハングしたりセッション失効で手順が止まるため、非対話で完走するという前提を壊す。
+
+| 用途 | スコープ |
+|---|---|
+| Azure Resource Manager（リソース作成・設定取得） | `https://management.azure.com/.default` |
+| Azure SQL Database（Entra ID 認証） | `https://database.windows.net/.default` |
+| Microsoft Graph（アプリ登録・権限操作） | `https://graph.microsoft.com/.default` |
+| 自前 API（Azure Functions 上の MCP Server 等） | `api://{app-id}/.default` |
+
+`scripts/azure_helper.py` が ARM / Graph の薄いラッパーを提供する。
+
+```python
+from azure_helper import arm_get, arm_post, graph_get, graph_patch, get_app_settings, get_sql_access_token
+
+# Function App のアプリ設定を取得（az functionapp config appsettings list の代替）
+settings = get_app_settings(subscription_id, "rg-example", "func-example")
+
+# Azure SQL に Entra ID トークンで接続
+sql_token = get_sql_access_token()
+
+# アプリ登録を Graph で更新
+app = graph_get("/applications?$filter=appId eq '{app-id}'")
+```
+
+> **自前 API のトークンが `AADSTS650057` になる場合**は、呼び出し側の問題ではなくアプリ登録側の設定不足。
+> 対象アプリで **OAuth2 スコープを公開**し、**パブリッククライアントを事前承認**する必要がある
+> （→ [mcp-server スキル](../../mcp-server/SKILL.md)）。
+
 #### `retry_metadata()` がリトライ／スキップする条件（★ 2026-07 拡張）
 
 | 条件 | 対処 |

--- a/.github/skills/standard/scripts/azure_helper.py
+++ b/.github/skills/standard/scripts/azure_helper.py
@@ -1,0 +1,107 @@
+"""Azure ARM / Graph 操作の共通ヘルパー。
+
+``auth_helper`` のキャッシュ済み認証を使うため **Azure CLI へのログインは不要**。
+初回のみデバイスコード認証が走り、以降はサイレントで非対話に完走する。
+
+```python
+from azure_helper import arm_get, arm_post, get_app_settings, get_sql_access_token
+
+settings = get_app_settings(sub_id, "rg-example", "func-example")
+token = get_sql_access_token()
+```
+
+`az` コマンドは使わない（テナント列挙でハングする・セッション失効で手順が止まるため）。
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from auth_helper import get_token  # noqa: E402
+
+ARM_BASE = "https://management.azure.com"
+ARM_SCOPE = "https://management.azure.com/.default"
+GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+SQL_SCOPE = "https://database.windows.net/.default"
+
+DEFAULT_ARM_API_VERSION = os.getenv("ARM_API_VERSION", "2023-12-01")
+_TIMEOUT = 180
+
+
+def _headers(scope: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {get_token(scope=scope)}", "Content-Type": "application/json"}
+
+
+def _check(res: requests.Response, what: str) -> Any:
+    if res.status_code >= 400:
+        raise RuntimeError(f"{what} が失敗しました: {res.status_code} {res.text}")
+    return res.json() if res.content else None
+
+
+def _arm_url(path: str, api_version: str) -> str:
+    sep = "&" if "?" in path else "?"
+    return f"{ARM_BASE}{path}{sep}api-version={api_version}"
+
+
+def arm_get(path: str, api_version: str = DEFAULT_ARM_API_VERSION) -> Any:
+    """ARM の GET。``path`` は ``/subscriptions/...`` 形式。"""
+    return _check(requests.get(_arm_url(path, api_version), headers=_headers(ARM_SCOPE), timeout=_TIMEOUT), f"GET {path}")
+
+
+def arm_post(path: str, body: dict | None = None, api_version: str = DEFAULT_ARM_API_VERSION) -> Any:
+    """ARM の POST。"""
+    res = requests.post(_arm_url(path, api_version), headers=_headers(ARM_SCOPE), json=body or {}, timeout=_TIMEOUT)
+    return _check(res, f"POST {path}")
+
+
+def arm_put(path: str, body: dict, api_version: str = DEFAULT_ARM_API_VERSION) -> Any:
+    """ARM の PUT。"""
+    res = requests.put(_arm_url(path, api_version), headers=_headers(ARM_SCOPE), json=body, timeout=_TIMEOUT)
+    return _check(res, f"PUT {path}")
+
+
+def arm_patch(path: str, body: dict, api_version: str = DEFAULT_ARM_API_VERSION) -> Any:
+    """ARM の PATCH。"""
+    res = requests.patch(_arm_url(path, api_version), headers=_headers(ARM_SCOPE), json=body, timeout=_TIMEOUT)
+    return _check(res, f"PATCH {path}")
+
+
+def graph_get(path: str) -> Any:
+    """Microsoft Graph の GET。``path`` は ``/applications`` 形式。"""
+    return _check(requests.get(f"{GRAPH_BASE}{path}", headers=_headers(GRAPH_SCOPE), timeout=_TIMEOUT), f"GET {path}")
+
+
+def graph_patch(path: str, body: dict) -> Any:
+    """Microsoft Graph の PATCH。"""
+    res = requests.patch(f"{GRAPH_BASE}{path}", headers=_headers(GRAPH_SCOPE), json=body, timeout=_TIMEOUT)
+    return _check(res, f"PATCH {path}")
+
+
+def get_sql_access_token() -> str:
+    """Azure SQL（Entra ID 認証）用のアクセストークンを返す。"""
+    return get_token(scope=SQL_SCOPE)
+
+
+def get_api_access_token(audience: str) -> str:
+    """自前 API（MCP Server 等）用のアクセストークンを返す。
+
+    ``AADSTS650057`` になる場合はアプリ登録側でスコープ公開とクライアント事前承認が未設定。
+    """
+    return get_token(scope=f"{audience.rstrip('/')}/.default")
+
+
+def get_app_settings(subscription_id: str, resource_group: str, site_name: str) -> dict[str, str]:
+    """App Service / Function App のアプリ設定を取得する。"""
+    path = (
+        f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}"
+        f"/providers/Microsoft.Web/sites/{site_name}/config/appsettings/list"
+    )
+    return (arm_post(path) or {}).get("properties", {})


### PR DESCRIPTION
## 概要

共通認証ヘルパーを Azure リソース操作にも使えるようにし、`az login` 前提の手順を排除する。

## 変更

- `scripts/azure_helper.py` を追加（ARM / Microsoft Graph / Azure SQL / 自前 API の薄いラッパー）
- `references/auth-patterns.md` に「Azure リソース操作も auth_helper で行う（az login 不要）」節を追加（スコープ一覧付き）
- `SKILL.md` のクイックリファレンスに Azure リソース操作の行を追加

## 背景

`az login` は対話が必要で、テナント列挙でハングしたりセッション失効で手順が止まるため、スキルの原則である「非対話で完走する」を壊していた。`get_token(scope=...)` は Dataverse 以外の任意スコープに使えるため、これを正式に文書化した。

## マージ順

**この PR を先にマージする。** 後続の `mcp-server` スキル PR が `azure_helper.py` に依存する。