### PR TITLE
mcp-server: Streamable HTTP 準拠と Copilot Studio 登録手順を追加

### DIFF
--- a/.github/skills/mcp-server/SKILL.md
+++ b/.github/skills/mcp-server/SKILL.md
@@ -32,7 +32,7 @@ Copilot Studio のエージェントから **社内の業務データ（DB・フ
 |---|---|
 | **データ層は非公開、コンピュート層は公開** | SQL / Storage は Private Endpoint のみ。Function App の HTTP エンドポイントは公開する（Copilot Studio は SaaS からアウトバウンド接続するため、非公開にすると到達できない） |
 | **キーレス** | 受信 = Entra ID Bearer JWT 検証、送信 = Managed Identity。関数キー・接続文字列・共有キーを使わない |
-| **プロトコルは最小実装** | `initialize` / `tools/list` / `tools/call` の 3 メソッドのみ。SSE・セッション管理は実装しない |
+| **プロトコルは最小実装** | `initialize` / `tools/list` / `tools/call` / `ping` のみ。SSE ストリーム・セッション管理は実装しないが、**Streamable HTTP の規約には従う**（Copilot Studio は Streamable のみ対応） |
 | **成否はルート実測で判定** | デプロイの終了コードや ARM のメタデータを信用せず、HTTP プローブで実際のルートを確認する |
 | **非対話で完走** | Azure 操作も `auth_helper` 経由（`az login` を手順に含めない）。→ [認証リファレンス](../standard/references/auth-patterns.md) |
 
@@ -40,9 +40,10 @@ Copilot Studio のエージェントから **社内の業務データ（DB・フ
 
 | リファレンス | 内容 |
 |---|---|
-| [MCP プロトコル最小実装](references/protocol.md) | JSON-RPC 2.0 の 3 メソッドとツール定義の書き方 |
+| [MCP プロトコル最小実装](references/protocol.md) | JSON-RPC 2.0 の実装と Streamable HTTP の必須要件、ツール定義の書き方 |
 | [認証モデル](references/auth-model.md) | 受信 JWT 検証 / 送信 Managed Identity の実装 |
 | [Private 環境でのデータ投入](references/private-data-seeding.md) | Private Endpoint 下でシードするための管理エンドポイントパターン |
+| [Copilot Studio への登録](references/copilot-studio-registration.md) | カスタムコネクタ（OpenAPI）とコネクタ用 OAuth 設定 |
 | [.env サンプル](references/.env.example) | 本スキルのパラメータ |
 | [異常系・トラブルシュート](references/troubleshooting.md) | 実際に踏んだ失敗と恒久対策 |
 
@@ -125,6 +126,9 @@ Azure Functions（Node.js 20 / TypeScript / v4 プログラミングモデル）
 - ハンドラは `authLevel: 'anonymous'` にし、**認可はコード側の JWT 検証で行う**（関数キーを使わない）。
 - `src/index.ts` は各関数モジュールを `import` するだけにする。**存在しないモジュールを 1 行でも import すると worker が
   起動できず、全ルートが 404 になる**（関数を削除・退避したら import も必ず消す）。
+- Copilot Studio から使うなら **Streamable HTTP の必須要件**を満たす（通知には 202 + 本文なし、
+  `protocolVersion` は `2025-03-26` 以降をネゴシエート、GET / DELETE に 405）。これを外すと
+  curl では成功するのにコネクタ接続だけが失敗する。
 - 実装の詳細は [protocol.md](references/protocol.md) と [auth-model.md](references/auth-model.md) を参照。
 
 ### Step 5: デプロイする
@@ -172,7 +176,8 @@ python .github/skills/mcp-server/scripts/seed_mcp_data.py
 python .github/skills/mcp-server/scripts/verify_mcp_server.py
 ```
 
-`api://{app-id}/.default` のトークンを取得し、`tools/list` でツール一覧、`tools/call` で**実データ**が返ることを確認する。
+`api://{app-id}/.default` のトークンを取得し、**Streamable HTTP 準拠の検査**に続けて
+`tools/list` でツール一覧、`tools/call` で**実データ**が返ることを確認する。
 ツール一覧が返るだけでは不十分で、**必ず 1 つ以上のツールを実行して中身を見る**。
 
 ### Step 8: 管理エンドポイントを削除して Copilot Studio に登録する
