### PR TITLE
fix: extract single Copilot JSON block

### DIFF
--- a/.github/scripts/community-issue-agent.mjs
+++ b/.github/scripts/community-issue-agent.mjs
@@ -79,9 +79,9 @@ export function parseJsonDocument(value) {
   try {
     return JSON.parse(trimmed);
   } catch (directError) {
-    const fenced = trimmed.match(/^```json\s*\r?\n([\s\S]*?)\r?\n```$/i);
-    if (!fenced) throw directError;
-    return JSON.parse(fenced[1]);
+    const fenced = [...trimmed.matchAll(/```json\s*\r?\n([\s\S]*?)\r?\n```/gi)];
+    if (fenced.length !== 1) throw directError;
+    return JSON.parse(fenced[0][1]);
   }
 }
 

--- a/.github/scripts/community-issue-agent.test.mjs
+++ b/.github/scripts/community-issue-agent.test.mjs
@@ -63,10 +63,10 @@ test('plan validation rejects an unsafe command among safe commands', () => {
   );
 });
 
-test('JSON parser accepts one fenced document but rejects surrounding prose', () => {
+test('JSON parser extracts one fenced document but rejects multiple candidates', () => {
   assert.deepEqual(parseJsonDocument('{"commands":[]}'), { commands: [] });
   assert.deepEqual(parseJsonDocument('```json\n{"commands":[]}\n```'), { commands: [] });
-  assert.throws(() => parseJsonDocument('Here is the result:\n```json\n{}\n```'));
+  assert.deepEqual(parseJsonDocument('Untrusted explanation\n```json\n{"commands":[]}\n```\nMore prose'), { commands: [] });
   assert.throws(() => parseJsonDocument('```json\n{}\n```\n```json\n{}\n```'));
 });
 


### PR DESCRIPTION
Extract exactly one fenced Copilot JSON block and cover the parsing behavior with focused tests.