### PR TITLE
fix: parse embedded Copilot JSON

### DIFF
--- a/.github/scripts/community-issue-agent.mjs
+++ b/.github/scripts/community-issue-agent.mjs
@@ -86,8 +86,46 @@ export function parseJsonDocument(value) {
     return JSON.parse(trimmed);
   } catch (directError) {
     const fenced = [...trimmed.matchAll(/```json\s*\r?\n([\s\S]*?)\r?\n```/gi)];
-    if (fenced.length !== 1) throw directError;
-    return JSON.parse(fenced[0][1]);
+    if (fenced.length === 1) return JSON.parse(fenced[0][1]);
+    if (fenced.length > 1) throw directError;
+
+    const candidates = [];
+    let start = -1;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let index = 0; index < trimmed.length; index += 1) {
+      const character = trimmed[index];
+      if (depth === 0) {
+        if (character === '{') {
+          start = index;
+          depth = 1;
+          inString = false;
+          escaped = false;
+        }
+        continue;
+      }
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (character === '\\') escaped = true;
+        else if (character === '"') inString = false;
+      } else if (character === '"') inString = true;
+      else if (character === '{') depth += 1;
+      else if (character === '}') {
+        depth -= 1;
+        if (depth === 0) candidates.push(trimmed.slice(start, index + 1));
+      }
+    }
+    const parsed = candidates.flatMap((candidate) => {
+      try {
+        const document = JSON.parse(candidate);
+        return document && typeof document === 'object' && !Array.isArray(document) ? [document] : [];
+      } catch {
+        return [];
+      }
+    });
+    if (parsed.length !== 1) throw directError;
+    return parsed[0];
   }
 }
 

--- a/.github/scripts/community-issue-agent.test.mjs
+++ b/.github/scripts/community-issue-agent.test.mjs
@@ -65,11 +65,15 @@ test('plan validation rejects an unsafe command among safe commands', () => {
   );
 });
 
-test('JSON parser extracts one fenced document but rejects multiple candidates', () => {
+test('JSON parser extracts one document but rejects multiple candidates', () => {
   assert.deepEqual(parseJsonDocument('{"commands":[]}'), { commands: [] });
   assert.deepEqual(parseJsonDocument('```json\n{"commands":[]}\n```'), { commands: [] });
   assert.deepEqual(parseJsonDocument('Untrusted explanation\n```json\n{"commands":[]}\n```\nMore prose'), { commands: [] });
+  assert.deepEqual(parseJsonDocument('Confirmed result: {"commands":[{"argv":["python","-c","assert {1: 2}[1] == 2"]}]} done'), {
+    commands: [{ argv: ['python', '-c', 'assert {1: 2}[1] == 2'] }],
+  });
   assert.throws(() => parseJsonDocument('```json\n{}\n```\n```json\n{}\n```'));
+  assert.throws(() => parseJsonDocument('First {"a":1}, second {"b":2}'));
 });
 
 test('reproduction may expect a failure but post-change validation may not', () => {


### PR DESCRIPTION
Parse a single embedded JSON object in Copilot output while rejecting ambiguous candidates.\n\nTests: node --test .github/scripts/community-issue-agent.test.mjs