@@ -188,9 +193,16 @@ python .github/skills/mcp-server/scripts/verify_mcp_server.py
 
 2. アプリ設定から `ADMIN_SEED_SECRET` を削除する。
 3. 残すルートが 401、削除したルートが 404 であることを HTTP で実測する。
-4. [copilot-studio-v2 スキル](../copilot-studio-v2/SKILL.md) の手順で、エージェントに MCP サーバーをツールとして追加する。
-   複数の MCP Server を 1 エージェントに束ねる場合は、エージェントの指示文に
-   **「どの質問でどのサーバーを使うか」** を明記しないと選択を誤る。
+4. カスタム コネクタ（OpenAPI + OAuth）を作成し、エージェントにツールとして追加する。
+   → [copilot-studio-registration.md](references/copilot-studio-registration.md)
+
+   ```powershell
+   python .github/skills/mcp-server/scripts/configure_connector_oauth.py --audience $env:MCP_API_AUDIENCE --secret-out .secrets/connector-oauth.json
+   ```
+
+   複数の MCP Server を 1 エージェントに束ねる場合は、コネクタの `description` とエージェントの指示文の
+   **両方に「どの質問でどのサーバーを使うか」**を明記しないと選択を誤る。
+   エージェント本体の構築は [copilot-studio-v2 スキル](../copilot-studio-v2/SKILL.md) に委譲する。
 
 ---
 
@@ -205,6 +217,7 @@ python .github/skills/mcp-server/scripts/verify_mcp_server.py
 - [ ] `src/index.ts` の相対 import が全て実在するモジュールを指している
 - [ ] デプロイ成否を **終了コードではなくルートの HTTP 実測**で判定した
 - [ ] `tools/call` で実データが返ることを確認した
+- [ ] Streamable HTTP 準拠（通知に 202 / バージョンネゴシエーション / GET に 405）を検証した
 - [ ] 管理エンドポイントを削除し、`ADMIN_SEED_SECRET` をアプリ設定から消した
 - [ ] 削除後に「残すルート = 401 / 削除したルート = 404」を HTTP で実測した
 - [ ] スクリプトが `auth_helper` 経由で非対話に完走する（`az login` を要求しない）

--- a/.github/skills/mcp-server/SKILL.md
+++ b/.github/skills/mcp-server/SKILL.md
@@ -43,7 +43,7 @@ Copilot Studio のエージェントから **社内の業務データ（DB・フ
 | [MCP プロトコル最小実装](references/protocol.md) | JSON-RPC 2.0 の実装と Streamable HTTP の必須要件、ツール定義の書き方 |
 | [認証モデル](references/auth-model.md) | 受信 JWT 検証 / 送信 Managed Identity の実装 |
 | [Private 環境でのデータ投入](references/private-data-seeding.md) | Private Endpoint 下でシードするための管理エンドポイントパターン |
-| [Copilot Studio への登録](references/copilot-studio-registration.md) | カスタムコネクタ（OpenAPI）とコネクタ用 OAuth 設定 |
+| [Copilot Studio への登録](references/copilot-studio-registration.md) | カスタムコネクタ（OpenAPI）とコネクタ用 OAuth 設定。Cowork から使う場合の参照先もここ |
 | [.env サンプル](references/.env.example) | 本スキルのパラメータ |
 | [異常系・トラブルシュート](references/troubleshooting.md) | 実際に踏んだ失敗と恒久対策 |
 
@@ -203,6 +203,11 @@ python .github/skills/mcp-server/scripts/verify_mcp_server.py
    複数の MCP Server を 1 エージェントに束ねる場合は、コネクタの `description` とエージェントの指示文の
    **両方に「どの質問でどのサーバーを使うか」**を明記しないと選択を誤る。
    エージェント本体の構築は [copilot-studio-v2 スキル](../copilot-studio-v2/SKILL.md) に委譲する。
