### PR TITLE
mcp-server: MCP Server 開発スキルを新規追加

### DIFF
--- a/.github/agents/GeekPowerCode.agent.md
+++ b/.github/agents/GeekPowerCode.agent.md
@@ -64,4 +64,5 @@ Power Platform コードファースト開発エキスパート。
 | AI チームメイト（Agent 365 / agentUser での Teams 公開） | .github/skills/ai-teammate/SKILL.md |
 | スキル作成・更新 | .github/skills/update-skills/SKILL.md |
 | Azure リファレンスアーキテクチャ（セキュア構成） | .github/skills/azure/SKILL.md |
+| MCP Server 開発（Azure Functions / Copilot Studio 連携） | .github/skills/mcp-server/SKILL.md |
 | SharePoint（Graph API・AAD アプリ登録不要） | .github/skills/sharepoint/SKILL.md |

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -113,7 +113,7 @@ triggers:                      # スキル発動条件キーワード（必須�
 
 ---
 
-## スキル一覧（20 スキル）
+## スキル一覧（21 スキル）
 
 ### architecture — アーキテクチャ・基盤
 
@@ -123,6 +123,7 @@ triggers:                      # スキル発動条件キーワード（必須�
 | [standard](standard/SKILL.md) | 共通認証・環境変数・ソリューション運用など、全スキル共通の開発基盤を提供する。 |
 | [update-skills](update-skills/SKILL.md) | スキル（SKILL.md/references/scripts）を作成・更新し、汎用化・秘匿化した上でリモートへ PR を作成・更新する。 |
 | [azure](azure/SKILL.md) | Azure のリファレンスアーキテクチャを選定し、テナントのセキュリティガバナンス（公衆アクセス禁止・共有キー禁止・MFA 必須等）に準拠した構成で構築・デプロイ・検証する。 |
+| [mcp-server](mcp-server/SKILL.md) | Copilot Studio から利用する自前 MCP Server を Azure Functions 上に構築する。JSON-RPC 最小実装・キーレス認証（受信 Entra JWT / 送信 Managed Identity）・Private Endpoint 下でのデータ投入・デプロイの実測検証までを非対話スクリプトで完結する。 |
 | [alm](alm/SKILL.md) | コードファースト資産を秘匿化・汎用化したテンプレートとして Git 管理し、pre-commit ゲート → 自律レビューゲート → 承認・デプロイ → リリース記録までを CI/CD で回す共通基盤。ai-teammate / code-apps などの各プロダクトスキルから利用する。 |
 | [sharepoint](sharepoint/SKILL.md) | AAD アプリ登録を行わずに、Microsoft Graph API 経由で SharePoint を包括的に操作する（リスト・列・リスト項目の作成、ファイルアップロード、ページ作成、M365 グループ経由のサイト作成）。 |
 

--- a/.github/skills/azure/SKILL.md
+++ b/.github/skills/azure/SKILL.md
@@ -31,6 +31,7 @@ Azure 開発を、**テナントのセキュリティガバナンスに準拠**�
 |---|---|---|
 | セキュアな Web × ストレージ | 公衆アクセス禁止ストレージのコンテンツを Web で安全配信 | [references/secure-website.md](references/secure-website.md) |
 | Microsoft Foundry エージェント | Web 組み込みエージェント / 知識グラウンディング(Work IQ・Foundry IQ・Fabric IQ) / AI Gateway ガバナンス | [references/foundry-agent.md](references/foundry-agent.md) |
+| MCP Server（Azure Functions） | 社内データを Copilot Studio エージェントへ公開する自前 MCP Server | [mcp-server スキル](../mcp-server/SKILL.md) |
 
 > 新しいリファレンスは `references/<topic>.md` として追加し、この表と参考リンクに1行足す。
 

--- a/.github/skills/copilot-studio-v2/SKILL.md
+++ b/.github/skills/copilot-studio-v2/SKILL.md
@@ -177,6 +177,9 @@ MCP サーバー（Dataverse MCP / Work IQ 等）のツール追加は、**Copil
 挙動が多く、API 経由での自動化は事故りやすい。そのため本スキルでは MCP ツール追加を
 **スクリプト化しない**。詳細な手動手順は [MCP サーバーの追加](references/mcp-servers.md) を参照。
 
+> **自前の MCP Server を作る場合**（社内 DB・ファイル共有・業務 API をエージェントに繋ぐ）は
+> [mcp-server スキル](../mcp-server/SKILL.md) で構築してから、ここでツールとして追加する。
+
 ## 必須要件・落とし穴（実機検証済み）
 
 ### Bot 作成は cliagent テンプレートなら API で成功する

--- a/.github/skills/mcp-server/SKILL.md
+++ b/.github/skills/mcp-server/SKILL.md
@@ -161,7 +161,7 @@ python .github/skills/mcp-server/scripts/verify_mcp_server.py
 1. 投入用の管理エンドポイントを削除して再デプロイする（攻撃面を残さない）。
 
    ```powershell
-   python .github/skills/mcp-server/scripts/cleanup_admin_endpoints.py --project <path> --app <function-app-name>
+   python .github/skills/mcp-server/scripts/cleanup_admin_endpoints.py --project <path> --app <function-app-name> --confirm
    ```
 
 2. アプリ設定から `ADMIN_SEED_SECRET` を削除する。

