### PR TITLE
fix: make community issue agent noninteractive

### DIFF
--- a/.github/scripts/community-issue-agent.mjs
+++ b/.github/scripts/community-issue-agent.mjs
@@ -268,6 +268,9 @@ async function finalizeReview(issueNumber) {
     REJECTED_INPUT: ['decision:rejected-input', 'b60205', 'Input was rejected by the safety policy'],
   };
   const [name, color, description] = names[decision.decision];
+  for (const [otherDecision, [otherName]] of Object.entries(names)) {
+    if (otherDecision !== decision.decision) await removeLabel(issueNumber, otherName);
+  }
   await addLabels(issueNumber, [{ name, color, description }]);
   await removeLabel(issueNumber, 'agent:reviewing');
   if (decision.decision === 'NEEDS_INFO' || decision.decision === 'OWNER_REVIEW' || decision.decision === 'REJECTED_INPUT') {
@@ -319,6 +322,7 @@ async function escalate(issueNumber, reason) {
     method: 'POST',
     body: JSON.stringify({ assignees: ['geekfujiwara'] }),
   });
+  await removeLabel(issueNumber, 'agent:reviewing');
   if (process.env.GITHUB_STEP_SUMMARY) {
     await writeFile(process.env.GITHUB_STEP_SUMMARY, `Owner review required: ${String(reason).slice(0, 2000)}\n`, { flag: 'a' });
   }

--- a/.github/scripts/community-issue-agent.test.mjs
+++ b/.github/scripts/community-issue-agent.test.mjs
@@ -40,6 +40,8 @@ test('workflow is cloud-only and explicitly provisions its runtime', async () =>
   assert.match(workflow, /docker version/);
   assert.doesNotMatch(workflow, /COMMUNITY_AGENT_TOKEN/);
   assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}/);
+  assert.match(workflow, /--no-ask-user/);
+  assert.match(workflow, /timeout-minutes: 5/);
 });
 
 test('sandbox accepts only narrow test and validation commands', () => {

--- a/.github/workflows/community-issue-agent.yml
+++ b/.github/workflows/community-issue-agent.yml
@@ -29,6 +29,7 @@ jobs:
            github.event.issue.author_association != 'MEMBER' &&
            github.event.issue.author_association != 'COLLABORATOR') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       issues: write
@@ -53,6 +54,7 @@ jobs:
     name: Reproduce and classify in isolation
     needs: acknowledge
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       issues: write
@@ -90,10 +92,13 @@ jobs:
 
       - name: Create a constrained reproduction plan
         if: ${{ env.COPILOT_CLI_TOKEN != '' }}
+        timeout-minutes: 5
         env:
           GH_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
         run: >-
           copilot --prompt "$(cat .github/prompts/community-issue-reproduction.md)"
+          --no-ask-user
+          --silent
           --allow-tool write
 
       - name: Verify the planner did not edit tracked files
@@ -118,10 +123,13 @@ jobs:
 
       - name: Classify from repository and reproduction evidence
         if: ${{ env.COPILOT_CLI_TOKEN != '' }}
+        timeout-minutes: 5
         env:
           GH_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
         run: >-
           copilot --prompt "$(cat .github/prompts/community-issue-decision.md)"
+          --no-ask-user
+          --silent
           --allow-tool write
 
       - name: Use owner review when the agent is unavailable
@@ -148,6 +156,7 @@ jobs:
     needs: review
     if: ${{ needs.review.outputs.decision == 'AUTO_PR' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
       issues: write
@@ -178,10 +187,13 @@ jobs:
         run: npm install --global "@github/copilot@${COPILOT_CLI_VERSION}"
 
       - name: Implement without command execution
+        timeout-minutes: 5
         env:
           GH_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
         run: >-
           copilot --prompt "$(cat .github/prompts/community-issue-implementation.md)"
+          --no-ask-user
+          --silent
           --allow-tool write
 
       - name: Enforce changed path and diff limits
@@ -233,6 +245,7 @@ jobs:
     needs: review
     if: ${{ always() && needs.review.result == 'failure' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       issues: write
@@ -258,6 +271,7 @@ jobs:
     needs: implement
     if: ${{ always() && needs.implement.result == 'failure' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
Summary:
- Make the community issue agent noninteractive with --no-ask-user.
- Add 5-minute Copilot step timeouts and job timeouts.
- Clean up stale decision labels.
- Add/retain 13 passing tests.

Tests: 13 passing.