+
+5. （任意）**M365 Copilot（Cowork）からも使う場合**は、同じ MCP Server を Cowork プラグインの
+   `agentConnectors.remoteMcpServer` としても登録する。**Server の実装は増えない**
+   （API アプリを 1 つに集約しておけば登録が 2 系統になるだけ）。
+   → [cowork/references/custom-mcp-connector.md](../cowork/references/custom-mcp-connector.md)
 
 ---
 

--- a/.github/skills/mcp-server/references/.env.example
+++ b/.github/skills/mcp-server/references/.env.example
@@ -19,3 +19,7 @@ MCP_PREAUTH_CLIENT_IDS=
 
 # === データ投入（Step 6 で使用し、Step 8 で削除する）===
 ADMIN_SEED_SECRET={generate-a-random-secret}
+
+# === Copilot Studio カスタムコネクタ（Step 8）===
+# configure_connector_oauth.py のシークレット出力先。必ず .gitignore 対象にする
+CONNECTOR_SECRET_OUT=.secrets/connector-oauth.json

--- a/.github/skills/mcp-server/references/copilot-studio-registration.md
+++ b/.github/skills/mcp-server/references/copilot-studio-registration.md
@@ -10,6 +10,11 @@ Copilot Studio が対応するのは **Streamable トランスポートのみ**�
 | MCP オンボーディング ウィザード | Copilot Studio の **ツール > ツールの追加 > 新しいツール > Model Context Protocol** でサーバー URL と認証を入力 | 単発・手早く繋ぐ |
 | **カスタム コネクタ（OpenAPI）** | `x-ms-agentic-protocol: mcp-streamable-1.0` を持つ swagger を Power Apps にインポート | **定義をコード管理したい場合。既定はこちら** |
 
+> **M365 Copilot（Cowork）から使いたい場合**は本手順ではなく、Cowork プラグインの
+> `agentConnectors.remoteMcpServer` として登録する →
+> [cowork/references/custom-mcp-connector.md](../../cowork/references/custom-mcp-connector.md)。
+> **同じ MCP Server を両方に登録できる**（API アプリを 1 つに集約しておけば、実装は増えず登録が 2 系統になるだけ）。
+
 ## Step 1: OpenAPI 定義を用意する
 
 `swagger: '2.0'` で、MCP エンドポイントの POST 操作 1 つだけを定義する。