--- a/.github/skills/mcp-server/SKILL.md
+++ b/.github/skills/mcp-server/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: mcp-server
+description: "Copilot Studio から利用する自前 MCP Server を Azure Functions 上に構築する。JSON-RPC 2.0 の最小実装、受信 Entra ID JWT 検証 / 送信 Managed Identity のキーレス認証、Private Endpoint 下でのデータ投入、Entra アプリ登録のスコープ公開と事前承認、デプロイの実測検証までを非対話スクリプトで完結させる。"
+category: architecture
+triggers:
+  - "MCP Server"
+  - "MCP サーバー 自作"
+  - "カスタム MCP"
+  - "Copilot Studio に MCP を追加"
+  - "Azure Functions で MCP"
+  - "tools/list"
+  - "tools/call"
+  - "JSON-RPC エージェント"
+  - "基幹データをエージェントに繋ぐ"
+  - "AADSTS650057"
+  - "func publish 失敗"
+  - "Entra スコープ公開"
+---
+
+# MCP Server 開発スキル
+
+Copilot Studio のエージェントから **社内の業務データ（DB・ファイル共有・業務 API）** を参照させるための
+**自前 MCP Server** を Azure Functions 上に構築する。
+
+> **役割分離**: VNet / Private Endpoint / Managed Identity といった **Azure 基盤の構成**は
+> [azure スキル](../azure/SKILL.md) に委譲する。本スキルは **MCP プロトコル層・Entra 認可・データ投入・
+> Copilot Studio 登録** を担当する。
+
+## 設計原則
+
+| 原則 | 内容 |
+|---|---|
+| **データ層は非公開、コンピュート層は公開** | SQL / Storage は Private Endpoint のみ。Function App の HTTP エンドポイントは公開する（Copilot Studio は SaaS からアウトバウンド接続するため、非公開にすると到達できない） |
+| **キーレス** | 受信 = Entra ID Bearer JWT 検証、送信 = Managed Identity。関数キー・接続文字列・共有キーを使わない |
+| **プロトコルは最小実装** | `initialize` / `tools/list` / `tools/call` の 3 メソッドのみ。SSE・セッション管理は実装しない |
+| **成否はルート実測で判定** | デプロイの終了コードや ARM のメタデータを信用せず、HTTP プローブで実際のルートを確認する |
+| **非対話で完走** | Azure 操作も `auth_helper` 経由（`az login` を手順に含めない）。→ [認証リファレンス](../standard/references/auth-patterns.md) |
+
+## サブリファレンス
+
+| リファレンス | 内容 |
+|---|---|
+| [MCP プロトコル最小実装](references/protocol.md) | JSON-RPC 2.0 の 3 メソッドとツール定義の書き方 |
+| [認証モデル](references/auth-model.md) | 受信 JWT 検証 / 送信 Managed Identity の実装 |
+| [Private 環境でのデータ投入](references/private-data-seeding.md) | Private Endpoint 下でシードするための管理エンドポイントパターン |
+| [.env サンプル](references/.env.example) | 本スキルのパラメータ |
+| [異常系・トラブルシュート](references/troubleshooting.md) | 実際に踏んだ失敗と恒久対策 |
+
+---
+
+## ワークフロー（正常系）
+
+### Step 1: ツール定義を先に確定する
+
+MCP は「エージェントがツール名と入力スキーマだけを見て呼ぶ」ため、**実装より先にツール定義を決める**。
+
+1. 接続するデータソース（Azure SQL / Azure Files / 業務 API）を列挙する。
+2. データソースごとに **1 つの MCP Server** を立てる（責務分割・障害分離のため）。
+3. ツールは **「一覧」「検索」「取得」の 3 系統** を基本形にする。エージェントは一覧で語彙を得てから検索するため、
+   `list_*` が無いと的外れな検索語で空振りする。
+4. 各ツールの `name` / `description` / `inputSchema` を確定する。→ [protocol.md](references/protocol.md)
+
+```
+例: 部品DB MCP   -> list_categories / search_parts / get_part_inquiries / search_inquiries
+例: 文書共有 MCP -> list_categories / list_documents / get_document / search_documents
+```
+
+### Step 2: Entra アプリ登録でスコープを公開し、クライアントを事前承認する
+
+MCP Server を **保護対象 API** として登録する。ここを飛ばすと、後でトークン取得が `AADSTS650057` で失敗する。
+
+```powershell
+python .github/skills/mcp-server/scripts/configure_entra_api.py
+```
+
+このスクリプトは以下を行う。
+
+1. `identifierUris` に `api://{app-id}` を設定する。
+2. OAuth2 権限スコープ（既定 `MCP.Access`）を公開する。
+3. パブリッククライアント（Azure CLI / Azure PowerShell）を **事前承認**し、同意画面なしでトークンを取得できるようにする。
+
+> **重要**: スコープ公開と事前承認を **1 回の PATCH にまとめてはいけない**。
+> 新規スコープ ID が未登録扱いになり `InvalidValue ... delegatedPermissionIds` で失敗する。
+> スクリプトは 2 段階に分割して送信している。
+
+### Step 3: Azure 基盤を構築する
+
+[azure スキル](../azure/SKILL.md) の手順で以下を構築する。本スキル固有の要件のみ以下に示す。
+
+| リソース | 本スキル固有の要件 |
+|---|---|
+| Function App | **Flex Consumption** + VNet 統合 + システム割り当て MI。HTTP は公開のまま |
+| データストア | Private Endpoint のみ（`publicNetworkAccess=Disabled`・共有キー禁止） |
+| RBAC | Function App の MI にデータ層への**データプレーン**ロールを付与 |
+| ファイル共有 | 共有の作成は**マネジメントプレーン**で行う（データプレーンのロールでは共有を作成できない） |
+
+### Step 4: MCP Server を実装する
+
+Azure Functions（Node.js 20 / TypeScript / v4 プログラミングモデル）で実装する。
+
+```
+<server-name>/
+├── local.settings.json        # ★ 必須（Step 5 参照）
+├── host.json
+├── package.json
+├── src/
+│   ├── functions/
+│   │   ├── mcp.ts             # route: mcp        認可 + JSON-RPC ディスパッチ
+│   │   └── adminSeed.ts       # route: seed-*     一時的なデータ投入用（Step 8 で削除）
+│   ├── lib/
+│   │   ├── auth.ts            # 受信 JWT 検証
+│   │   └── <datasource>.ts    # 送信 Managed Identity アクセス
+│   └── tools/
+│       └── <domain>Tools.ts   # ツール定義 + ハンドラ
+```
+
+- ハンドラは `authLevel: 'anonymous'` にし、**認可はコード側の JWT 検証で行う**（関数キーを使わない）。
+- 実装の詳細は [protocol.md](references/protocol.md) と [auth-model.md](references/auth-model.md) を参照。
+
+### Step 5: デプロイする
+
+```powershell
+python .github/skills/mcp-server/scripts/deploy_mcp_function.py --project <path> --app <function-app-name>
+```
+
+このスクリプトは **デプロイ前チェック → ビルド → publish → ルート実測検証** を通しで行う。手作業で `func` を叩かない。
+
+事前チェックの内容（いずれも実際に失敗した事象への恒久対策）:
+
+| チェック | 理由 |
+|---|---|
+| `local.settings.json` の存在と `FUNCTIONS_WORKER_RUNTIME` | 無いと `Worker runtime cannot be 'None'` で publish が失敗する。このファイルは `.gitignore` 対象のため clone 直後は存在しない |
+| `func` コマンドの実行可否 | npm グローバルインストールで zip が未展開のまま残ることがある。失敗時は自動で展開して復旧する |
+| ビルド出力（`dist/`）の存在 | 空パッケージのままデプロイされ、ルートが 404 になるのを防ぐ |
+| publish 後のルート実測 | `func publish` は成功しても終了コード 1 と "appears to be unhealthy" を返すことがある。**終了コードで判定しない** |
+
+### Step 6: データを投入する
+
+データ層が Private Endpoint 内にあるため、**ローカル PC からは接続できない**。
+VNet 統合された Function App 内の一時的な管理エンドポイント経由で投入する。
+
+```powershell
+python .github/skills/mcp-server/scripts/seed_mcp_data.py
+```
+
+- 管理エンドポイントは **共有シークレット（`ADMIN_SEED_SECRET`）** で保護し、アプリ設定に置く。
+- DB のスキーマ作成・MI へのロール付与は Entra 管理者権限が要るため、**実行者のアクセストークンを渡して**実行する。
+- 詳細は [private-data-seeding.md](references/private-data-seeding.md)。
+
+### Step 7: エンドツーエンドで検証する
+
+```powershell
+python .github/skills/mcp-server/scripts/verify_mcp_server.py
+```
+
+`api://{app-id}/.default` のトークンを取得し、`tools/list` でツール一覧、`tools/call` で**実データ**が返ることを確認する。
+ツール一覧が返るだけでは不十分で、**必ず 1 つ以上のツールを実行して中身を見る**。
+
+### Step 8: 管理エンドポイントを削除して Copilot Studio に登録する
+
+1. 投入用の管理エンドポイントを削除して再デプロイする（攻撃面を残さない）。
+
+   ```powershell
+   python .github/skills/mcp-server/scripts/cleanup_admin_endpoints.py --project <path> --app <function-app-name>
+   ```
+
+2. アプリ設定から `ADMIN_SEED_SECRET` を削除する。
+3. [copilot-studio-v2 スキル](../copilot-studio-v2/SKILL.md) の手順で、エージェントに MCP サーバーをツールとして追加する。
+   複数の MCP Server を 1 エージェントに束ねる場合は、エージェントの指示文に
+   **「どの質問でどのサーバーを使うか」** を明記しないと選択を誤る。
+
+---
+
+## 検証チェックリスト
+
+- [ ] ツール定義に `list_*` 系があり、エージェントが語彙を獲得できる
+- [ ] Entra アプリ登録でスコープを公開し、クライアントを事前承認した（Step 2）
+- [ ] Function App の HTTP は公開、データ層は Private Endpoint のみ
+- [ ] 関数キー・接続文字列・共有キーを一切使っていない
+- [ ] `local.settings.json` が存在し `FUNCTIONS_WORKER_RUNTIME` が設定されている
+- [ ] デプロイ成否を **終了コードではなくルートの HTTP 実測**で判定した
+- [ ] `tools/call` で実データが返ることを確認した
+- [ ] 管理エンドポイントを削除し、`ADMIN_SEED_SECRET` をアプリ設定から消した
+- [ ] スクリプトが `auth_helper` 経由で非対話に完走する（`az login` を要求しない）
+
+## 参考リンク
+
+- [Azure リファレンスアーキテクチャ](../azure/SKILL.md)
+- [共通認証（auth_helper / azure_helper）](../standard/references/auth-patterns.md)
+- [Copilot Studio v2](../copilot-studio-v2/SKILL.md)
+- [異常系・トラブルシュート](references/troubleshooting.md)

--- a/.github/skills/mcp-server/references/.env.example
+++ b/.github/skills/mcp-server/references/.env.example
@@ -1,0 +1,21 @@
+# === Azure 基盤 ===
+AZURE_SUBSCRIPTION_ID={your-subscription-id}
+AZURE_RESOURCE_GROUP=rg-example-mcp
+AZURE_LOCATION=japaneast
+
+# === MCP Server（Function App）===
+# カンマ区切りで複数指定できる。Step 5/6/7 のスクリプトが順に処理する
+MCP_FUNCTION_APPS=func-example-db-mcp,func-example-files-mcp
+
+# === Entra アプリ登録（MCP Server を保護する API）===
+MCP_API_APP_ID={your-api-app-id}
+MCP_API_AUDIENCE=api://{your-api-app-id}
+MCP_API_SCOPE_VALUE=MCP.Access
+ENTRA_TENANT_ID={your-tenant-id}
+
+# 事前承認するパブリッククライアント（既定: Azure CLI / Azure PowerShell）
+# 変更が不要なら未設定でよい
+MCP_PREAUTH_CLIENT_IDS=
+
+# === データ投入（Step 6 で使用し、Step 8 で削除する）===
+ADMIN_SEED_SECRET={generate-a-random-secret}

