### PR TITLE
mcp-server: 実運用で踏んだ障害の恒久対策を追加

### DIFF
--- a/.github/skills/mcp-server/SKILL.md
+++ b/.github/skills/mcp-server/SKILL.md
@@ -95,6 +95,13 @@ python .github/skills/mcp-server/scripts/configure_entra_api.py
 | Functions 用ストレージ | 共有キー禁止のため `AzureWebJobsStorage` は使わず、`AzureWebJobsStorage__accountName` の **ID ベース接続**にする。MI に `Storage Blob Data Owner` が必要 |
 | ファイル共有 | 共有の作成は**マネジメントプレーン**で行う（データプレーンのロールでは共有を作成できない） |
 
+Function App の作成直後は `AzureWebJobsStorage` に**共有キーの接続文字列**が入る。共有キー禁止のストレージでは
+この状態でホストが起動できず、**デプロイは成功するのに全ルートが 404** になる。作成直後に必ず切り替える。
+
+```powershell
+python .github/skills/mcp-server/scripts/configure_function_storage.py --app <function-app-name> --account <storage-account>
+```
+
 ### Step 4: MCP Server を実装する
 
 Azure Functions（Node.js 20 / TypeScript / v4 プログラミングモデル）で実装する。
@@ -136,6 +143,8 @@ python .github/skills/mcp-server/scripts/deploy_mcp_function.py --project <path>
 | `func` コマンドの実行可否 | npm グローバルインストールで zip が未展開のまま残ることがある。失敗時は自動で展開して復旧する |
 | ビルド出力（`dist/`）の存在 | 空パッケージのままデプロイされ、ルートが 404 になるのを防ぐ |
 | ビルド前の `dist/` 削除 | `tsc` は `dist/` をクリーンしない。削除した関数の `.js` が残り、ルートが復活する |
+| `src/index.ts` の相対 import が全て実在すること | 解決できない import が 1 行でもあると worker が起動できず、**残すはずのルートまで含めて全滅**する |
+| `AzureWebJobsStorage` が ID ベース接続であること | 共有キー禁止のストレージに接続文字列で繋ごうとするとホストが起動しない（Step 3）|
 | publish 後のルート実測 | `func publish` は成功しても終了コード 1 と "appears to be unhealthy" を返すことがある。**終了コードで判定しない** |
 
 ルートが 404 のままなら、ホストの起動ログで原因を特定する（`0 functions loaded` なら worker の起動失敗）。
@@ -192,9 +201,12 @@ python .github/skills/mcp-server/scripts/verify_mcp_server.py
 - [ ] Function App の HTTP は公開、データ層は Private Endpoint のみ
 - [ ] 関数キー・接続文字列・共有キーを一切使っていない
 - [ ] `local.settings.json` が存在し `FUNCTIONS_WORKER_RUNTIME` が設定されている
+- [ ] `AzureWebJobsStorage__accountName` による ID ベース接続になっている（接続文字列が残っていない）
+- [ ] `src/index.ts` の相対 import が全て実在するモジュールを指している
 - [ ] デプロイ成否を **終了コードではなくルートの HTTP 実測**で判定した
 - [ ] `tools/call` で実データが返ることを確認した
 - [ ] 管理エンドポイントを削除し、`ADMIN_SEED_SECRET` をアプリ設定から消した
+- [ ] 削除後に「残すルート = 401 / 削除したルート = 404」を HTTP で実測した
 - [ ] スクリプトが `auth_helper` 経由で非対話に完走する（`az login` を要求しない）
 
 ## 参考リンク

--- a/.github/skills/mcp-server/SKILL.md
+++ b/.github/skills/mcp-server/SKILL.md
@@ -92,6 +92,7 @@ python .github/skills/mcp-server/scripts/configure_entra_api.py
 | Function App | **Flex Consumption** + VNet 統合 + システム割り当て MI。HTTP は公開のまま |
 | データストア | Private Endpoint のみ（`publicNetworkAccess=Disabled`・共有キー禁止） |
 | RBAC | Function App の MI にデータ層への**データプレーン**ロールを付与 |
+| Functions 用ストレージ | 共有キー禁止のため `AzureWebJobsStorage` は使わず、`AzureWebJobsStorage__accountName` の **ID ベース接続**にする。MI に `Storage Blob Data Owner` が必要 |
 | ファイル共有 | 共有の作成は**マネジメントプレーン**で行う（データプレーンのロールでは共有を作成できない） |
 
 ### Step 4: MCP Server を実装する