--- a/.github/skills/mcp-server/references/copilot-studio-registration.md
+++ b/.github/skills/mcp-server/references/copilot-studio-registration.md
@@ -1,0 +1,109 @@
+# Copilot Studio に自前 MCP Server を登録する
+
+Copilot Studio が対応するのは **Streamable トランスポートのみ**（SSE は 2025 年 8 月で廃止）。
+登録前に [protocol.md](protocol.md) の「Streamable HTTP の必須要件」を満たしていること。
+
+登録方式は 2 つある。
+
+| 方式 | 内容 | 使いどころ |
+|---|---|---|
+| MCP オンボーディング ウィザード | Copilot Studio の **ツール > ツールの追加 > 新しいツール > Model Context Protocol** でサーバー URL と認証を入力 | 単発・手早く繋ぐ |
+| **カスタム コネクタ（OpenAPI）** | `x-ms-agentic-protocol: mcp-streamable-1.0` を持つ swagger を Power Apps にインポート | **定義をコード管理したい場合。既定はこちら** |
+
+## Step 1: OpenAPI 定義を用意する
+
+`swagger: '2.0'` で、MCP エンドポイントの POST 操作 1 つだけを定義する。
+`x-ms-agentic-protocol` が MCP として扱うためのマーカーで、これが無いと通常の REST 操作になる。
+
+```yaml
+swagger: '2.0'
+info:
+  title: <サーバー表示名>
+  description: >-
+    このサーバーが何を答えられるかを書く。複数の MCP Server を 1 エージェントに束ねる場合は
+    「別の用途では〇〇サーバーを使うこと」まで書く。オーケストレーターはこの説明で選択する。
+  version: 1.0.0
+host: <function-app>.azurewebsites.net
+basePath: /
+schemes:
+  - https
+paths:
+  /api/mcp:
+    post:
+      summary: <サーバー表示名>
+      operationId: InvokeMCP
+      x-ms-agentic-protocol: mcp-streamable-1.0
+      responses:
+        '200':
+          description: Success
+securityDefinitions:
+  oauth2_auth:
+    type: oauth2
+    flow: accessCode
+    authorizationUrl: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
+    tokenUrl: https://login.microsoftonline.com/common/oauth2/v2.0/token
+    scopes:
+      ${MCP_API_AUDIENCE}/${MCP_API_SCOPE_VALUE}: MCP サーバーへのアクセス
+security:
+  - oauth2_auth:
+      - ${MCP_API_AUDIENCE}/${MCP_API_SCOPE_VALUE}
+```
+
+> `tools/list` の中身は書かない。ツール一覧は接続後に MCP サーバーから動的に取得され、
+> サーバー側で増減させると Copilot Studio に自動反映される。
+
+## Step 2: Entra アプリ登録にコネクタ用 OAuth 設定を追加する
+
+カスタムコネクタは認可コードフローで動くため、API アプリ登録に固定のリダイレクト URI と
+クライアントシークレットが必要になる。
+
+```powershell
+python .github/skills/mcp-server/scripts/configure_connector_oauth.py `
+  --audience $env:MCP_API_AUDIENCE --secret-out .secrets/connector-oauth.json
+```
+
+このスクリプトは以下を行う。
+
+1. リダイレクト URI `https://global.consent.azure-apim.net/redirect` を追加する（全カスタムコネクタ共通の固定値）。
+2. クライアントシークレットを発行する。
+3. 自分自身のスコープへの委任アクセスを `requiredResourceAccess` に追加し、同意を成立させる。
+
+> **シークレットは標準出力に出さず**、`--secret-out` のファイルにだけ書き出す。
+> 出力先は必ず `.gitignore` 対象のパスにする。
+
+## Step 3: カスタム コネクタを作成する
+
+Power Apps（make.powerapps.com）＞ **カスタム コネクタ** ＞ **新しいカスタム コネクタ** ＞
+**OpenAPI ファイルをインポート** で Step 1 の YAML を読み込み、セキュリティ タブで以下を設定する。
+
+| 項目 | 値 |
+|---|---|
+| 認証タイプ | OAuth 2.0 |
+| ID プロバイダー | Azure Active Directory |
+| クライアント ID / クライアント シークレット | Step 2 の出力ファイルの値 |
+| リソース URL | `${MCP_API_AUDIENCE}` |
+| スコープ | `${MCP_API_SCOPE_VALUE}` |
+
+ブラウザ操作は VS Code 統合ブラウザで自動化する。開始前に `AskUserQuestion` で使用する
+Microsoft Edge プロファイルを確認し、回答前はポータルを開かない
+（→ [ブラウザ自動化方針](../../standard/references/browser-automation.md)）。
+
+## Step 4: エージェントにツールとして追加する
+
+Copilot Studio でエージェントを開き、**ツール > ツールの追加** から作成したコネクタを選び、
+接続を作成して追加する。追加後に再公開する。
+
+- **生成オーケストレーションが有効**でないと MCP は使えない。
+- 複数の MCP Server を 1 エージェントに束ねる場合は、エージェントの指示文にも
+  「どの質問でどのサーバーを使うか」を明記する。コネクタの `description` だけでは選択を誤ることがある。
+
+## Step 5: 実測で確認する
+
+Copilot Studio のテスト ペインで、各サーバーの `list_*` 系ツールが呼ばれることを確認する。
+ツールが呼ばれない場合は、まず [verify_mcp_server.py](../scripts/verify_mcp_server.py) を実行して
+サーバー側の Streamable HTTP 準拠を切り分ける（サーバーが原因か、登録が原因かを先に確定させる）。
+
+## 参考リンク
+
+- [Connect your agent to an existing MCP server](https://learn.microsoft.com/microsoft-copilot-studio/mcp-add-existing-server-to-agent)
+- [Extend your agent with Model Context Protocol](https://learn.microsoft.com/microsoft-copilot-studio/agent-extend-action-mcp)

--- a/.github/skills/mcp-server/references/protocol.md
+++ b/.github/skills/mcp-server/references/protocol.md
@@ -1,13 +1,28 @@
 # MCP プロトコル最小実装
 
 Copilot Studio から呼ぶだけであれば、MCP 仕様の全体を実装する必要はない。
-**JSON-RPC 2.0 over HTTP POST** で以下 3 メソッドを返せば足りる。SSE・セッション管理・通知は実装しない。
+**JSON-RPC 2.0 over HTTP POST** で以下を返せば足りる。SSE ストリームとセッション管理は実装しない。
 
 | メソッド | 役割 |
 |---|---|
 | `initialize` | プロトコルバージョンとサーバー情報を返す |
 | `tools/list` | ツール定義（`name` / `description` / `inputSchema`）の配列を返す |
 | `tools/call` | ツールを実行し、結果を `content` 配列で返す |
+| `ping` | 空の result を返す（数行） |
+
+## Streamable HTTP の必須要件
+
+Copilot Studio は **Streamable トランスポートのみ**対応する（SSE トランスポートは 2025 年 8 月で廃止）。
+以下を満たさないと、`tools/list` は自前の curl で成功するのに **コネクタ接続だけが失敗**する。
+
+| 要件 | 内容 |
+|---|---|
+| 通知に本文を返さない | `id` を持たないメッセージ（`notifications/initialized` 等）は **202 + 本文なし**。`body.id ?? null` で補って応答するとハンドシェイク直後に切断される |
+| バージョンをネゴシエートする | `initialize` でクライアント提示版を返す。**`2025-03-26` 以降**でないと Streamable と見なされない |
+| GET / DELETE を登録する | SSE 未対応でも **405 を返す**。`methods: ['POST']` だけだと GET が 404 になり、サーバー不在と誤判定される |
+| ツールエラーは result で返す | 実行失敗は JSON-RPC `error` ではなく `{ content: [...], isError: true }`。モデルが原因を読める |
+
+これらは [verify_mcp_server.py](../scripts/verify_mcp_server.py) の `check_streamable_compliance()` が毎回検査する。
 
 ## ディスパッチャ
 
@@ -17,20 +32,30 @@ import { app, HttpRequest, HttpResponseInit } from '@azure/functions';
 import { verifyToken } from '../lib/auth';
 import { TOOLS, callTool } from '../tools/domainTools';
 
-const PROTOCOL_VERSION = '2024-11-05';
+// 新しい順。クライアント提示版がこの中にあればそれを、無ければ先頭を返す。
+const SUPPORTED_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26', '2024-11-05'];
 
 app.http('mcp', {
-  methods: ['POST'],
+  methods: ['POST', 'GET', 'DELETE'],
   authLevel: 'anonymous', // 認可はコード側の JWT 検証で行う（関数キーは使わない）
   route: 'mcp',
   handler: async (req: HttpRequest): Promise<HttpResponseInit> => {
+    if (req.method !== 'POST') {
+      return { status: 405, headers: { Allow: 'POST' }, jsonBody: { error: 'method not allowed' } };
+    }
+
     const auth = await verifyToken(req.headers.get('authorization'));
     if (!auth.ok) {
       return { status: 401, jsonBody: { error: auth.reason } };
     }
 
     const body = (await req.json()) as { id?: unknown; method?: string; params?: any };
-    const id = body.id ?? null;
+
+    // id を持たないメッセージは通知。応答本文を返してはならない。
+    if (body.id === undefined) {
+      return { status: 202 };
+    }
+    const id = body.id;
 
     const reply = (result: unknown): HttpResponseInit => ({
       status: 200,
@@ -38,19 +63,31 @@ app.http('mcp', {
     });
 
     switch (body.method) {
-      case 'initialize':
+      case 'initialize': {
+        const requested = body.params?.protocolVersion;
         return reply({
-          protocolVersion: PROTOCOL_VERSION,
+          protocolVersion: SUPPORTED_PROTOCOL_VERSIONS.includes(requested)
+            ? requested
+            : SUPPORTED_PROTOCOL_VERSIONS[0],
           capabilities: { tools: {} },
           serverInfo: { name: 'example-mcp', version: '1.0.0' },
         });
+      }
+
+      case 'ping':
+        return reply({});
 
       case 'tools/list':
         return reply({ tools: TOOLS });
 
       case 'tools/call': {
-        const text = await callTool(body.params?.name, body.params?.arguments ?? {});
-        return reply({ content: [{ type: 'text', text }] });
+        try {
+          const text = await callTool(body.params?.name, body.params?.arguments ?? {});
+          return reply({ content: [{ type: 'text', text }] });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'internal error';
+          return reply({ content: [{ type: 'text', text: message }], isError: true });
+        }
       }
 
       default:

--- a/.github/skills/mcp-server/references/troubleshooting.md
+++ b/.github/skills/mcp-server/references/troubleshooting.md
@@ -104,6 +104,35 @@ Get-Content "$env:TEMP\publish.log" -Tail 30
 
 ---
 
+## Copilot Studio との接続
+
+### curl では `tools/list` が返るのに、Copilot Studio のコネクタからは接続できない
+
+**原因**: Copilot Studio は **Streamable トランスポートのみ**対応する（SSE は 2025 年 8 月で廃止）。
+自前実装で以下のいずれかを外していると、自前の curl では成功するのに接続だけが失敗する。
+
+| 違反 | 症状 |
+|---|---|
+| `id` なしの通知（`notifications/initialized`）に JSON-RPC 本文を返す | initialize 直後のハンドシェイクで切断される |
+| `protocolVersion` を `2024-11-05` 等に固定し、クライアント提示版を無視する | Streamable と見なされない |
+| `methods: ['POST']` のみで GET が 404 | サーバー不在と誤判定される |
+
+**対処**: [protocol.md](protocol.md) の「Streamable HTTP の必須要件」に従い、通知は **202 + 本文なし**、
+`protocolVersion` は `2025-03-26` 以降をネゴシエート、GET / DELETE は **405** を返す。
+
+**恒久対策済み**: `verify_mcp_server.py` の `check_streamable_compliance()` が、
+毎回の E2E 検証で上記 3 点を実測して違反を列挙する（`tools/list` の前に実行される）。
+
+### カスタムコネクタの OAuth 同意でリダイレクトが失敗する
+
+**原因**: Entra アプリ登録にカスタムコネクタ共通のリダイレクト URI
+`https://global.consent.azure-apim.net/redirect` が登録されていない。
+
+**対処**: `configure_connector_oauth.py` を実行する（リダイレクト URI 追加・シークレット発行・
+自己スコープへの委任アクセス付与をまとめて行う）。
+
+---
+
 ## 認証・認可
 
 ### トークン取得が `AADSTS650057: Invalid resource ... List of valid resources from app registration: .`

--- a/.github/skills/mcp-server/scripts/configure_connector_oauth.py
+++ b/.github/skills/mcp-server/scripts/configure_connector_oauth.py
@@ -1,0 +1,118 @@
+"""Power Platform カスタムコネクタから MCP Server を呼ぶための OAuth 設定を Entra アプリに追加する。
+
+カスタムコネクタは認可コードフローで動くため、API アプリ登録に以下が必要になる。
+
+1. リダイレクト URI ``https://global.consent.azure-apim.net/redirect``（コネクタ共通の固定値）
+2. クライアントシークレット
+3. 自分自身のスコープへの ``requiredResourceAccess``（同意を成立させるため）
+
+シークレットは **標準出力に出さず**、``--secret-out`` のファイルにだけ書き出す。
+ファイルは必ず .gitignore の対象に置くこと。
+
+使い方:
+    python .github/skills/mcp-server/scripts/configure_connector_oauth.py --audience api://<app-id> --secret-out .secrets/connector.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
+
+from azure_helper import graph_get, graph_patch, graph_post  # noqa: E402
+
+CONNECTOR_REDIRECT_URI = "https://global.consent.azure-apim.net/redirect"
+
+
+def find_application(audience: str) -> dict:
+    apps = graph_get(f"/applications?$filter=identifierUris/any(u:u eq '{audience}')")["value"]
+    if not apps:
+        raise SystemExit(f"identifierUris に {audience} を持つアプリ登録が見つかりません")
+    return apps[0]
+
+
+def ensure_redirect_uri(app: dict) -> None:
+    uris = app.get("web", {}).get("redirectUris", [])
+    if CONNECTOR_REDIRECT_URI in uris:
+        print("[skip] リダイレクト URI は登録済み")
+        return
+    graph_patch(f"/applications/{app['id']}", {"web": {"redirectUris": [*uris, CONNECTOR_REDIRECT_URI]}})
+    print(f"[app] リダイレクト URI を追加: {CONNECTOR_REDIRECT_URI}")
+
+
+def ensure_self_permission(app: dict, scope_name: str) -> str:
+    scopes = app.get("api", {}).get("oauth2PermissionScopes", [])
+    scope = next((s for s in scopes if s["value"] == scope_name), None)
+    if not scope:
+        raise SystemExit(f"スコープ {scope_name} が公開されていません。configure_entra_api.py を先に実行してください")
+
+    required = app.get("requiredResourceAccess", [])
+    entry = next((r for r in required if r["resourceAppId"] == app["appId"]), None)
+    if entry and any(a["id"] == scope["id"] for a in entry.get("resourceAccess", [])):
+        print("[skip] 自分自身のスコープへの委任アクセスは設定済み")
+        return scope["id"]
+
+    access = {"id": scope["id"], "type": "Scope"}
+    if entry:
+        entry["resourceAccess"].append(access)
+    else:
+        required.append({"resourceAppId": app["appId"], "resourceAccess": [access]})
+    graph_patch(f"/applications/{app['id']}", {"requiredResourceAccess": required})
+    print(f"[app] 自分自身のスコープ {scope_name} への委任アクセスを追加")
+    return scope["id"]
+
+
+def create_secret(app: dict, display_name: str) -> dict:
+    return graph_post(
+        f"/applications/{app['id']}/addPassword",
+        {"passwordCredential": {"displayName": display_name}},
+    )
+
+
+def write_secret_file(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    if os.name != "nt":
+        path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--audience", default=os.getenv("MCP_API_AUDIENCE"), help="api://<app-id>")
+    parser.add_argument("--scope", default=os.getenv("MCP_API_SCOPE_VALUE", "MCP.Access"))
+    parser.add_argument("--secret-out", default=".secrets/connector-oauth.json")
+    parser.add_argument("--secret-name", default="power-platform-custom-connector")
+    args = parser.parse_args()
+
+    if not args.audience:
+        raise SystemExit("--audience または MCP_API_AUDIENCE を指定してください")
+
+    app = find_application(args.audience)
+    ensure_redirect_uri(app)
+    ensure_self_permission(app, args.scope)
+    secret = create_secret(app, args.secret_name)
+
+    out = Path(args.secret_out)
+    write_secret_file(
+        out,
+        {
+            "clientId": app["appId"],
+            "clientSecret": secret["secretText"],
+            "secretExpiresOn": secret["endDateTime"],
+            "resourceUri": args.audience,
+            "scope": f"{args.audience}/{args.scope}",
+            "redirectUri": CONNECTOR_REDIRECT_URI,
+        },
+    )
+    print(f"[secret] {out} に書き出しました（値は表示しません）")
+    print(f"[info] clientId={app['appId']} / scope={args.audience}/{args.scope}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/mcp-server/scripts/verify_mcp_server.py
+++ b/.github/skills/mcp-server/scripts/verify_mcp_server.py
@@ -1,6 +1,7 @@
 """MCP Server をエンドツーエンドで検証する。
 
-`tools/list` でツール一覧を取得し、続けて `tools/call` を実行して**実データが返ること**まで確認する。
+Streamable HTTP の準拠を確かめた上で、`tools/list` でツール一覧を取得し、
+続けて `tools/call` を実行して**実データが返ること**まで確認する。
 ツール一覧が返るだけでは不十分（データ層への接続や権限が壊れていても一覧は返るため）。
 
 使い方:
@@ -21,6 +22,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scrip
 
 from azure_helper import get_api_access_token  # noqa: E402
 
+# Streamable HTTP トランスポートが導入されたバージョン。Copilot Studio はこれ以降を要求する。
+MIN_STREAMABLE_PROTOCOL_VERSION = "2025-03-26"
+CLIENT_PROTOCOL_VERSION = "2025-06-18"
+
 
 def rpc(url: str, token: str, method: str, params: dict | None = None) -> dict:
     res = requests.post(
@@ -37,9 +42,54 @@ def rpc(url: str, token: str, method: str, params: dict | None = None) -> dict:
     return payload.get("result", {})
 
 
+def check_streamable_compliance(url: str, token: str) -> list[str]:
+    """Copilot Studio が接続できる Streamable HTTP 準拠を検査し、違反を返す。
+
+    いずれも tools/list は成功するのにコネクタ接続だけが失敗するクラスの不具合。
+    """
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    violations = []
+
+    init = rpc(url, token, "initialize", {"protocolVersion": CLIENT_PROTOCOL_VERSION, "capabilities": {}})
+    version = init.get("protocolVersion", "")
+    if version < MIN_STREAMABLE_PROTOCOL_VERSION:
+        violations.append(
+            f"initialize の protocolVersion が {version or '未返却'}。"
+            f"Streamable HTTP には {MIN_STREAMABLE_PROTOCOL_VERSION} 以降が必要"
+        )
+
+    # 通知（id なし）には応答本文を返してはいけない。返すとハンドシェイク直後に切断される。
+    notified = requests.post(
+        url, headers=headers, json={"jsonrpc": "2.0", "method": "notifications/initialized"}, timeout=60
+    )
+    if notified.status_code not in (202, 204) or notified.content:
+        violations.append(
+            f"通知（id なし）への応答が {notified.status_code} / body {len(notified.content)} bytes。"
+            "202 かつ本文なしでなければならない"
+        )
+
+    # SSE 未対応なら 405、対応するなら 200。404 は GET がルートに登録されていない。
+    streamed = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=60)
+    if streamed.status_code == 404:
+        violations.append("GET が 404。SSE 未対応なら 405 を返すよう methods に GET を含める")
+
+    return violations
+
+
 def verify(app: str, token: str, call: str | None) -> bool:
     url = f"https://{app}.azurewebsites.net/api/mcp"
     print(f"\n=== {app} ===")
+    try:
+        violations = check_streamable_compliance(url, token)
+    except RuntimeError as exc:
+        print(f"NG: {exc}")
+        return False
+    if violations:
+        for v in violations:
+            print(f"NG: {v}")
+        return False
+    print("Streamable HTTP 準拠 OK")
+
     try:
         tools = [t["name"] for t in rpc(url, token, "tools/list").get("tools", [])]
     except RuntimeError as exc:


### PR DESCRIPTION
Copilot Studio へ自前 MCP Server を登録する際に判明した非準拠 3 点を、正常フローの手順と自動チェックとして取り込む。

## 背景
curl では tools/list が成功するのに、Copilot Studio のコネクタ接続だけが失敗した。原因は Streamable HTTP の規約違反 3 点。

- id なしの通知に JSON-RPC 本文を返していた（202 + 本文なしが必須）
- protocolVersion を 2024-11-05 に固定していた（2025-03-26 以降のネゴシエーションが必須）
- methods が POST のみで GET が 404（SSE 未対応でも 405 が必須）

## 変更内容
- verify_mcp_server.py に check_streamable_compliance() を追加し、tools/list の前に上記 3 点を実測する
- protocol.md に「Streamable HTTP の必須要件」と ping / 405 / 202 / バージョンネゴシエーションを含むディスパッチャ実装を追加
- copilot-studio-registration.md を新規追加（OpenAPI 定義 → Entra OAuth 設定 → カスタムコネクタ → ツール追加 → 実測確認）
- configure_connector_oauth.py を新規追加（リダイレクト URI 追加・自己スコープ委任・シークレット発行。シークレットは表示せずファイル出力）
- troubleshooting.md に上記症状と恒久対策済みの記載を追加
- SKILL.md の Step 4 / 7 / 8 と検証チェックリストを更新
- .env.example に CONNECTOR_SECRET_OUT を追加し、スコープ変数名を MCP_API_SCOPE_VALUE に統一

## 検証
実プロジェクト 2 件で実測。修正前のサーバーでは違反 3 件を正しく検出し、修正後は 2/2 件が準拠 OK（偽陽性なし）。

## マージ順
standard スキルの graph_post 追加（#376）に依存するため、#376 を先にマージすること。