--- a/.github/skills/mcp-server/references/auth-model.md
+++ b/.github/skills/mcp-server/references/auth-model.md
@@ -1,0 +1,132 @@
+# 認証モデル（キーレス）
+
+MCP Server は **受信・送信の両方でシークレットを持たない**。
+
+```
+Copilot Studio ──(Entra ID Bearer JWT)──▶ Function App ──(Managed Identity)──▶ Azure SQL / Azure Files
+                    受信: JWT 検証                        送信: トークン取得
+```
+
+| 方向 | 方式 | 使わないもの |
+|---|---|---|
+| 受信 | Entra ID が発行した JWT を JWKS で署名検証 | 関数キー・API キー |
+| 送信 | `DefaultAzureCredential`（システム割り当て MI） | 接続文字列・ストレージ共有キー |
+
+---
+
+## 受信: Entra ID JWT の検証
+
+```typescript
+// src/lib/auth.ts
+import jwt, { JwtHeader, SigningKeyCallback } from 'jsonwebtoken';
+import jwksClient from 'jwks-rsa';
+
+const TENANT_ID = process.env.ENTRA_TENANT_ID!;
+const AUDIENCE = process.env.MCP_API_AUDIENCE!; // api://{app-id}
+
+const client = jwksClient({
+  jwksUri: `https://login.microsoftonline.com/${TENANT_ID}/discovery/v2.0/keys`,
+  cache: true,
+  cacheMaxAge: 10 * 60 * 1000,
+});
+
+function getKey(header: JwtHeader, cb: SigningKeyCallback) {
+  client.getSigningKey(header.kid!, (err, key) => cb(err, key?.getPublicKey()));
+}
+
+export async function verifyToken(authorization: string | null): Promise<{ ok: boolean; reason?: string }> {
+  if (!authorization?.startsWith('Bearer ')) {
+    return { ok: false, reason: 'missing bearer token' };
+  }
+  const token = authorization.slice('Bearer '.length);
+
+  return new Promise((resolve) => {
+    jwt.verify(
+      token,
+      getKey,
+      {
+        audience: [AUDIENCE, AUDIENCE.replace(/^api:\/\//, '')], // aud は api:// 付き/無しの両方があり得る
+        issuer: [
+          `https://login.microsoftonline.com/${TENANT_ID}/v2.0`,
+          `https://sts.windows.net/${TENANT_ID}/`,
+        ],
+        algorithms: ['RS256'],
+      },
+      (err) => resolve(err ? { ok: false, reason: err.message } : { ok: true }),
+    );
+  });
+}
+```
+
+### 押さえるポイント
+
+- **`audience` は 2 パターン許容する**。トークンの `aud` は `api://{app-id}` の場合と `{app-id}` の場合がある。
+- **`issuer` も v1.0 / v2.0 の両方**を許容する。クライアントによって発行元が異なる。
+- `algorithms: ['RS256']` を必ず指定する。省略すると `alg: none` を受け入れる脆弱性になる。
+- JWKS はキャッシュする。毎リクエストで取りに行くとコールドスタート時にタイムアウトする。
+
+---
+
+## 送信: Managed Identity
+
+### Azure SQL Database
+
+```typescript
+import { DefaultAzureCredential } from '@azure/identity';
+import sql from 'mssql';
+
+const credential = new DefaultAzureCredential();
+
+export async function getPool(): Promise<sql.ConnectionPool> {
+  const token = await credential.getToken('https://database.windows.net/.default');
+  return new sql.ConnectionPool({
+    server: process.env.SQL_SERVER!,
+    database: process.env.SQL_DATABASE!,
+    options: { encrypt: true },
+    authentication: { type: 'azure-active-directory-access-token', options: { token: token!.token } },
+  }).connect();
+}
+```
+
+MI は事前に SQL 側でユーザーとして作成し、ロールを付与しておく必要がある
+（Entra 管理者権限が必要なため、[private-data-seeding.md](private-data-seeding.md) の管理エンドポイント経由で実行する）。
+
+```sql
+CREATE USER [<function-app-name>] FROM EXTERNAL PROVIDER;
+ALTER ROLE db_datareader ADD MEMBER [<function-app-name>];
+ALTER ROLE db_datawriter ADD MEMBER [<function-app-name>];
+```
+
+### Azure Files（共有キー禁止環境）
+
+共有キーが禁止されている場合、Files は **REST API を OAuth トークンで叩く**。
+
+```typescript
+const token = await credential.getToken('https://storage.azure.com/.default');
+
+const res = await fetch(url, {
+  headers: {
+    Authorization: `Bearer ${token!.token}`,
+    'x-ms-version': '2022-11-02',
+    'x-ms-file-request-intent': 'backup', // ★ OAuth で Files を操作する場合は必須
+  },
+});
+```
+
+| 落とし穴 | 対処 |
+|---|---|
+| `x-ms-file-request-intent: backup` が無いと 403 | 全リクエストに固定で付ける |
+| データプレーンのロールでは**共有そのものを作成できない** | 共有はマネジメントプレーン（`Microsoft.Storage/.../fileServices/shares` の PUT）で先に作る |
+| `x-ms-version` が古いと OAuth 非対応 | `2022-11-02` 以降を指定する |
+
+---
+
+## クライアント側のトークン取得
+
+```python
+from azure_helper import get_api_access_token
+token = get_api_access_token(os.environ["MCP_API_AUDIENCE"])
+```
+
+`AADSTS650057: Invalid resource` が返る場合、**呼び出し側ではなくアプリ登録側の設定不足**。
+`scripts/configure_entra_api.py` でスコープ公開と事前承認を行う（SKILL.md の Step 2）。

--- a/.github/skills/mcp-server/references/private-data-seeding.md
+++ b/.github/skills/mcp-server/references/private-data-seeding.md
@@ -1,0 +1,83 @@
+# Private Endpoint 環境でのデータ投入
+
+## 問題
+
+組織ポリシーで `publicNetworkAccess=Disabled` / 共有キー禁止が強制されていると、
+**開発 PC から SQL にもストレージにも到達できない**。ローカルからのシードスクリプトは全て失敗する。
+
+```
+開発 PC ──✕── Azure SQL (Private Endpoint のみ)
+開発 PC ──✕── Storage  (Private Endpoint のみ・共有キー禁止)
+```
+
+VPN や Bastion を用意するのは重い。ポリシーの一時解除は却下される（そして戻し忘れる）。
+
+## 解決: VNet 内の一時的な管理エンドポイント
+
+**すでに VNet 統合済みの Function App 自身**にシード用の HTTP エンドポイントを置く。
+Function App はデータ層に Private Endpoint 経由で到達できるため、外部からは HTTP を叩くだけで済む。
+
+```
+開発 PC ──(HTTPS + 共有シークレット)──▶ Function App ──(MI + Private Endpoint)──▶ データ層
+```
+
+| エンドポイント | 役割 |
+|---|---|
+| `internal-db-setup` | スキーマ作成 + MI へのロール付与（**実行者のトークン**を受け取る） |
+| `internal-seed` | 業務データの投入（べき等・既存データがあればスキップ） |
+| `seed-upload` | ファイル共有へのドキュメント一括アップロード |
+
+### 保護
+
+- 共有シークレット（`ADMIN_SEED_SECRET`）をアプリ設定に置き、`x-admin-seed-secret` ヘッダーで検証する。
+- **比較は固定時間比較にする**（タイミング攻撃対策）。
+- ソースに「投入完了後はこのファイルごと削除・再デプロイすること」とコメントを残す。
+- **投入後は必ず削除する**（SKILL.md の Step 8）。アプリ設定のシークレットも消す。
+
+```typescript
+import { timingSafeEqual } from 'crypto';
+
+function isAuthorized(req: HttpRequest): boolean {
+  const expected = process.env.ADMIN_SEED_SECRET ?? '';
+  const actual = req.headers.get('x-admin-seed-secret') ?? '';
+  if (!expected || expected.length !== actual.length) return false;
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(actual));
+}
+```
+
+## SQL の MI 権限付与だけは特別扱いする
+
+`CREATE USER ... FROM EXTERNAL PROVIDER` は **Entra 管理者権限**が必要で、Function App の MI では実行できない。
+そのため、**実行者（開発者）のアクセストークンをリクエストボディで渡し**、Function App 側はそれを使って接続する。
+
+```python
+# クライアント側
+from azure_helper import get_sql_access_token
+body = {"accessToken": get_sql_access_token()}
+```
+
+```typescript
+// サーバー側（internal-db-setup）
+const pool = await new sql.ConnectionPool({
+  server, database,
+  options: { encrypt: true },
+  authentication: { type: 'azure-active-directory-access-token', options: { token: body.accessToken } },
+}).connect();
+```
+
+> トークンは**ログに出さない**。レスポンスにも含めない。返すのは `{"status":"ok","principalName":"..."}` 程度に留める。
+
+## べき等にする
+
+シードは何度でも安全に実行できるようにする。デプロイ検証のたびに再実行するため。
+
+```json
+{"status":"skipped","reason":"already seeded","itemCount":40}
+```
+
+## ファイル共有はマネジメントプレーンで先に作る
+
+`Storage File Data Privileged Contributor` などのデータプレーンロールには
+**共有（share）を作成する権限が含まれない**。共有だけは先にマネジメントプレーンで作成しておく。
+
+作成後に `seed-upload` を叩くと成功する。この順序を間違えると 404 / 403 の切り分けで時間を溶かす。

--- a/.github/skills/mcp-server/references/protocol.md
+++ b/.github/skills/mcp-server/references/protocol.md
@@ -1,0 +1,111 @@
+# MCP プロトコル最小実装
+
+Copilot Studio から呼ぶだけであれば、MCP 仕様の全体を実装する必要はない。
+**JSON-RPC 2.0 over HTTP POST** で以下 3 メソッドを返せば足りる。SSE・セッション管理・通知は実装しない。
+
+| メソッド | 役割 |
+|---|---|
+| `initialize` | プロトコルバージョンとサーバー情報を返す |
+| `tools/list` | ツール定義（`name` / `description` / `inputSchema`）の配列を返す |
+| `tools/call` | ツールを実行し、結果を `content` 配列で返す |
+
+## ディスパッチャ
+
+```typescript
+// src/functions/mcp.ts
+import { app, HttpRequest, HttpResponseInit } from '@azure/functions';
+import { verifyToken } from '../lib/auth';
+import { TOOLS, callTool } from '../tools/domainTools';
+
+const PROTOCOL_VERSION = '2024-11-05';
+
+app.http('mcp', {
+  methods: ['POST'],
+  authLevel: 'anonymous', // 認可はコード側の JWT 検証で行う（関数キーは使わない）
+  route: 'mcp',
+  handler: async (req: HttpRequest): Promise<HttpResponseInit> => {
+    const auth = await verifyToken(req.headers.get('authorization'));
+    if (!auth.ok) {
+      return { status: 401, jsonBody: { error: auth.reason } };
+    }
+
+    const body = (await req.json()) as { id?: unknown; method?: string; params?: any };
+    const id = body.id ?? null;
+
+    const reply = (result: unknown): HttpResponseInit => ({
+      status: 200,
+      jsonBody: { jsonrpc: '2.0', id, result },
+    });
+
+    switch (body.method) {
+      case 'initialize':
+        return reply({
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: { name: 'example-mcp', version: '1.0.0' },
+        });
+
+      case 'tools/list':
+        return reply({ tools: TOOLS });
+
+      case 'tools/call': {
+        const text = await callTool(body.params?.name, body.params?.arguments ?? {});
+        return reply({ content: [{ type: 'text', text }] });
+      }
+
+      default:
+        return {
+          status: 200,
+          jsonBody: { jsonrpc: '2.0', id, error: { code: -32601, message: 'Method not found' } },
+        };
+    }
+  },
+});
+```
+
+> エラーもステータス 200 + JSON-RPC `error` オブジェクトで返す。HTTP のエラーコードで返すと
+> クライアント側が JSON-RPC として解釈せず、原因が追いにくくなる。
+
+## ツール定義
+
+```typescript
+// src/tools/domainTools.ts
+export const TOOLS = [
+  {
+    name: 'list_categories',
+    description: 'データのカテゴリ一覧を返す。検索前に必ず呼び、利用可能な語彙を把握すること。',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'search_items',
+    description: 'キーワードで項目を検索する。カテゴリで絞り込める。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        keyword: { type: 'string', description: '検索キーワード' },
+        category: { type: 'string', description: 'list_categories が返したカテゴリ名' },
+        top: { type: 'number', description: '最大取得件数（既定 20）' },
+      },
+      required: ['keyword'],
+    },
+  },
+] as const;
+```
+
+### 設計のコツ
+
+- **`list_*` を必ず用意する**。エージェントは語彙を知らないため、一覧が無いと的外れなキーワードで空振りする。
+- `description` は **エージェント向けの指示文**として書く。「検索前に必ず呼ぶこと」のような使用順序も書いてよい。
+- 戻り値は **人が読めるテキスト**にする（Markdown 表や箇条書き）。生 JSON を返すとエージェントの要約精度が落ちる。
+- 返す件数は上限を設ける。大量に返すとコンテキストを食い潰し、回答が途中で切れる。
+
+## 動作確認
+
+```powershell
+# 認可が効いていること（トークン無しは 401）
+curl.exe -s -w "`nSTATUS:%{http_code}" -X POST "https://<app>.azurewebsites.net/api/mcp" `
+  -H "Content-Type: application/json" -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}'
+```
+
+`401` が返れば **ルートは存在し認可も動いている**。`404` ならデプロイされていない。
+この 401 / 404 の違いが、デプロイ成否を判定する最も確実なシグナルになる。

--- a/.github/skills/mcp-server/references/troubleshooting.md
+++ b/.github/skills/mcp-server/references/troubleshooting.md
@@ -1,0 +1,138 @@
+# 異常系・トラブルシュート
+
+すべて実案件で実際に踏んだ事象。**恒久対策は `scripts/` に事前チェックとして組み込み済み**なので、
+正常系のワークフローどおりに進めれば再発しない。ここは原因を理解したいときに読む。
+
+---
+
+## デプロイ
+
+### `func publish` が「Worker runtime cannot be 'None'」「Can't determine project language」で失敗する
+
+**原因**: プロジェクト直下に `local.settings.json` が無い。`func` はこのファイルからワーカーランタイムを判定する。
+このファイルは `.gitignore` 対象なので、**clone 直後や新規作成直後は必ず存在しない**。
+
+**対処**: 以下を作成する。`deploy_mcp_function.py` が存在確認し、無ければ自動生成する。
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": { "FUNCTIONS_WORKER_RUNTIME": "node", "AzureWebJobsStorage": "" }
+}
+```
+
+### `func` コマンドが見つからない（npm でグローバルインストール済みなのに）
+
+**原因**: `azure-functions-core-tools` の postinstall が zip を展開しないまま終わることがある。
+`node_modules/azure-functions-core-tools/bin/` に `Azure.Functions.Cli.*.zip` だけが残る。
+
+**対処**: 手動で展開する。`deploy_mcp_function.py` が `func --version` に失敗したら自動で展開して復旧する。
+
+### publish が終了コード 1 で "Deployment was successful but the app appears to be unhealthy"
+
+**原因**: Flex Consumption のヘルスチェックが起動直後のコールドスタートを拾って誤判定している。
+**デプロイ自体は成功している**。
+
+**対処**: **終了コードで成否を判定しない**。ルートに HTTP プローブして判定する。
+
+| 応答 | 意味 |
+|---|---|
+| `401` | ルートは存在し、認可も動いている → **成功** |
+| `404` | ルートが存在しない → デプロイされていない |
+
+### ルートが 404 のまま。ARM 上は関数が存在することになっている
+
+**原因**: `Microsoft.Web/sites/functions` のメタデータは**古いまま残る**ことがある。
+過去のデプロイの残骸が表示され、実際に動いているパッケージの内容とは一致しない。
+
+**対処**: ARM のメタデータを信用しない。**HTTP プローブを唯一の真実**として扱う。
+
+### publish がハングしたように見えて進捗が分からない
+
+**原因**: PowerShell で `| Select-Object -Last N` を挟むと、コマンドの全出力がバッファされて完了まで何も表示されない。
+
+**対処**: ログをファイルにリダイレクトし、別途 tail する。
+
+```powershell
+func azure functionapp publish <app> *> "$env:TEMP\publish.log"
+Get-Content "$env:TEMP\publish.log" -Tail 30
+```
+
+---
+
+## 認証・認可
+
+### トークン取得が `AADSTS650057: Invalid resource ... List of valid resources from app registration: .`
+
+**原因**: 末尾の一覧が空になっているとおり、**アプリ登録がスコープを 1 つも公開していない**。
+加えて、公開してもクライアントが事前承認されていなければ同意が必要になり、非対話では取れない。
+
+**対処**: `scripts/configure_entra_api.py` を実行する（SKILL.md の Step 2）。
+
+### Graph が `InvalidValue: Property api.preAuthorizedApplications.delegatedPermissionIds has a Permission Id that cannot be found in the AppPermissions sets.`
+
+**原因**: スコープの新規追加と、そのスコープ ID を参照する事前承認を**同一 PATCH** で送っている。
+Graph は同一トランザクション内の新規スコープ ID を未登録として扱う。
+
+**対処**: PATCH を 2 段階に分ける。
+
+1. `identifierUris` + `oauth2PermissionScopes` を PATCH
+2. その後に `preAuthorizedApplications` を PATCH
+
+`configure_entra_api.py` は分割済み。
+
+### JWT 検証が `jwt audience invalid` で失敗する
+
+**原因**: トークンの `aud` はクライアントによって `api://{app-id}` の場合と `{app-id}` の場合がある。
+`iss` も v1.0（`sts.windows.net`）と v2.0（`login.microsoftonline.com/.../v2.0`）が混在する。
+
+**対処**: 両形式を配列で許容する。→ [auth-model.md](auth-model.md)
+
+### `az login --use-device-code` が「Retrieving tenants and subscriptions」でハングする
+
+**原因**: 全テナントを列挙しようとして応答が返らない。
+
+**対処**: そもそも **`az` を手順に含めない**。Azure 操作は `azure_helper.py`（`auth_helper` 経由）で行う。
+どうしても `az` が必要な場合のみ `--tenant <tenant-id>` を明示して列挙をスキップする。
+
+---
+
+## データアクセス
+
+### Azure Files への REST 呼び出しが 403 になる
+
+**原因**: OAuth トークンで Files を操作する場合、`x-ms-file-request-intent: backup` ヘッダーが必須。
+
+**対処**: 全リクエストに固定で付与する。
+
+### 共有（share）の作成が権限エラーになる
+
+**原因**: `Storage File Data Privileged Contributor` などのデータプレーンロールには
+共有作成の権限（`Microsoft.Storage/storageAccounts/fileServices/shares/write`）が含まれない。
+
+**対処**: 共有はマネジメントプレーンで先に作成する。→ [private-data-seeding.md](private-data-seeding.md)
+
+### ローカルから SQL / Storage に接続できない
+
+**原因**: 組織ポリシーで `publicNetworkAccess=Disabled` が強制されている。仕様どおりの挙動。
+
+**対処**: ポリシーと戦わない。VNet 統合済み Function App 内の一時的な管理エンドポイント経由で投入する。
+→ [private-data-seeding.md](private-data-seeding.md)
+
+---
+
+## Copilot Studio 連携
+
+### エージェントが MCP サーバーを呼ばない / 誤ったサーバーを選ぶ
+
+**原因**: 複数の MCP Server を 1 エージェントに束ねると、どちらを使うべきか判断できない。
+
+**対処**: エージェントの指示文に「どの質問でどのサーバーを使うか」を明記する。
+また各ツールの `description` に用途と使用順序（例: 「検索前に `list_categories` を呼ぶ」）を書く。
+
+### Copilot Studio から Function App に到達できない
+
+**原因**: セキュリティを優先して Function App の `publicNetworkAccess` まで無効化した。
+
+**対処**: **コンピュート層の HTTP は公開のままにする**。Copilot Studio は SaaS からアウトバウンド接続するため、
+非公開にすると到達できない。保護は Entra ID の JWT 検証で担保する。データ層のみ Private Endpoint にする。

--- a/.github/skills/mcp-server/scripts/cleanup_admin_endpoints.py
+++ b/.github/skills/mcp-server/scripts/cleanup_admin_endpoints.py
@@ -1,0 +1,63 @@
+"""データ投入用の管理エンドポイントを削除し、再デプロイして到達不能になったことを確認する。
+
+投入が終わったら必ず実行する。攻撃面を残さないための後始末。
+
+使い方:
+    python .github/skills/mcp-server/scripts/cleanup_admin_endpoints.py --project mcp-servers/example-mcp --app func-example-mcp
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from deploy_mcp_function import build, ensure_func_cli, ensure_local_settings, publish  # noqa: E402
+
+ADMIN_FILE_HINTS = ("adminseed", "adminsetup", "admindbsetup", "seedupload")
+
+
+def find_admin_sources(project: Path) -> list[Path]:
+    functions_dir = project / "src" / "functions"
+    if not functions_dir.exists():
+        return []
+    return [p for p in functions_dir.glob("*.ts") if p.stem.lower().replace("_", "") in ADMIN_FILE_HINTS]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--app", required=True)
+    parser.add_argument("--route", action="append", default=None, help="削除されたことを確認するルート")
+    args = parser.parse_args()
+
+    project = Path(args.project).resolve()
+    targets = find_admin_sources(project)
+    if not targets:
+        print("削除対象の管理エンドポイントが見つかりませんでした（削除済みの可能性）")
+    for path in targets:
+        print(f"[remove] {path.relative_to(project)}")
+        path.unlink()
+
+    ensure_local_settings(project)
+    func = ensure_func_cli()
+    build(project)
+    publish(func, project, args.app)
+
+    ok = True
+    for route in args.route or []:
+        url = f"https://{args.app}.azurewebsites.net/api/{route}"
+        status = requests.post(url, timeout=60).status_code
+        print(f"[verify] {route}: {status} {'OK（削除済み）' if status == 404 else 'NG（まだ到達できる）'}")
+        ok = ok and status == 404
+
+    print("\nアプリ設定から ADMIN_SEED_SECRET を削除してください（本スクリプトは設定を変更しません）")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/mcp-server/scripts/cleanup_admin_endpoints.py
+++ b/.github/skills/mcp-server/scripts/cleanup_admin_endpoints.py
@@ -3,7 +3,7 @@
 投入が終わったら必ず実行する。攻撃面を残さないための後始末。
 
 使い方:
-    python .github/skills/mcp-server/scripts/cleanup_admin_endpoints.py --project mcp-servers/example-mcp --app func-example-mcp
+    python .github/skills/mcp-server/scripts/cleanup_admin_endpoints.py --project mcp-servers/example-mcp --app func-example-mcp --confirm
 """
 
 from __future__ import annotations
@@ -12,11 +12,11 @@ import argparse
 import sys
 from pathlib import Path
 
-import requests
-
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
 
 from deploy_mcp_function import build, ensure_func_cli, ensure_local_settings, publish  # noqa: E402
+from azure_helper import function_url, http_post  # noqa: E402
 
 ADMIN_FILE_HINTS = ("adminseed", "adminsetup", "admindbsetup", "seedupload")
 
@@ -33,10 +33,20 @@ def main() -> int:
     parser.add_argument("--project", required=True)
     parser.add_argument("--app", required=True)
     parser.add_argument("--route", action="append", default=None, help="削除されたことを確認するルート")
+    parser.add_argument("--confirm", action="store_true", help="管理エンドポイントを削除して再デプロイする")
     args = parser.parse_args()
 
     project = Path(args.project).resolve()
     targets = find_admin_sources(project)
+    if not args.confirm:
+        if targets:
+            print("削除予定の管理エンドポイント:")
+            for path in targets:
+                print(f"  {path.relative_to(project)}")
+        else:
+            print("削除対象の管理エンドポイントは見つかりませんでした")
+        print("実行するには内容を確認して --confirm を追加してください")
+        return 0
     if not targets:
         print("削除対象の管理エンドポイントが見つかりませんでした（削除済みの可能性）")
     for path in targets:
@@ -50,8 +60,12 @@ def main() -> int:
 
     ok = True
     for route in args.route or []:
-        url = f"https://{args.app}.azurewebsites.net/api/{route}"
-        status = requests.post(url, timeout=60).status_code
+        try:
+            status, _ = http_post(function_url(args.app, route), timeout=60)
+        except (RuntimeError, ValueError) as exc:
+            print(f"[verify] {route}: 接続失敗 {exc}")
+            ok = False
+            continue
         print(f"[verify] {route}: {status} {'OK（削除済み）' if status == 404 else 'NG（まだ到達できる）'}")
         ok = ok and status == 404
 

--- a/.github/skills/mcp-server/scripts/configure_entra_api.py
+++ b/.github/skills/mcp-server/scripts/configure_entra_api.py
@@ -1,0 +1,88 @@
+"""MCP Server 用の Entra アプリ登録に API スコープを公開し、クライアントを事前承認する。
+
+auth_helper のキャッシュ認証で Microsoft Graph を呼ぶため Azure CLI ログインは不要。
+
+使い方:
+    python .github/skills/mcp-server/scripts/configure_entra_api.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
+
+from azure_helper import graph_get, graph_patch  # noqa: E402
+
+# auth_helper / Azure CLI / Azure PowerShell が使う Microsoft 発行のパブリッククライアント
+DEFAULT_PREAUTH_CLIENT_IDS = [
+    "04b07795-8ddb-461a-bbee-02f9e1bf7b46",  # Microsoft Azure CLI
+    "1950a258-227b-4e31-a9cf-717495945fc2",  # Microsoft Azure PowerShell
+]
+
+
+def _new_scope(scope_value: str) -> dict:
+    label = "MCP サーバーへのアクセス"
+    description = "MCP サーバーのツールを呼び出す権限"
+    return {
+        "id": str(uuid.uuid4()),
+        "value": scope_value,
+        "type": "User",
+        "isEnabled": True,
+        "adminConsentDisplayName": label,
+        "adminConsentDescription": description,
+        "userConsentDisplayName": label,
+        "userConsentDescription": description,
+    }
+
+
+def main() -> int:
+    app_id = os.getenv("MCP_API_APP_ID")
+    if not app_id:
+        print("MCP_API_APP_ID を .env に設定してください")
+        return 1
+    scope_value = os.getenv("MCP_API_SCOPE_VALUE", "MCP.Access")
+    preauth = [c.strip() for c in os.getenv("MCP_PREAUTH_CLIENT_IDS", "").split(",") if c.strip()]
+    preauth = preauth or DEFAULT_PREAUTH_CLIENT_IDS
+
+    app = graph_get(f"/applications(appId='{app_id}')")
+    object_id = app["id"]
+    api = app.get("api") or {}
+    scopes = api.get("oauth2PermissionScopes") or []
+
+    scope = next((s for s in scopes if s["value"] == scope_value), None)
+    if scope is None:
+        scope = _new_scope(scope_value)
+        scopes.append(scope)
+        print(f"スコープ {scope_value} を追加します")
+    else:
+        print(f"スコープ {scope_value} は既に存在します")
+
+    # スコープ登録と事前承認を同一 PATCH で送ると新規スコープ ID が未登録扱いになるため分割する
+    graph_patch(
+        f"/applications/{object_id}",
+        {
+            "identifierUris": app.get("identifierUris") or [f"api://{app_id}"],
+            "api": {**api, "oauth2PermissionScopes": scopes},
+        },
+    )
+    graph_patch(
+        f"/applications/{object_id}",
+        {
+            "api": {
+                "preAuthorizedApplications": [
+                    {"appId": cid, "delegatedPermissionIds": [scope["id"]]} for cid in preauth
+                ]
+            }
+        },
+    )
+    print(f"アプリ登録を更新しました（スコープ公開 + クライアント {len(preauth)} 件の事前承認）")
+    print(f"audience: api://{app_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/mcp-server/scripts/configure_entra_api.py
+++ b/.github/skills/mcp-server/scripts/configure_entra_api.py
@@ -8,6 +8,7 @@ auth_helper のキャッシュ認証で Microsoft Graph を呼ぶため Azure CL
 
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 import uuid
@@ -40,6 +41,9 @@ def _new_scope(scope_value: str) -> dict:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+
     app_id = os.getenv("MCP_API_APP_ID")
     if not app_id:
         print("MCP_API_APP_ID を .env に設定してください")

--- a/.github/skills/mcp-server/scripts/deploy_mcp_function.py
+++ b/.github/skills/mcp-server/scripts/deploy_mcp_function.py
@@ -1,0 +1,142 @@
+"""MCP Server（Azure Functions）を事前チェック付きでデプロイし、ルートを実測検証する。
+
+`func azure functionapp publish` は成功しても終了コード 1 と "appears to be unhealthy" を
+返すことがあるため、**成否は HTTP プローブで判定する**。
+
+使い方:
+    python .github/skills/mcp-server/scripts/deploy_mcp_function.py --project mcp-servers/example-mcp --app func-example-mcp
+    python .github/skills/mcp-server/scripts/deploy_mcp_function.py --project ... --app ... --route mcp --route seed-upload
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+import requests
+
+LOCAL_SETTINGS = {
+    "IsEncrypted": False,
+    "Values": {"FUNCTIONS_WORKER_RUNTIME": "node", "AzureWebJobsStorage": ""},
+}
+
+
+def ensure_local_settings(project: Path) -> None:
+    """`local.settings.json` を保証する。
+
+    これが無いと publish が "Worker runtime cannot be 'None'" で失敗する。
+    .gitignore 対象のファイルなので clone 直後は必ず存在しない。
+    """
+    path = project / "local.settings.json"
+    if path.exists():
+        values = json.loads(path.read_text(encoding="utf-8")).get("Values", {})
+        if values.get("FUNCTIONS_WORKER_RUNTIME"):
+            print("[check] local.settings.json OK")
+            return
+        print("[fix] local.settings.json に FUNCTIONS_WORKER_RUNTIME が無いため補完します")
+    else:
+        print("[fix] local.settings.json が無いため生成します")
+    path.write_text(json.dumps(LOCAL_SETTINGS, indent=2), encoding="utf-8")
+
+
+def ensure_func_cli() -> str:
+    """`func` を実行可能にする。npm の zip 未展開を検知したら展開して復旧する。"""
+    func = shutil.which("func")
+    if func and subprocess.run([func, "--version"], capture_output=True).returncode == 0:
+        print("[check] func CLI OK")
+        return func
+
+    npm_root = subprocess.run(["npm", "root", "-g"], capture_output=True, text=True, shell=os.name == "nt")
+    bin_dir = Path(npm_root.stdout.strip()) / "azure-functions-core-tools" / "bin"
+    archives = list(bin_dir.glob("Azure.Functions.Cli.*.zip")) if bin_dir.exists() else []
+    if not archives:
+        raise SystemExit("func CLI が見つかりません。`npm i -g azure-functions-core-tools@4` を実行してください")
+
+    print(f"[fix] core tools の zip が未展開のため展開します: {archives[0].name}")
+    with zipfile.ZipFile(archives[0]) as zf:
+        zf.extractall(bin_dir)
+    func = shutil.which("func") or str(bin_dir / "func.exe")
+    if subprocess.run([func, "--version"], capture_output=True).returncode != 0:
+        raise SystemExit("func CLI の復旧に失敗しました")
+    return func
+
+
+def build(project: Path) -> None:
+    for args in (["npm", "install"], ["npm", "run", "build"]):
+        res = subprocess.run(args, cwd=project, shell=os.name == "nt")
+        if res.returncode != 0:
+            raise SystemExit(f"{' '.join(args)} が失敗しました")
+    dist = project / "dist"
+    if not dist.exists() or not any(dist.rglob("*.js")):
+        raise SystemExit("ビルド出力 dist/ が空です。空パッケージのデプロイを中止しました")
+    print("[check] ビルド出力 OK")
+
+
+def publish(func: str, project: Path, app: str) -> None:
+    # 出力をパイプで受けるとバッファされて進捗が見えなくなるため、ログファイルへ流す
+    log = Path(tempfile.gettempdir()) / f"publish-{app}.log"
+    print(f"[publish] {app} (log: {log})")
+    with log.open("w", encoding="utf-8", errors="replace") as fp:
+        subprocess.run(
+            [func, "azure", "functionapp", "publish", app, "--typescript"],
+            cwd=project,
+            stdout=fp,
+            stderr=subprocess.STDOUT,
+        )
+    # 終了コードは "appears to be unhealthy" で 1 になり得るため成否判定に使わない
+    print("".join(log.read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)[-15:]))
+
+
+def verify_routes(app: str, routes: list[str]) -> bool:
+    """ルートを HTTP プローブする。401 = 存在して認可が動いている、404 = 未デプロイ。"""
+    ok = True
+    for route in routes:
+        url = f"https://{app}.azurewebsites.net/api/{route}"
+        try:
+            status = requests.post(url, json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}, timeout=60).status_code
+        except requests.RequestException as exc:
+            print(f"[verify] {route}: 接続失敗 {exc}")
+            ok = False
+            continue
+        if status == 404:
+            print(f"[verify] {route}: 404 未デプロイ")
+            ok = False
+        else:
+            print(f"[verify] {route}: {status} OK（ルート存在）")
+    return ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", required=True, help="Functions プロジェクトのパス")
+    parser.add_argument("--app", required=True, help="Function App 名")
+    parser.add_argument("--route", action="append", default=None, help="検証するルート（既定: mcp）")
+    parser.add_argument("--skip-build", action="store_true")
+    args = parser.parse_args()
+
+    project = Path(args.project).resolve()
+    if not (project / "package.json").exists():
+        raise SystemExit(f"Functions プロジェクトが見つかりません: {project}")
+
+    ensure_local_settings(project)
+    func = ensure_func_cli()
+    if not args.skip_build:
+        build(project)
+    publish(func, project, args.app)
+
+    if not verify_routes(args.app, args.route or ["mcp"]):
+        print("デプロイ後のルート検証に失敗しました")
+        return 1
+    print("デプロイ完了")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/mcp-server/scripts/deploy_mcp_function.py
+++ b/.github/skills/mcp-server/scripts/deploy_mcp_function.py
@@ -20,7 +20,9 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-import requests
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
+
+from azure_helper import function_url, http_post  # noqa: E402
 
 LOCAL_SETTINGS = {
     "IsEncrypted": False,
@@ -98,10 +100,13 @@ def verify_routes(app: str, routes: list[str]) -> bool:
     """ルートを HTTP プローブする。401 = 存在して認可が動いている、404 = 未デプロイ。"""
     ok = True
     for route in routes:
-        url = f"https://{app}.azurewebsites.net/api/{route}"
         try:
-            status = requests.post(url, json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}, timeout=60).status_code
-        except requests.RequestException as exc:
+            status, _ = http_post(
+                function_url(app, route),
+                {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+                timeout=60,
+            )
+        except (RuntimeError, ValueError) as exc:
             print(f"[verify] {route}: 接続失敗 {exc}")
             ok = False
             continue

--- a/.github/skills/mcp-server/scripts/seed_mcp_data.py
+++ b/.github/skills/mcp-server/scripts/seed_mcp_data.py
@@ -19,11 +19,9 @@ import os
 import sys
 from pathlib import Path
 
-import requests
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
 
-from azure_helper import get_app_settings, get_sql_access_token  # noqa: E402
+from azure_helper import function_url, get_app_settings, get_sql_access_token, http_post  # noqa: E402
 
 
 def resolve_secret(app: str) -> str:
@@ -51,11 +49,19 @@ def main() -> int:
         # CREATE USER ... FROM EXTERNAL PROVIDER は Entra 管理者権限が必要で MI では実行できない
         body["accessToken"] = get_sql_access_token()
 
-    url = f"https://{args.app}.azurewebsites.net/api/{args.route}"
-    res = requests.post(url, headers={"x-admin-seed-secret": resolve_secret(args.app)}, json=body, timeout=600)
-    # トークンを含むリクエストボディはログに出さない
-    print(f"{args.route} -> {res.status_code} {res.text[:500]}")
-    return 0 if res.status_code < 400 else 1
+    try:
+        status, _ = http_post(
+            function_url(args.app, args.route),
+            body,
+            headers={"x-admin-seed-secret": resolve_secret(args.app)},
+            timeout=600,
+        )
+    except (RuntimeError, ValueError, KeyError) as exc:
+        print(f"{args.route} -> 接続失敗: {exc}", file=sys.stderr)
+        return 1
+    # 応答がリクエスト内容を反射してもトークンを漏らさないよう本文は表示しない。
+    print(f"{args.route} -> {status}")
+    return 0 if status < 400 else 1
 
 
 if __name__ == "__main__":

--- a/.github/skills/mcp-server/scripts/seed_mcp_data.py
+++ b/.github/skills/mcp-server/scripts/seed_mcp_data.py
@@ -1,0 +1,62 @@
+"""Private Endpoint 環境の MCP Server へ、管理エンドポイント経由でデータを投入する。
+
+ローカルからデータ層に到達できないため、VNet 統合済み Function App の一時エンドポイントを叩く。
+認証は auth_helper のキャッシュを使うため非対話で完走する。
+
+使い方:
+    # スキーマ作成 + MI へのロール付与（実行者のトークンを渡す）
+    python .github/skills/mcp-server/scripts/seed_mcp_data.py --app func-example-db-mcp --route internal-db-setup --with-sql-token
+    # 業務データ投入
+    python .github/skills/mcp-server/scripts/seed_mcp_data.py --app func-example-db-mcp --route internal-seed
+    # ファイル共有へのアップロード
+    python .github/skills/mcp-server/scripts/seed_mcp_data.py --app func-example-files-mcp --route seed-upload
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
+
+from azure_helper import get_app_settings, get_sql_access_token  # noqa: E402
+
+
+def resolve_secret(app: str) -> str:
+    """`ADMIN_SEED_SECRET` を .env から、無ければ Function App のアプリ設定から取得する。"""
+    secret = os.getenv("ADMIN_SEED_SECRET")
+    if secret:
+        return secret
+    subscription = os.environ["AZURE_SUBSCRIPTION_ID"]
+    resource_group = os.environ["AZURE_RESOURCE_GROUP"]
+    secret = get_app_settings(subscription, resource_group, app).get("ADMIN_SEED_SECRET")
+    if not secret:
+        raise SystemExit(f"{app} のアプリ設定に ADMIN_SEED_SECRET がありません")
+    return secret
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--app", required=True, help="Function App 名")
+    parser.add_argument("--route", required=True, help="管理エンドポイントのルート")
+    parser.add_argument("--with-sql-token", action="store_true", help="Azure SQL のアクセストークンを body に含める")
+    args = parser.parse_args()
+
+    body: dict = {}
+    if args.with_sql_token:
+        # CREATE USER ... FROM EXTERNAL PROVIDER は Entra 管理者権限が必要で MI では実行できない
+        body["accessToken"] = get_sql_access_token()
+
+    url = f"https://{args.app}.azurewebsites.net/api/{args.route}"
+    res = requests.post(url, headers={"x-admin-seed-secret": resolve_secret(args.app)}, json=body, timeout=600)
+    # トークンを含むリクエストボディはログに出さない
+    print(f"{args.route} -> {res.status_code} {res.text[:500]}")
+    return 0 if res.status_code < 400 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/mcp-server/scripts/verify_mcp_server.py
+++ b/.github/skills/mcp-server/scripts/verify_mcp_server.py
@@ -1,0 +1,86 @@
+"""MCP Server をエンドツーエンドで検証する。
+
+`tools/list` でツール一覧を取得し、続けて `tools/call` を実行して**実データが返ること**まで確認する。
+ツール一覧が返るだけでは不十分（データ層への接続や権限が壊れていても一覧は返るため）。
+
+使い方:
+    python .github/skills/mcp-server/scripts/verify_mcp_server.py
+    python .github/skills/mcp-server/scripts/verify_mcp_server.py --app func-example-mcp --call list_categories
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
+
+from azure_helper import get_api_access_token  # noqa: E402
+
+
+def rpc(url: str, token: str, method: str, params: dict | None = None) -> dict:
+    res = requests.post(
+        url,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params or {}},
+        timeout=180,
+    )
+    if res.status_code != 200:
+        raise RuntimeError(f"{method} が失敗しました: {res.status_code} {res.text[:300]}")
+    payload = res.json()
+    if "error" in payload:
+        raise RuntimeError(f"{method} が JSON-RPC エラーを返しました: {payload['error']}")
+    return payload.get("result", {})
+
+
+def verify(app: str, token: str, call: str | None) -> bool:
+    url = f"https://{app}.azurewebsites.net/api/mcp"
+    print(f"\n=== {app} ===")
+    try:
+        tools = [t["name"] for t in rpc(url, token, "tools/list").get("tools", [])]
+    except RuntimeError as exc:
+        print(f"NG: {exc}")
+        return False
+    print(f"tools/list -> {tools}")
+    if not tools:
+        print("NG: ツールが 0 件です")
+        return False
+
+    target = call or next((t for t in tools if t.startswith("list_")), tools[0])
+    try:
+        content = rpc(url, token, "tools/call", {"name": target, "arguments": {}}).get("content", [])
+    except RuntimeError as exc:
+        print(f"NG: {exc}")
+        return False
+    text = "".join(c.get("text", "") for c in content).strip()
+    print(f"tools/call {target} -> {text[:400]}")
+    if not text:
+        print("NG: 実データが空です")
+        return False
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--app", action="append", help="Function App 名（未指定なら MCP_FUNCTION_APPS）")
+    parser.add_argument("--call", help="実行するツール名（既定: list_* の先頭）")
+    args = parser.parse_args()
+
+    apps = args.app or [a.strip() for a in os.getenv("MCP_FUNCTION_APPS", "").split(",") if a.strip()]
+    if not apps:
+        raise SystemExit("MCP_FUNCTION_APPS を .env に設定するか --app を指定してください")
+
+    audience = os.environ["MCP_API_AUDIENCE"]
+    token = get_api_access_token(audience)
+
+    results = [verify(app, token, args.call) for app in apps]
+    print(f"\n結果: {sum(results)}/{len(results)} 件成功")
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/mcp-server/scripts/verify_mcp_server.py
+++ b/.github/skills/mcp-server/scripts/verify_mcp_server.py
@@ -15,30 +15,29 @@ import os
 import sys
 from pathlib import Path
 