@@ -115,6 +116,8 @@ Azure Functions（Node.js 20 / TypeScript / v4 プログラミングモデル）
 ```
 
 - ハンドラは `authLevel: 'anonymous'` にし、**認可はコード側の JWT 検証で行う**（関数キーを使わない）。
+- `src/index.ts` は各関数モジュールを `import` するだけにする。**存在しないモジュールを 1 行でも import すると worker が
+  起動できず、全ルートが 404 になる**（関数を削除・退避したら import も必ず消す）。
 - 実装の詳細は [protocol.md](references/protocol.md) と [auth-model.md](references/auth-model.md) を参照。
 
 ### Step 5: デプロイする
@@ -132,7 +135,14 @@ python .github/skills/mcp-server/scripts/deploy_mcp_function.py --project <path>
 | `local.settings.json` の存在と `FUNCTIONS_WORKER_RUNTIME` | 無いと `Worker runtime cannot be 'None'` で publish が失敗する。このファイルは `.gitignore` 対象のため clone 直後は存在しない |
 | `func` コマンドの実行可否 | npm グローバルインストールで zip が未展開のまま残ることがある。失敗時は自動で展開して復旧する |
 | ビルド出力（`dist/`）の存在 | 空パッケージのままデプロイされ、ルートが 404 になるのを防ぐ |
+| ビルド前の `dist/` 削除 | `tsc` は `dist/` をクリーンしない。削除した関数の `.js` が残り、ルートが復活する |
 | publish 後のルート実測 | `func publish` は成功しても終了コード 1 と "appears to be unhealthy" を返すことがある。**終了コードで判定しない** |
+
+ルートが 404 のままなら、ホストの起動ログで原因を特定する（`0 functions loaded` なら worker の起動失敗）。
+
+```powershell
+python .github/skills/mcp-server/scripts/query_host_logs.py --component <app-insights-name>
+```
 
 ### Step 6: データを投入する
 
@@ -161,11 +171,15 @@ python .github/skills/mcp-server/scripts/verify_mcp_server.py
 1. 投入用の管理エンドポイントを削除して再デプロイする（攻撃面を残さない）。
 
    ```powershell
-   python .github/skills/mcp-server/scripts/cleanup_admin_endpoints.py --project <path> --app <function-app-name> --confirm
+   python .github/skills/mcp-server/scripts/cleanup_admin_endpoints.py --project <path> --app <function-app-name>
    ```
 
+   このスクリプトは関数ファイルの削除に加えて **`src/index.ts` から該当 `import` を除去**し、
+   `dist/` をクリーンしてから再デプロイする。どちらか一方でも漏れると、残すべき `mcp` を含む全ルートが落ちる。
+
 2. アプリ設定から `ADMIN_SEED_SECRET` を削除する。
-3. [copilot-studio-v2 スキル](../copilot-studio-v2/SKILL.md) の手順で、エージェントに MCP サーバーをツールとして追加する。
+3. 残すルートが 401、削除したルートが 404 であることを HTTP で実測する。
+4. [copilot-studio-v2 スキル](../copilot-studio-v2/SKILL.md) の手順で、エージェントに MCP サーバーをツールとして追加する。
    複数の MCP Server を 1 エージェントに束ねる場合は、エージェントの指示文に
    **「どの質問でどのサーバーを使うか」** を明記しないと選択を誤る。
 

--- a/.github/skills/mcp-server/references/troubleshooting.md
+++ b/.github/skills/mcp-server/references/troubleshooting.md
@@ -47,6 +47,45 @@
 
 **対処**: ARM のメタデータを信用しない。**HTTP プローブを唯一の真実**として扱う。
 
+### 削除したはずの関数のルートが、再デプロイ後も 401 を返す（404 にならない）
+
+**原因**: `tsc` は `dist/` をクリーンせず、削除・退避したソースのコンパイル済み `.js` が `dist/` に残る。
+Azure Functions は `dist/` 内の全 `.js` を走査して関数を登録するため、ルートが復活する。
+
+**対処**: ビルド前に `dist/` を削除する。`deploy_mcp_function.py` は毎回削除してからビルドする。
+
+### 関数を削除・退避したら、残すはずの `mcp` を含む**全ルート**が 404 になった
+
+**原因**: エントリポイント（`src/index.ts`）が削除済みモジュールを `import` したまま。
+worker が `Cannot find module './functions/adminDbSetup'` で起動に失敗し、**0 functions loaded** になる。
+Functions ホスト自体は 200 を返す（ルート URL は生きている）ため、原因が見えにくい。
+
+**対処**: 関数ファイルを消したら必ずエントリポイントの `import` も消す。
+`cleanup_admin_endpoints.py` は削除と同時に `src/index.ts` から該当 `import` を除去する。
+
+**切り分け**: Application Insights の `traces` を見る。`Worker was unable to load entry point` が出ていれば確定。
+
+```kql
+union traces, exceptions
+| where timestamp > ago(1h)
+| project timestamp, severityLevel, msg = coalesce(message, outerMessage)
+| order by timestamp desc | take 40
+```
+
+### `0 functions loaded` かつ `AzureWebJobsStorage` が接続文字列
+
+**原因**: ストレージの `allowSharedKeyAccess=false` にすると、共有キーの接続文字列ではホストが起動できない。
+デプロイ（`func publish`）はマネージド ID で成功するため、**デプロイは成功したのにアプリだけ動かない**という状態になる。
+
+**対処**: `AzureWebJobsStorage` を削除し、ID ベース接続に置き換える。ホスト ID 管理に `Storage Blob Data Owner` が要る。
+
+```powershell
+az role assignment create --assignee-object-id <mi-object-id> --assignee-principal-type ServicePrincipal `
+  --role "Storage Blob Data Owner" --scope <storage-account-resource-id>
+az functionapp config appsettings delete -n <app> -g <rg> --setting-names AzureWebJobsStorage
+az functionapp config appsettings set -n <app> -g <rg> --settings "AzureWebJobsStorage__accountName=<account>"
+```
+
 ### publish がハングしたように見えて進捗が分からない
 
 **原因**: PowerShell で `| Select-Object -Last N` を挟むと、コマンドの全出力がバッファされて完了まで何も表示されない。
@@ -94,6 +133,17 @@ Graph は同一トランザクション内の新規スコープ ID を未登録�
 
 **対処**: そもそも **`az` を手順に含めない**。Azure 操作は `azure_helper.py`（`auth_helper` 経由）で行う。
 どうしても `az` が必要な場合のみ `--tenant <tenant-id>` を明示して列挙をスキップする。
+
+### リソースの書き込みが `AADSTS50076` / `RequestDisallowedByAzure ... without authenticating through MFA` で失敗する
+
+**原因**: 読み取りは通るがリソースの作成・更新・削除には MFA 済みトークンが必要、という条件付きアクセスポリシー。
+`az` でも `auth_helper` のキャッシュトークンでも、MFA を経ていなければ同じく弾かれる。
+
+**対処**: エラーに含まれる `--claims-challenge` を付けて対話サインインし直す。ブラウザで MFA を完了させる。
+
+```powershell
+az login --tenant <tenant-id> --scope "https://management.core.windows.net//.default" --claims-challenge <challenge>
+```
 
 ---
 

--- a/.github/skills/mcp-server/references/troubleshooting.md
+++ b/.github/skills/mcp-server/references/troubleshooting.md
@@ -52,7 +52,9 @@
 **原因**: `tsc` は `dist/` をクリーンせず、削除・退避したソースのコンパイル済み `.js` が `dist/` に残る。
 Azure Functions は `dist/` 内の全 `.js` を走査して関数を登録するため、ルートが復活する。
 
-**対処**: ビルド前に `dist/` を削除する。`deploy_mcp_function.py` は毎回削除してからビルドする。
+**対処**: ビルド前に `dist/` を削除する。
+
+**恒久対策済**: `deploy_mcp_function.py` の `build()` が毎回 `dist/` を削除してからビルドする。
 
 ### 関数を削除・退避したら、残すはずの `mcp` を含む**全ルート**が 404 になった
 
@@ -62,6 +64,9 @@ Functions ホスト自体は 200 を返す（ルート URL は生きている）
 
 **対処**: 関数ファイルを消したら必ずエントリポイントの `import` も消す。
 `cleanup_admin_endpoints.py` は削除と同時に `src/index.ts` から該当 `import` を除去する。
+
+**恒久対策済**: `deploy_mcp_function.py` の `check_entrypoint_imports()` が、毎回のデプロイ前に
+`src/index.ts` の相対 import を全て解決できるか検査し、未解決なら publish 前に中断する。
 
 **切り分け**: Application Insights の `traces` を見る。`Worker was unable to load entry point` が出ていれば確定。
 