-import requests
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
 
-from azure_helper import get_api_access_token  # noqa: E402
+from azure_helper import function_url, get_api_access_token, http_post  # noqa: E402
 
 
 def rpc(url: str, token: str, method: str, params: dict | None = None) -> dict:
-    res = requests.post(
+    status, payload = http_post(
         url,
         headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
-        json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params or {}},
+        body={"jsonrpc": "2.0", "id": 1, "method": method, "params": params or {}},
         timeout=180,
     )
-    if res.status_code != 200:
-        raise RuntimeError(f"{method} が失敗しました: {res.status_code} {res.text[:300]}")
-    payload = res.json()
+    if status != 200:
+        raise RuntimeError(f"{method} が失敗しました: HTTP {status}")
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{method} が不正な JSON 応答を返しました")
     if "error" in payload:
         raise RuntimeError(f"{method} が JSON-RPC エラーを返しました: {payload['error']}")
     return payload.get("result", {})
 
 
 def verify(app: str, token: str, call: str | None) -> bool:
-    url = f"https://{app}.azurewebsites.net/api/mcp"
+    url = function_url(app, "mcp")
     print(f"\n=== {app} ===")
     try:
         tools = [t["name"] for t in rpc(url, token, "tools/list").get("tools", [])]

--- a/.github/skills/standard/scripts/azure_helper.py
+++ b/.github/skills/standard/scripts/azure_helper.py
@@ -16,6 +16,7 @@ token = get_sql_access_token()
 from __future__ import annotations
 
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -96,6 +97,40 @@ def get_api_access_token(audience: str) -> str:
     ``AADSTS650057`` になる場合はアプリ登録側でスコープ公開とクライアント事前承認が未設定。
     """
     return get_token(scope=f"{audience.rstrip('/')}/.default")
+
+
+def function_url(app: str, route: str) -> str:
+    """検証済みの Azure Functions HTTP エンドポイント URL を返す。"""
+    if not re.fullmatch(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,58}[A-Za-z0-9])?", app):
+        raise ValueError(f"Function App 名が不正です: {app}")
+    normalized_route = route.strip("/")
+    if not normalized_route or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._~/-]*", normalized_route):
+        raise ValueError(f"Function route が不正です: {route}")
+    return f"https://{app}.azurewebsites.net/api/{normalized_route}"
+
+
+def http_post(
+    url: str,
+    body: dict | None = None,
+    headers: dict[str, str] | None = None,
+    scope: str | None = None,
+    timeout: int = _TIMEOUT,
+) -> tuple[int, Any]:
+    """任意の HTTPS API を POST し、status code と解析済み応答を返す。"""
+    if not url.startswith("https://"):
+        raise ValueError("HTTP POST の送信先は HTTPS URL に限ります")
+    request_headers = {"Content-Type": "application/json", **(headers or {})}
+    if scope:
+        request_headers["Authorization"] = f"Bearer {get_token(scope=scope)}"
+    try:
+        res = requests.post(url, headers=request_headers, json=body or {}, timeout=timeout)
+    except requests.RequestException as exc:
+        raise RuntimeError(f"POST {url} への接続に失敗しました: {exc}") from exc
+    try:
+        payload: Any = res.json() if res.content else None
+    except requests.JSONDecodeError:
+        payload = res.text
+    return res.status_code, payload
 
 
 def get_app_settings(subscription_id: str, resource_group: str, site_name: str) -> dict[str, str]:

--- a/.github/skills/update-skills/scripts/validate_skill.py
+++ b/.github/skills/update-skills/scripts/validate_skill.py
@@ -65,6 +65,7 @@ ALLOWLIST = {
     "00000001-0000-0000-0001-00000000009b",  # Dataverse Default Solution（全環境固定）
     "4273edbd-ac1d-40d3-9fb2-095c621b552d",  # 標準フォームコントロール CLASSID（全環境固定）
     "04b07795-8ddb-461a-bbee-02f9e1bf7b46",  # Azure CLI の well-known パブリッククライアント ID（固定）
+    "1950a258-227b-4e31-a9cf-717495945fc2",  # Azure PowerShell の well-known パブリッククライアント ID（固定）
     "14d82eec-204b-4c2f-b7e8-296a70dab67e",  # Microsoft Graph PowerShell の well-known パブリッククライアント ID（固定）
     "5a807f24-c9de-44ee-a3a7-329e88a00ffc",  # Messaging Bot API Application の appId（全テナント共通）
     "fdcc1f02-fc51-4226-8753-f668596af7f7",  # Work IQ 第一者アプリの appId（全テナント共通）


### PR DESCRIPTION
## 概要

Copilot Studio から利用する自前 MCP Server を Azure Functions 上に構築するスキルを追加する。

## スコープ

VNet / Private Endpoint / Managed Identity といった Azure 基盤の構成は `azure` スキルに委譲し、本スキルは **MCP プロトコル層・Entra 認可・データ投入・Copilot Studio 登録** を担当する。

## 追加

- `SKILL.md`: Step 1〜8（ツール定義確定 → Entra スコープ公開 → 基盤 → 実装 → デプロイ → 投入 → 検証 → 後始末と登録）
- `references/protocol.md`: JSON-RPC 2.0 の最小実装（initialize / tools/list / tools/call）
- `references/auth-model.md`: 受信 Entra JWT 検証 / 送信 Managed Identity のキーレス構成
- `references/private-data-seeding.md`: Private Endpoint 下でのデータ投入パターン
- `references/troubleshooting.md`: 実案件で踏んだ異常系
- `scripts/`: configure_entra_api / deploy_mcp_function / seed_mcp_data / verify_mcp_server / cleanup_admin_endpoints

## 恒久的な事前チェック（再発防止）

`deploy_mcp_function.py` に、実際に踏んだ失敗への恒久対策を組み込んだ。

| チェック | 防ぐ事象 |
|---|---|
| `local.settings.json` の存在と `FUNCTIONS_WORKER_RUNTIME` | `Worker runtime cannot be None` で publish が失敗する |
| `func` の実行可否（zip 未展開なら自動展開） | npm グローバルインストール後に `func` が見つからない |
| `dist/` の存在 | 空パッケージをデプロイしてルートが 404 になる |
| publish 後のルート実測（401/404 判定） | 終了コード 1 + appears to be unhealthy の誤判定 |

## 集約ファイルの更新

- `.github/skills/README.md`: カタログに 1 行追加（20 → 21 スキル）
- `.github/agents/GeekPowerCode.agent.md`: スキル表に 1 行追加
- `.github/skills/azure/SKILL.md` / `copilot-studio-v2/SKILL.md`: 相互リンクを追加
- `.github/skills/update-skills/scripts/validate_skill.py`: Azure PowerShell の well-known パブリッククライアント ID を許可リストへ追加

## マージ順

**#373（standard）を先にマージしてから、この PR をマージする。** スクリプトが `standard/scripts/azure_helper.py` に依存する。