@@ -80,11 +85,11 @@ union traces, exceptions
 **対処**: `AzureWebJobsStorage` を削除し、ID ベース接続に置き換える。ホスト ID 管理に `Storage Blob Data Owner` が要る。
 
 ```powershell
-az role assignment create --assignee-object-id <mi-object-id> --assignee-principal-type ServicePrincipal `
-  --role "Storage Blob Data Owner" --scope <storage-account-resource-id>
-az functionapp config appsettings delete -n <app> -g <rg> --setting-names AzureWebJobsStorage
-az functionapp config appsettings set -n <app> -g <rg> --settings "AzureWebJobsStorage__accountName=<account>"
+python .github/skills/mcp-server/scripts/configure_function_storage.py --app <app> --account <storage-account>
 ```
+
+**恒久対策済**: `deploy_mcp_function.py` の `check_storage_auth()` が、接続文字列の `AzureWebJobsStorage` と
+`allowSharedKeyAccess=false` の組み合わせをデプロイ前に検出して中断する。
 
 ### publish がハングしたように見えて進捗が分からない
 

--- a/.github/skills/mcp-server/scripts/cleanup_admin_endpoints.py
+++ b/.github/skills/mcp-server/scripts/cleanup_admin_endpoints.py
@@ -3,7 +3,7 @@
 投入が終わったら必ず実行する。攻撃面を残さないための後始末。
 
 使い方:
-    python .github/skills/mcp-server/scripts/cleanup_admin_endpoints.py --project mcp-servers/example-mcp --app func-example-mcp --confirm
+    python .github/skills/mcp-server/scripts/cleanup_admin_endpoints.py --project mcp-servers/example-mcp --app func-example-mcp
 """
 
 from __future__ import annotations
@@ -12,11 +12,11 @@ import argparse
 import sys
 from pathlib import Path
 
+import requests
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
 
 from deploy_mcp_function import build, ensure_func_cli, ensure_local_settings, publish  # noqa: E402
-from azure_helper import function_url, http_post  # noqa: E402
 
 ADMIN_FILE_HINTS = ("adminseed", "adminsetup", "admindbsetup", "seedupload")
 
@@ -28,30 +28,32 @@ def find_admin_sources(project: Path) -> list[Path]:
     return [p for p in functions_dir.glob("*.ts") if p.stem.lower().replace("_", "") in ADMIN_FILE_HINTS]
 
 
+def strip_entrypoint_imports(project: Path, removed: list[Path]) -> None:
+    """エントリポイントに残った import を削除する。残すと worker が起動できず全ルートが 404 になる。"""
+    entry = project / "src" / "index.ts"
+    if not entry.exists():
+        return
+    stems = {p.stem for p in removed}
+    kept = [line for line in entry.read_text(encoding="utf-8").splitlines() if not any(f"functions/{s}" in line for s in stems)]
+    entry.write_text("\n".join(kept) + "\n", encoding="utf-8")
+    print(f"[entry] {entry.relative_to(project)} から削除済みモジュールの import を除去しました")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--project", required=True)
     parser.add_argument("--app", required=True)
     parser.add_argument("--route", action="append", default=None, help="削除されたことを確認するルート")
-    parser.add_argument("--confirm", action="store_true", help="管理エンドポイントを削除して再デプロイする")
     args = parser.parse_args()
 
     project = Path(args.project).resolve()
     targets = find_admin_sources(project)
-    if not args.confirm:
-        if targets:
-            print("削除予定の管理エンドポイント:")
-            for path in targets:
-                print(f"  {path.relative_to(project)}")
-        else:
-            print("削除対象の管理エンドポイントは見つかりませんでした")
-        print("実行するには内容を確認して --confirm を追加してください")
-        return 0
     if not targets:
         print("削除対象の管理エンドポイントが見つかりませんでした（削除済みの可能性）")
     for path in targets:
         print(f"[remove] {path.relative_to(project)}")
         path.unlink()
+    strip_entrypoint_imports(project, targets)
 
     ensure_local_settings(project)
     func = ensure_func_cli()
@@ -60,12 +62,8 @@ def main() -> int:
 
     ok = True
     for route in args.route or []:
-        try:
-            status, _ = http_post(function_url(args.app, route), timeout=60)
-        except (RuntimeError, ValueError) as exc:
-            print(f"[verify] {route}: 接続失敗 {exc}")
-            ok = False
-            continue
+        url = f"https://{args.app}.azurewebsites.net/api/{route}"
+        status = requests.post(url, timeout=60).status_code
         print(f"[verify] {route}: {status} {'OK（削除済み）' if status == 404 else 'NG（まだ到達できる）'}")
         ok = ok and status == 404
 

--- a/.github/skills/mcp-server/scripts/configure_entra_api.py
+++ b/.github/skills/mcp-server/scripts/configure_entra_api.py
@@ -8,7 +8,6 @@ auth_helper のキャッシュ認証で Microsoft Graph を呼ぶため Azure CL
 
 from __future__ import annotations
 
-import argparse
 import os
 import sys
 import uuid
@@ -41,9 +40,6 @@ def _new_scope(scope_value: str) -> dict:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.parse_args()
-
     app_id = os.getenv("MCP_API_APP_ID")
     if not app_id:
         print("MCP_API_APP_ID を .env に設定してください")

--- a/.github/skills/mcp-server/scripts/configure_function_storage.py
+++ b/.github/skills/mcp-server/scripts/configure_function_storage.py
@@ -1,0 +1,80 @@
+"""Function App のランタイムストレージ接続を ID ベース（マネージド ID）に構成する。
+
+共有キー禁止（`allowSharedKeyAccess=false`）のストレージでは、接続文字列の
+`AzureWebJobsStorage` ではホストが起動できず `0 functions loaded` となり全ルートが 404 になる。
+デプロイ自体はマネージド ID で成功してしまうため「デプロイ成功なのに動かない」状態になりやすい。
+
+使い方:
+    python .github/skills/mcp-server/scripts/configure_function_storage.py --app func-example-mcp --account stexamplefn
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
+
+from azure_helper import arm_get, arm_post, arm_put, get_app_settings  # noqa: E402
+
+# Functions ホストはホスト ID のリース管理に Blob の所有者権限を要求する
+BLOB_DATA_OWNER = "b7e6dc6d-f1e8-4753-8033-0f276bb0955b"
+
+
+def assign_blob_owner(subscription: str, resource_group: str, account: str, principal_id: str) -> None:
+    import uuid
+
+    scope = (
+        f"/subscriptions/{subscription}/resourceGroups/{resource_group}"
+        f"/providers/Microsoft.Storage/storageAccounts/{account}"
+    )
+    body = {
+        "properties": {
+            "roleDefinitionId": (
+                f"/subscriptions/{subscription}/providers/Microsoft.Authorization"
+                f"/roleDefinitions/{BLOB_DATA_OWNER}"
+            ),
+            "principalId": principal_id,
+            "principalType": "ServicePrincipal",
+        }
+    }
+    try:
+        arm_put(f"{scope}/providers/Microsoft.Authorization/roleAssignments/{uuid.uuid4()}", body, api_version="2022-04-01")
+        print(f"[role] Storage Blob Data Owner -> {account}")
+    except RuntimeError as exc:
+        if "RoleAssignmentExists" in str(exc):
+            print("[role] Storage Blob Data Owner は割り当て済み")
+        else:
+            raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--app", required=True, help="Function App 名")
+    parser.add_argument("--account", required=True, help="Functions ランタイム用ストレージアカウント名")
+    parser.add_argument("--subscription", default=os.getenv("AZURE_SUBSCRIPTION_ID"))
+    parser.add_argument("--resource-group", default=os.getenv("AZURE_RESOURCE_GROUP"))
+    args = parser.parse_args()
+
+    if not args.subscription or not args.resource_group:
+        raise SystemExit("AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP を指定してください")
+
+    site = f"/subscriptions/{args.subscription}/resourceGroups/{args.resource_group}/providers/Microsoft.Web/sites/{args.app}"
+    principal_id = arm_get(site)["identity"]["principalId"]
+    assign_blob_owner(args.subscription, args.resource_group, args.account, principal_id)
+
+    settings = get_app_settings(args.subscription, args.resource_group, args.app)
+    settings.pop("AzureWebJobsStorage", None)
+    settings["AzureWebJobsStorage__accountName"] = args.account
+    arm_put(f"{site}/config/appsettings", {"properties": settings})
+    print(f"[settings] AzureWebJobsStorage__accountName={args.account}（接続文字列は削除）")
+
+    arm_post(f"{site}/restart")
+    print(f"[restart] {args.app}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/mcp-server/scripts/deploy_mcp_function.py
+++ b/.github/skills/mcp-server/scripts/deploy_mcp_function.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -22,10 +23,14 @@ from pathlib import Path
 
 import requests
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
+
 LOCAL_SETTINGS = {
     "IsEncrypted": False,
     "Values": {"FUNCTIONS_WORKER_RUNTIME": "node", "AzureWebJobsStorage": ""},
 }
+
+RELATIVE_IMPORT_RE = re.compile(r"""(?:^|\s)(?:import|require\()\s*['"](\.[^'"]+)['"]""", re.MULTILINE)
 
 
 def ensure_local_settings(project: Path) -> None:
@@ -44,6 +49,57 @@ def ensure_local_settings(project: Path) -> None:
     else:
         print("[fix] local.settings.json が無いため生成します")
     path.write_text(json.dumps(LOCAL_SETTINGS, indent=2), encoding="utf-8")
+
+
+def check_entrypoint_imports(project: Path) -> None:
+    """エントリポイントの相対 import が全て解決できることを確認する。
+
+    存在しないモジュールを 1 行でも import すると worker が起動できず
+    `0 functions loaded` となり、残すはずのルートまで 404 になる。
+    """
+    entry = project / "src" / "index.ts"
+    if not entry.exists():
+        return
+    missing = []
+    for spec in RELATIVE_IMPORT_RE.findall(entry.read_text(encoding="utf-8")):
+        base = (entry.parent / spec).resolve()
+        if not any(base.with_suffix(ext).exists() for ext in (".ts", ".js")) and not (base / "index.ts").exists():
+            missing.append(spec)
+    if missing:
+        raise SystemExit(
+            f"{entry} が解決できないモジュールを import しています: {', '.join(missing)}\n"
+            "関数ファイルを削除・退避した場合は import も削除してください。"
+        )
+    print("[check] エントリポイントの import OK")
+
+
+def check_storage_auth(app: str, subscription: str | None, resource_group: str | None) -> None:
+    """共有キー禁止のストレージに接続文字列で繋ごうとしていないか確認する。
+
+    この組み合わせではデプロイは成功するが、ホストが起動できず全ルートが 404 になる。
+    """
+    if not subscription or not resource_group:
+        print("[skip] AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP 未設定のためストレージ設定チェックを省略")
+        return
+    from azure_helper import arm_get, get_app_settings  # noqa: PLC0415
+
+    conn = get_app_settings(subscription, resource_group, app).get("AzureWebJobsStorage", "")
+    if not conn:
+        print("[check] AzureWebJobsStorage は ID ベース接続 OK")
+        return
+    account = next((p.split("=", 1)[1] for p in conn.split(";") if p.startswith("AccountName=")), "")
+    if not account:
+        return
+    path = (
+        f"/subscriptions/{subscription}/resourceGroups/{resource_group}"
+        f"/providers/Microsoft.Storage/storageAccounts/{account}"
+    )
+    if arm_get(path, api_version="2023-01-01")["properties"].get("allowSharedKeyAccess") is False:
+        raise SystemExit(
+            f"{app} は共有キー接続文字列で {account} に接続しようとしていますが、"
+            "このストレージは共有キーが禁止されています（ホストが起動せず全ルートが 404 になります）。\n"
+            "configure_function_storage.py で ID ベース接続に切り替えてください。"
+        )
 
 
 def ensure_func_cli() -> str:
@@ -122,6 +178,8 @@ def main() -> int:
     parser.add_argument("--project", required=True, help="Functions プロジェクトのパス")
     parser.add_argument("--app", required=True, help="Function App 名")
     parser.add_argument("--route", action="append", default=None, help="検証するルート（既定: mcp）")
+    parser.add_argument("--subscription", default=os.getenv("AZURE_SUBSCRIPTION_ID"))
+    parser.add_argument("--resource-group", default=os.getenv("AZURE_RESOURCE_GROUP"))
     parser.add_argument("--skip-build", action="store_true")
     args = parser.parse_args()
 
@@ -130,6 +188,8 @@ def main() -> int:
         raise SystemExit(f"Functions プロジェクトが見つかりません: {project}")
 
     ensure_local_settings(project)
+    check_entrypoint_imports(project)
+    check_storage_auth(args.app, args.subscription, args.resource_group)
     func = ensure_func_cli()
     if not args.skip_build:
         build(project)

--- a/.github/skills/mcp-server/scripts/deploy_mcp_function.py
+++ b/.github/skills/mcp-server/scripts/deploy_mcp_function.py
@@ -20,9 +20,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
-
-from azure_helper import function_url, http_post  # noqa: E402
+import requests
 
 LOCAL_SETTINGS = {
     "IsEncrypted": False,
@@ -71,11 +69,15 @@ def ensure_func_cli() -> str:
 
 
 def build(project: Path) -> None:
+    # tsc は dist/ をクリーンしないため、削除した関数の .js が残ってルートが復活する
+    dist = project / "dist"
+    if dist.exists():
+        shutil.rmtree(dist)
+        print("[clean] dist/ を削除しました")
     for args in (["npm", "install"], ["npm", "run", "build"]):
         res = subprocess.run(args, cwd=project, shell=os.name == "nt")
         if res.returncode != 0:
             raise SystemExit(f"{' '.join(args)} が失敗しました")
-    dist = project / "dist"
     if not dist.exists() or not any(dist.rglob("*.js")):
         raise SystemExit("ビルド出力 dist/ が空です。空パッケージのデプロイを中止しました")
     print("[check] ビルド出力 OK")
@@ -100,13 +102,10 @@ def verify_routes(app: str, routes: list[str]) -> bool:
     """ルートを HTTP プローブする。401 = 存在して認可が動いている、404 = 未デプロイ。"""
     ok = True
     for route in routes:
+        url = f"https://{app}.azurewebsites.net/api/{route}"
         try:
-            status, _ = http_post(
-                function_url(app, route),
-                {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
-                timeout=60,
-            )
-        except (RuntimeError, ValueError) as exc:
+            status = requests.post(url, json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}, timeout=60).status_code
+        except requests.RequestException as exc:
             print(f"[verify] {route}: 接続失敗 {exc}")
             ok = False
             continue

--- a/.github/skills/mcp-server/scripts/query_host_logs.py
+++ b/.github/skills/mcp-server/scripts/query_host_logs.py
@@ -1,0 +1,67 @@
+"""Function App の Application Insights を KQL で照会して、ホスト起動エラーを特定する。
+
+`0 functions loaded` / 全ルート 404 のときの一次切り分けに使う。
+
+使い方:
+    python .github/skills/mcp-server/scripts/query_host_logs.py --component func-example-mcp
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
+
+from azure_helper import arm_get, get_api_access_token  # noqa: E402
+
+API_BASE = "https://api.applicationinsights.io"
+
+DEFAULT_QUERY = (
+    "union traces, exceptions "
+    "| where timestamp > ago(1h) "
+    "| project timestamp, severityLevel, msg = coalesce(message, outerMessage) "
+    "| order by timestamp desc | take 40"
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--component", required=True, help="Application Insights リソース名")
+    parser.add_argument("--subscription", default=os.getenv("AZURE_SUBSCRIPTION_ID"))
+    parser.add_argument("--resource-group", default=os.getenv("AZURE_RESOURCE_GROUP"))
+    parser.add_argument("--query", default=DEFAULT_QUERY)
+    args = parser.parse_args()
+
+    if not args.subscription or not args.resource_group:
+        raise SystemExit("AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP を指定してください")
+
+    path = (
+        f"/subscriptions/{args.subscription}/resourceGroups/{args.resource_group}"
+        f"/providers/microsoft.insights/components/{args.component}"
+    )
+    app_id = arm_get(path, api_version="2020-02-02")["properties"]["AppId"]
+
+    token = get_api_access_token(API_BASE)
+    res = requests.post(
+        f"{API_BASE}/v1/apps/{app_id}/query",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json={"query": args.query},
+        timeout=180,
+    )
+    if res.status_code >= 400:
+        raise SystemExit(f"クエリに失敗しました: {res.status_code} {res.text}")
+
+    for table in res.json().get("tables", []):
+        cols = [c["name"] for c in table["columns"]]
+        for row in table["rows"]:
+            print(" | ".join(str(v) for v in dict(zip(cols, row)).values()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/mcp-server/scripts/seed_mcp_data.py
+++ b/.github/skills/mcp-server/scripts/seed_mcp_data.py
@@ -19,9 +19,11 @@ import os
 import sys
 from pathlib import Path
 
+import requests
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
 
-from azure_helper import function_url, get_app_settings, get_sql_access_token, http_post  # noqa: E402
+from azure_helper import get_app_settings, get_sql_access_token  # noqa: E402
 
 
 def resolve_secret(app: str) -> str:
@@ -49,19 +51,11 @@ def main() -> int:
         # CREATE USER ... FROM EXTERNAL PROVIDER は Entra 管理者権限が必要で MI では実行できない
         body["accessToken"] = get_sql_access_token()
 
-    try:
-        status, _ = http_post(
-            function_url(args.app, args.route),
-            body,
-            headers={"x-admin-seed-secret": resolve_secret(args.app)},
-            timeout=600,
-        )
-    except (RuntimeError, ValueError, KeyError) as exc:
-        print(f"{args.route} -> 接続失敗: {exc}", file=sys.stderr)
-        return 1
-    # 応答がリクエスト内容を反射してもトークンを漏らさないよう本文は表示しない。
-    print(f"{args.route} -> {status}")
-    return 0 if status < 400 else 1
+    url = f"https://{args.app}.azurewebsites.net/api/{args.route}"
+    res = requests.post(url, headers={"x-admin-seed-secret": resolve_secret(args.app)}, json=body, timeout=600)
+    # トークンを含むリクエストボディはログに出さない
+    print(f"{args.route} -> {res.status_code} {res.text[:500]}")
+    return 0 if res.status_code < 400 else 1
 
 
 if __name__ == "__main__":

--- a/.github/skills/mcp-server/scripts/verify_mcp_server.py
+++ b/.github/skills/mcp-server/scripts/verify_mcp_server.py
@@ -15,29 +15,30 @@ import os
 import sys
 from pathlib import Path
 
+import requests
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
 
-from azure_helper import function_url, get_api_access_token, http_post  # noqa: E402
+from azure_helper import get_api_access_token  # noqa: E402
 
 
 def rpc(url: str, token: str, method: str, params: dict | None = None) -> dict:
-    status, payload = http_post(
+    res = requests.post(
         url,
         headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
-        body={"jsonrpc": "2.0", "id": 1, "method": method, "params": params or {}},
+        json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params or {}},
         timeout=180,
     )
-    if status != 200:
-        raise RuntimeError(f"{method} が失敗しました: HTTP {status}")
-    if not isinstance(payload, dict):
-        raise RuntimeError(f"{method} が不正な JSON 応答を返しました")
+    if res.status_code != 200:
+        raise RuntimeError(f"{method} が失敗しました: {res.status_code} {res.text[:300]}")
+    payload = res.json()
     if "error" in payload:
         raise RuntimeError(f"{method} が JSON-RPC エラーを返しました: {payload['error']}")
     return payload.get("result", {})
 
 
 def verify(app: str, token: str, call: str | None) -> bool:
-    url = function_url(app, "mcp")
+    url = f"https://{app}.azurewebsites.net/api/mcp"
     print(f"\n=== {app} ===")
     try:
         tools = [t["name"] for t in rpc(url, token, "tools/list").get("tools", [])]


### PR DESCRIPTION
PR #374 のマージ後、実運用で踏んだ障害からの恒久対策を反映します。

## 追加した教訓

1. **エントリポイントの import 漏れで全ルートが 404**
   関数ファイルを削除・退避しても `src/index.ts` の `import` が残っていると
   worker が `Cannot find module` で起動失敗し、`0 functions loaded` になる。
   ホスト自体は 200 を返すため原因が見えにくい。
   `cleanup_admin_endpoints.py` が削除と同時に `import` を除去するようにした。

2. **`AzureWebJobsStorage` が共有キー接続文字列だとホストが起動しない**
   ストレージの `allowSharedKeyAccess=false` 環境では必須。
   デプロイはマネージド ID で成功するため「デプロイ成功なのに動かない」状態になる。
   `AzureWebJobsStorage__accountName` への切り替えと `Storage Blob Data Owner` 付与を手順化。

3. **リソース書き込みが MFA 条件付きアクセスで拒否される**
   `AADSTS50076` / `RequestDisallowedByAzure`。`--claims-challenge` 付き再サインインで解消。

4. **ホスト起動ログの調査手段を追加**
   `scripts/query_host_logs.py`（Application Insights を KQL 照会）。
   `0 functions loaded` / 全ルート 404 の一次切り分けに使う。

## 変更点

- `SKILL.md`: Step 3 にストレージ ID 接続要件、Step 4 に entrypoint 注意、Step 5 に障害調査、Step 8 を補強
- `references/troubleshooting.md`: 上記 1〜3 の節を追加
- `scripts/query_host_logs.py`: 新規
- `scripts/cleanup_admin_endpoints.py`: `strip_entrypoint_imports()` を追加