### PR TITLE
feat(mcp-server): support Copilot Studio onboarding wizard

### DIFF
--- a/.github/skills/copilot-studio-v2/references/mcp-servers.md
+++ b/.github/skills/copilot-studio-v2/references/mcp-servers.md
@@ -9,16 +9,27 @@ McpTool + 接続参照）で自動追加する手順を提供していたが、�
 
 ## 前提
 
-- 対象コネクタ（例: Microsoft Dataverse、Work IQ OneDrive）の **Connected な接続**が
-  環境に存在していること。無ければ make.powerautomate.com で一度作成・承認する。
+- 既存コネクタ（例: Microsoft Dataverse、Work IQ OneDrive）を追加する場合は、対象の
+  **Connected な接続**が環境に存在していること。
 - エージェント（cliagent）が `scripts/create_agent.py` 等で作成済みであること。
 
-> **自前の MCP Server を追加する場合**は、事前にカスタム コネクタ（`x-ms-agentic-protocol: mcp-streamable-1.0`
-> の OpenAPI）と Entra の OAuth 設定が必要になる。作り方は
-> [mcp-server スキルの Copilot Studio 登録手順](../../mcp-server/references/copilot-studio-registration.md) を参照。
-> コネクタを用意したうえで、以下の UI 手順で追加する。
+## 自前 MCP Server をウィザードで追加する
 
-## 手順（UI）
+自前 Server は、Copilot Studio の **Tools > Add a tool > New tool > Model Context Protocol** から
+オンボーディングウィザードで追加する。事前に OpenAPI コネクタを作る必要はない。
+
+1. [mcp-server スキルの登録手順](../../mcp-server/references/copilot-studio-registration.md) に従い、
+   Server ごとのコピペ用 MD を `generate_copilot_studio_guide.py` で生成する。
+2. `Server name` は英字・数字・ハイフン・ドットだけにする。日本語名は内部コネクタ名の作成で 400 になる。
+3. `Authentication = OAuth 2.0`、`Configuration type = Manual` を選び、生成 MD から貼り付けて **Add** する。
+4. **Select a connection** で生成 MD の `Display name (optional)` を入力し、**Create** を選ぶ。
+5. `AADSTS50011` が出たら、エラーのパス付き Redirect URI を
+   `add_connector_redirect_uri.py` で Entra アプリへ追加し、接続ダイアログを開き直す。
+6. 接続後に **Add to agent**、必要なら **Confirm**、最後にエージェントを再公開する。
+
+入力 MD は Client secret を含むため、Server ごとに分けて `.gitignore` 対象にする。
+
+## 既存コネクタを追加する
 
 開始前に [ブラウザ自動化方針](../../standard/references/browser-automation.md)に従い、
 `AskUserQuestion` で使用する Edge プロファイルを確認する。回答前は Copilot Studio を開かず、
@@ -89,3 +100,5 @@ PAC CLI・Dataverse Web API のいずれにも自動化手段は提供しない�
 | 実行時に MCP が反応しない / 認可エラー | 追加後の Confirm 未実施、または接続未承認 | UI で **Confirm** ＋ 接続の承認を確認 |
 | **UI の Confirm を押しても接続できない** | 接続参照バインドが古い状態で残っている | UI で対象 MCP サーバーを削除→再追加 → 再公開 → 再 Confirm |
 | `Connected な接続がありません` | 環境に該当コネクタの接続が無い | make.powerautomate.com で接続を作成/承認 |
+| `POST .../connectors/apim 400` | Server name に日本語・空白等を使用 | 英字・数字・ハイフン・ドットだけに変更 |
+| サインインで `AADSTS50011` | コネクタ固有 Redirect URI が Entra に未登録 | エラーに表示された URI を `add_connector_redirect_uri.py` で追加 |

--- a/.github/skills/mcp-server/SKILL.md
+++ b/.github/skills/mcp-server/SKILL.md
@@ -45,7 +45,8 @@ Copilot Studio のエージェントから **社内の業務データ（DB・フ
 | [Private 環境でのデータ投入](references/private-data-seeding.md) | Private Endpoint 下でシードするための管理エンドポイントパターン |
 | [ファイルを読ませるツールの設計](references/file-backed-tools.md) | サイドカーテキストレイヤー・パストラバーサル対策・出力上限・プロンプトインジェクション防御 |
 | [SQL バックエンドのツール設計](references/sql-tools-pattern.md) | パラメータ化クエリ・集計軸のホワイトリスト・トークン寿命と接続プール・読み取り専用権限 |
-| [Copilot Studio への登録](references/copilot-studio-registration.md) | カスタムコネクタ（OpenAPI）とコネクタ用 OAuth 設定。Cowork から使う場合の参照先もここ |
+| [Copilot Studio への登録](references/copilot-studio-registration.md) | オンボーディングウィザード、コピペ用 MD 生成、OAuth 接続。OpenAPI 方式もここ |
+| [Copilot Studio の DLP 診断](references/copilot-studio-dlp.md) | MCP ツールが DLP でブロックされた場合の読み取り診断と最小変更 |
 | [.env サンプル](references/.env.example) | 本スキルのパラメータ |
 | [異常系・トラブルシュート](references/troubleshooting.md) | 実際に踏んだ失敗と恒久対策 |
 
@@ -199,12 +200,37 @@ python .github/skills/mcp-server/scripts/verify_mcp_server.py
 
 2. アプリ設定から `ADMIN_SEED_SECRET` を削除する。
 3. 残すルートが 401、削除したルートが 404 であることを HTTP で実測する。
-4. カスタム コネクタ（OpenAPI + OAuth）を作成し、エージェントにツールとして追加する。
+4. Copilot Studio の MCP オンボーディングウィザードで、エージェントにツールとして追加する。
    → [copilot-studio-registration.md](references/copilot-studio-registration.md)
 
    ```powershell
    python .github/skills/mcp-server/scripts/configure_connector_oauth.py --audience $env:MCP_API_AUDIENCE --secret-out .secrets/connector-oauth.json
+   python .github/skills/mcp-server/scripts/generate_copilot_studio_guide.py `
+     --server-name example-files-mcp `
+     --server-description "文書を検索して内容を取得します。" `
+     --server-url "https://<function-app>.azurewebsites.net/api/mcp" `
+     --display-name "文書 MCP 接続" `
+     --output "<server-dir>/copilot-studio-connection.md"
    ```
+
+   - `Server name` は **1～64 文字の英字・数字・ハイフン・ドットのみ**。日本語や空白は
+     Power Platform の内部コネクタ名作成で 400 になるため、生成スクリプトが事前に拒否する。
+   - 生成 MD は Client secret を含む。**MCP Server ごとに分け**、先に `.gitignore` へ追加する。
+   - 認証は `OAuth 2.0`、構成は `Manual` を選ぶ。接続画面では任意の表示名も生成 MD から貼り付ける。
+   - コネクタ作成後に表示された callback URL、または `AADSTS50011` に表示された URI は、次で Entra に追加する。
+
+     ```powershell
+     python .github/skills/mcp-server/scripts/add_connector_redirect_uri.py `
+       --audience $env:MCP_API_AUDIENCE `
+       --redirect-uri "https://global.consent.azure-apim.net/redirect/<connector-id>"
+     ```
+
+   - `This tool is blocked by your data loss prevention policy` と表示された場合は、公開やポリシー変更を
+     繰り返さず、[Copilot Studio の DLP 診断](references/copilot-studio-dlp.md) に従って適用ポリシーと
+     コネクタ分類を読み取り確認する。DLP ポリシーを操作する公開 REST API はないため、公式の
+     `Microsoft.PowerApps.Administration.PowerShell` cmdlet を使う。
+
+   OpenAPI をコード管理する必要がある場合だけ、カスタムコネクタのインポート方式を使う。
 
    複数の MCP Server を 1 エージェントに束ねる場合は、コネクタの `description` とエージェントの指示文の
    **両方に「どの質問でどのサーバーを使うか」**を明記しないと選択を誤る。

--- a/.github/skills/mcp-server/references/.env.example
+++ b/.github/skills/mcp-server/references/.env.example
@@ -23,3 +23,18 @@ ADMIN_SEED_SECRET={generate-a-random-secret}
 # === Copilot Studio カスタムコネクタ（Step 8）===
 # configure_connector_oauth.py のシークレット出力先。必ず .gitignore 対象にする
 CONNECTOR_SECRET_OUT=.secrets/connector-oauth.json
+
+# MCP Server ごとに値と出力先を変えて generate_copilot_studio_guide.py を実行する
+# Server name は英字・数字・ハイフン・ドットのみ（1～64文字）
+MCP_CONNECTOR_SERVER_NAME=example-files-mcp
+MCP_CONNECTOR_SERVER_DESCRIPTION=社内文書を検索して内容を取得します。
+MCP_CONNECTOR_SERVER_URL=https://func-example-files-mcp.azurewebsites.net/api/mcp
+MCP_CONNECTOR_DISPLAY_NAME=文書 MCP 接続
+# Client secret を含むため、このパスを必ず .gitignore へ追加する
+MCP_CONNECTOR_GUIDE_OUT=mcp-servers/example-files-mcp/copilot-studio-connection.md
+
+# === Copilot Studio DLP 診断（任意）===
+# Power Platform 管理センターの環境 ID
+POWER_PLATFORM_ENVIRONMENT_ID={your-environment-id}
+# MCP カスタムコネクタのホスト名（スキームやパスを含めない）
+MCP_CONNECTOR_HOST=func-example-files-mcp.azurewebsites.net

--- a/.github/skills/mcp-server/references/copilot-studio-registration.md
+++ b/.github/skills/mcp-server/references/copilot-studio-registration.md
@@ -1,41 +1,141 @@
 # Copilot Studio に自前 MCP Server を登録する
 
-Copilot Studio が対応するのは **Streamable トランスポートのみ**（SSE は 2025 年 8 月で廃止）。
-登録前に [protocol.md](protocol.md) の「Streamable HTTP の必須要件」を満たしていること。
+Copilot Studio が対応するのは **Streamable HTTP** のみ。登録前に [protocol.md](protocol.md) の
+要件を満たし、[verify_mcp_server.py](../scripts/verify_mcp_server.py) で `tools/call` まで成功させる。
 
-登録方式は 2 つある。
+| 方式 | 使いどころ |
+|---|---|
+| **MCP オンボーディングウィザード（推奨）** | Copilot Studio 内で Server URL と認証を入力して追加する通常経路 |
+| カスタムコネクタ（OpenAPI） | 定義をコード管理し、複数環境へ同じ OpenAPI を配布する場合 |
 
-| 方式 | 内容 | 使いどころ |
-|---|---|---|
-| MCP オンボーディング ウィザード | Copilot Studio の **ツール > ツールの追加 > 新しいツール > Model Context Protocol** でサーバー URL と認証を入力 | 単発・手早く繋ぐ |
-| **カスタム コネクタ（OpenAPI）** | `x-ms-agentic-protocol: mcp-streamable-1.0` を持つ swagger を Power Apps にインポート | **定義をコード管理したい場合。既定はこちら** |
+> M365 Copilot（Cowork）から使う場合は、Cowork プラグインの `agentConnectors.remoteMcpServer` として
+> 別途登録する。→ [custom-mcp-connector.md](../../cowork/references/custom-mcp-connector.md)
 
-> **M365 Copilot（Cowork）から使いたい場合**は本手順ではなく、Cowork プラグインの
-> `agentConnectors.remoteMcpServer` として登録する →
-> [cowork/references/custom-mcp-connector.md](../../cowork/references/custom-mcp-connector.md)。
-> **同じ MCP Server を両方に登録できる**（API アプリを 1 つに集約しておけば、実装は増えず登録が 2 系統になるだけ）。
+## 推奨: MCP オンボーディングウィザード
 
-## Step 1: OpenAPI 定義を用意する
+### Step 1: OAuth クライアントを準備する
 
-`swagger: '2.0'` で、MCP エンドポイントの POST 操作 1 つだけを定義する。
-`x-ms-agentic-protocol` が MCP として扱うためのマーカーで、これが無いと通常の REST 操作になる。
+Entra アプリ登録に委任スコープを公開した後、認可コードフロー用の Client secret を作成する。
+
+```powershell
+python .github/skills/mcp-server/scripts/configure_entra_api.py
+python .github/skills/mcp-server/scripts/configure_connector_oauth.py `
+  --audience $env:MCP_API_AUDIENCE `
+  --secret-out .secrets/connector-oauth.json
+```
+
+`.secrets/connector-oauth.json` は Client secret を含むため、必ず `.gitignore` 対象にする。
+スクリプトは ignore されていない出力先と既存ファイルへの上書きを、secret 発行前に拒否する。
+既存ファイルがある場合はその secret を再利用し、期限切れ等で意図的に更新するときだけ
+`--rotate-secret` を付ける。新形式の出力は credential の `keyId` も保存し、更新成功後に旧credentialを削除する。
+旧形式のファイルに `keyId` がない場合は警告に従い、Entra 管理センターで旧credentialを手動削除する。
+このスクリプトが登録する共通 URI `https://global.consent.azure-apim.net/redirect` だけでは、
+オンボーディングウィザードが生成する**パス付き Redirect URI**には一致しない。Step 4 で追加する。
+
+### Step 2: MCP Server ごとの入力ガイドを生成する
+
+入力値を探し回らずに済むよう、Server ごとにコピペ用 MD を生成する。MD には Client secret が入るため、
+**生成前に出力先を `.gitignore` へ追加する**。生成スクリプトは ignore されていなければ中断する。
+
+```gitignore
+mcp-servers/example-files-mcp/copilot-studio-connection.md
+```
+
+```powershell
+python .github/skills/mcp-server/scripts/generate_copilot_studio_guide.py `
+  --server-name example-files-mcp `
+  --server-description "社内文書を検索して内容を取得します。" `
+  --server-url "https://func-example-files-mcp.azurewebsites.net/api/mcp" `
+  --display-name "文書 MCP 接続" `
+  --tenant-id $env:ENTRA_TENANT_ID `
+  --audience $env:MCP_API_AUDIENCE `
+  --secret-file .secrets/connector-oauth.json `
+  --output mcp-servers/example-files-mcp/copilot-studio-connection.md
+```
+
+- 複数 Server を登録するときは、**1 Server = 1 MD** に分ける。
+- `Server name` は `^[A-Za-z0-9.\-]{1,64}$`、つまり英字・数字・ハイフン・ドットだけにする。
+  日本語や空白を使うと、`POST .../connectors/apim` が内部名の検証で 400 を返す。
+- `Server description` には「何を取得できるか」と「どの質問で使うか」を書く。
+- `Display name (optional)` は接続作成画面で使う、人が判別しやすい名前にする。
+
+### Step 3: Add MCP server を入力する
+
+ブラウザ操作前に [ブラウザ自動化方針](../../standard/references/browser-automation.md) に従って
+使用する Edge プロファイルを確認し、同じプロファイルを最後まで使う。
+
+1. Copilot Studio で対象エージェントを開く。
+2. **Tools > Add a tool > New tool > Model Context Protocol** を開く。
+3. 生成した MD から次を貼り付ける。
+
+| 画面の項目 | 値 |
+|---|---|
+| Server name | 英数字の Server 名 |
+| Server description | 用途の説明 |
+| Server URL | `https://<function-app>.azurewebsites.net/api/mcp` |
+| Authentication | `OAuth 2.0` |
+| Configuration type | `Manual` |
+| Client ID | Entra アプリの Client ID |
+| Client secret | Step 1 で発行した値 |
+| Authorization URL | `https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize` |
+| Token URL | `https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token` |
+| Refresh token URL | Token URL と同じ |
+| Scopes | `api://<app-id>/<scope>`。対話同意では `/.default` を使わない |
+
+4. **Add** を選択する。`POST .../connectors/apim` が 400 の場合は、ブラウザ開発者ツールの
+   **Network > connectors/apim > Response** を確認する。Initiator の JavaScript スタックだけでは原因は分からない。
+
+### Step 4: コネクタ固有 Redirect URI を登録する
+
+コネクタ作成後に callback URL が表示されたら、その値を使う。接続時に `AADSTS50011` が出た場合は、
+エラー本文の `redirect URI '...'` を**完全一致のまま**使う。Request Payload や Client secret は共有しない。
+
+```powershell
+python .github/skills/mcp-server/scripts/add_connector_redirect_uri.py `
+  --audience $env:MCP_API_AUDIENCE `
+  --redirect-uri "https://global.consent.azure-apim.net/redirect/<connector-id>"
+```
+
+このスクリプトは既存の Web redirect URI を保持し、追加後に Graph で再取得して検証する。
+Client secret は作成・ローテーションしない。入力ガイドにも URI を残す場合は、Step 2 のコマンドへ
+`--redirect-uri` を加えて再生成する。
+
+### Step 5: 接続を作成してエージェントへ追加する
+
+1. **Select a connection** で対象コネクタの **Create** を選ぶ。
+2. 生成 MD の `Display name (optional)` を貼り付ける。
+3. 組織アカウントでサインインする。Step 4 の URI 追加直後は、接続ダイアログを一度閉じて開き直す。
+4. 接続が `Connected` になったら **Add to agent** を選ぶ。
+5. MCP Server の詳細で接続を選び、表示される場合は **Confirm** を選ぶ。
+6. エージェントを再公開する。
+
+生成オーケストレーションを有効にする。複数 Server を追加するときは、各 description と
+エージェントの Instructions の両方に、どの質問でどの Server を使うかを書く。
+
+### Step 6: テストする
+
+テストペインで Server ごとの質問を実行し、期待した Server の `tools/list` と `tools/call` が呼ばれること、
+実データが回答へ反映されることを確認する。ツールが呼ばれない場合は、登録問題と Server 問題を分けるため
+`verify_mcp_server.py` を再実行する。
+
+## 代替: OpenAPI からカスタムコネクタを作る
+
+定義をコード管理する場合は `swagger: '2.0'` で MCP の POST 操作だけを定義し、Power Apps の
+**Custom connectors > Import OpenAPI file** から作成する。
 
 ```yaml
 swagger: '2.0'
 info:
-  title: <サーバー表示名>
-  description: >-
-    このサーバーが何を答えられるかを書く。複数の MCP Server を 1 エージェントに束ねる場合は
-    「別の用途では〇〇サーバーを使うこと」まで書く。オーケストレーターはこの説明で選択する。
+  title: Example MCP
+  description: 社内データを検索して取得する MCP Server
   version: 1.0.0
-host: <function-app>.azurewebsites.net
+host: func-example-mcp.azurewebsites.net
 basePath: /
-schemes:
-  - https
+schemes: [https]
 paths:
   /api/mcp:
     post:
-      summary: <サーバー表示名>
+      summary: Example MCP
       operationId: InvokeMCP
       x-ms-agentic-protocol: mcp-streamable-1.0
       responses:
@@ -48,65 +148,13 @@ securityDefinitions:
     authorizationUrl: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
     tokenUrl: https://login.microsoftonline.com/common/oauth2/v2.0/token
     scopes:
-      ${MCP_API_AUDIENCE}/${MCP_API_SCOPE_VALUE}: MCP サーバーへのアクセス
+      api://<app-id>/MCP.Access: MCP Server へのアクセス
 security:
   - oauth2_auth:
-      - ${MCP_API_AUDIENCE}/${MCP_API_SCOPE_VALUE}
+      - api://<app-id>/MCP.Access
 ```
 
-> `tools/list` の中身は書かない。ツール一覧は接続後に MCP サーバーから動的に取得され、
-> サーバー側で増減させると Copilot Studio に自動反映される。
-
-## Step 2: Entra アプリ登録にコネクタ用 OAuth 設定を追加する
-
-カスタムコネクタは認可コードフローで動くため、API アプリ登録に固定のリダイレクト URI と
-クライアントシークレットが必要になる。
-
-```powershell
-python .github/skills/mcp-server/scripts/configure_connector_oauth.py `
-  --audience $env:MCP_API_AUDIENCE --secret-out .secrets/connector-oauth.json
-```
-
-このスクリプトは以下を行う。
-
-1. リダイレクト URI `https://global.consent.azure-apim.net/redirect` を追加する（全カスタムコネクタ共通の固定値）。
-2. クライアントシークレットを発行する。
-3. 自分自身のスコープへの委任アクセスを `requiredResourceAccess` に追加し、同意を成立させる。
-
-> **シークレットは標準出力に出さず**、`--secret-out` のファイルにだけ書き出す。
-> 出力先は必ず `.gitignore` 対象のパスにする。
-
-## Step 3: カスタム コネクタを作成する
-
-Power Apps（make.powerapps.com）＞ **カスタム コネクタ** ＞ **新しいカスタム コネクタ** ＞
-**OpenAPI ファイルをインポート** で Step 1 の YAML を読み込み、セキュリティ タブで以下を設定する。
-
-| 項目 | 値 |
-|---|---|
-| 認証タイプ | OAuth 2.0 |
-| ID プロバイダー | Azure Active Directory |
-| クライアント ID / クライアント シークレット | Step 2 の出力ファイルの値 |
-| リソース URL | `${MCP_API_AUDIENCE}` |
-| スコープ | `${MCP_API_SCOPE_VALUE}` |
-
-ブラウザ操作は VS Code 統合ブラウザで自動化する。開始前に `AskUserQuestion` で使用する
-Microsoft Edge プロファイルを確認し、回答前はポータルを開かない
-（→ [ブラウザ自動化方針](../../standard/references/browser-automation.md)）。
-
-## Step 4: エージェントにツールとして追加する
-
-Copilot Studio でエージェントを開き、**ツール > ツールの追加** から作成したコネクタを選び、
-接続を作成して追加する。追加後に再公開する。
-
-- **生成オーケストレーションが有効**でないと MCP は使えない。
-- 複数の MCP Server を 1 エージェントに束ねる場合は、エージェントの指示文にも
-  「どの質問でどのサーバーを使うか」を明記する。コネクタの `description` だけでは選択を誤ることがある。
-
-## Step 5: 実測で確認する
-
-Copilot Studio のテスト ペインで、各サーバーの `list_*` 系ツールが呼ばれることを確認する。
-ツールが呼ばれない場合は、まず [verify_mcp_server.py](../scripts/verify_mcp_server.py) を実行して
-サーバー側の Streamable HTTP 準拠を切り分ける（サーバーが原因か、登録が原因かを先に確定させる）。
+`tools/list` の内容は OpenAPI に書かない。接続後に MCP Server から動的に取得される。
 
 ## 参考リンク
 

--- a/.github/skills/mcp-server/references/troubleshooting.md
+++ b/.github/skills/mcp-server/references/troubleshooting.md
@@ -126,6 +126,20 @@ Get-Content "$env:TEMP\publish.log" -Tail 30
 
 ## Copilot Studio との接続
 
+### Add MCP server が `POST .../connectors/apim 400` で失敗する
+
+**症状**: Response に `Name ... did not match validation regex ^[a-zA-Z0-9\-\.]{1,64}$` と表示される。
+Console の Initiator に出る JavaScript スタックだけでは原因は分からないため、ブラウザ開発者ツールの
+**Network > connectors/apim > Response** を確認する。Request Payload は Client secret を含むため共有しない。
+
+**原因**: `Server name` に日本語、空白、アンダースコア等を使い、Power Platform が生成する
+内部コネクタ名の制約に違反している。
+
+**対処**: `Server name` を 1～64 文字の英字・数字・ハイフン・ドットだけにする。
+
+**恒久対策済み**: `generate_copilot_studio_guide.py` の `validate_server_name()` が、入力ガイド生成時に
+不正な名前を検出して、Copilot Studio へ入力する前に中断する。
+
 ### curl では `tools/list` が返るのに、Copilot Studio のコネクタからは接続できない
 
 **原因**: Copilot Studio は **Streamable トランスポートのみ**対応する（SSE は 2025 年 8 月で廃止）。
@@ -145,11 +159,38 @@ Get-Content "$env:TEMP\publish.log" -Tail 30
 
 ### カスタムコネクタの OAuth 同意でリダイレクトが失敗する
 
-**原因**: Entra アプリ登録にカスタムコネクタ共通のリダイレクト URI
-`https://global.consent.azure-apim.net/redirect` が登録されていない。
+**症状**: サインイン時に `AADSTS50011: The redirect URI ... does not match` が表示される。
 
-**対処**: `configure_connector_oauth.py` を実行する（リダイレクト URI 追加・シークレット発行・
-自己スコープへの委任アクセス付与をまとめて行う）。
+**原因**: オンボーディングウィザードが作るカスタムコネクタは、共通 URI
+`https://global.consent.azure-apim.net/redirect` ではなく、末尾にコネクタ ID が付いた URI を送る。
+Entra の Redirect URI は完全一致のため、共通 URI だけでは認証できない。
+
+**対処**: callback URL、または `AADSTS50011` に表示された URI をそのまま追加する。
+
+```powershell
+python .github/skills/mcp-server/scripts/add_connector_redirect_uri.py `
+  --audience $env:MCP_API_AUDIENCE `
+  --redirect-uri "https://global.consent.azure-apim.net/redirect/<connector-id>"
+```
+
+**恒久対策済み**: `add_connector_redirect_uri.py` が URI のホストとパスを検証し、既存 URI を保持したまま
+追加して、Graph の再取得で反映を確認する。Client secret は再発行しない。
+
+### MCP ツールが DLP ポリシーでブロックされ、公開できない
+
+**症状**: ツールに `This tool is blocked by your data loss prevention policy` と表示される。
+
+**原因**: MCP Server は Power Platform のカスタムコネクタとして DLP 評価される。対象コネクタが
+`Blocked` の場合だけでなく、エージェント内でデータを受け渡す他のコネクタと `Business` / `Non-Business`
+グループが異なる場合も違反になる。OAuth の `AADSTS50011` は別問題で、Redirect URI の追加だけでは
+DLP 分類は変わらない。
+
+**対処**: [Copilot Studio の DLP 診断](copilot-studio-dlp.md) に従い、まず読み取り専用スクリプトで
+適用ポリシー、コネクタの明示分類、Host URL パターンを確認する。Copilot Studio のエラー詳細も
+ダウンロードし、違反したポリシー名とコネクタ名を一致させてから管理者が最小変更する。
+
+**恒久対策済み**: `diagnose_copilot_dlp.ps1` は対象環境に適用されるポリシーだけを抽出し、対象カスタム
+コネクタが明示分類されていなければ既定グループを表示する。スクリプトはポリシーを変更しない。
 
 ---
 

--- a/.github/skills/mcp-server/scripts/add_connector_redirect_uri.py
+++ b/.github/skills/mcp-server/scripts/add_connector_redirect_uri.py
@@ -1,0 +1,82 @@
+"""Copilot Studio のコネクタ固有 Redirect URI を Entra アプリへ追加する。
+
+既存の Web redirect URI は保持し、Client secret は作成・更新しない。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
+
+from azure_helper import graph_get, graph_patch  # noqa: E402
+
+REDIRECT_HOST = "global.consent.azure-apim.net"
+REDIRECT_PATH_PREFIX = "/redirect/"
+CONNECTOR_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9.\-]*$")
+
+
+def validate_redirect_uri(value: str) -> None:
+    parsed = urlparse(value)
+    connector_id = parsed.path.removeprefix(REDIRECT_PATH_PREFIX)
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc.lower() != REDIRECT_HOST
+        or not parsed.path.startswith(REDIRECT_PATH_PREFIX)
+        or not CONNECTOR_ID_PATTERN.fullmatch(connector_id)
+        or ".." in connector_id
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise SystemExit(
+            "--redirect-uri には Copilot Studio が表示した "
+            f"https://{REDIRECT_HOST}{REDIRECT_PATH_PREFIX}<connector-id> をそのまま指定してください"
+        )
+
+
+def find_application(audience: str) -> dict:
+    apps = graph_get(f"/applications?$filter=identifierUris/any(u:u eq '{audience}')")['value']
+    if len(apps) != 1:
+        raise SystemExit(f"identifierUris={audience} のアプリ登録が一意に見つかりません: {len(apps)} 件")
+    return apps[0]
+
+
+def add_redirect_uri(audience: str, redirect_uri: str) -> bool:
+    app = find_application(audience)
+    web = app.get("web") or {}
+    redirect_uris = web.get("redirectUris") or []
+    if redirect_uri in redirect_uris:
+        return False
+
+    graph_patch(
+        f"/applications/{app['id']}",
+        {"web": {**web, "redirectUris": [*redirect_uris, redirect_uri]}},
+    )
+    verified = graph_get(f"/applications/{app['id']}?$select=web")
+    if redirect_uri not in ((verified.get("web") or {}).get("redirectUris") or []):
+        raise SystemExit("Redirect URI の追加後検証に失敗しました")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="コネクタ固有 Redirect URI を Entra アプリへ追加する")
+    parser.add_argument("--audience", default=os.getenv("MCP_API_AUDIENCE"), help="api://<app-id>")
+    parser.add_argument("--redirect-uri", required=True, help="callback URL または AADSTS50011 に表示された URI")
+    args = parser.parse_args()
+
+    if not args.audience:
+        raise SystemExit("--audience または MCP_API_AUDIENCE を指定してください")
+    validate_redirect_uri(args.redirect_uri)
+    changed = add_redirect_uri(args.audience, args.redirect_uri)
+    status = "added" if changed else "already registered"
+    print(f"[redirect] {status}: {args.redirect_uri}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/mcp-server/scripts/configure_connector_oauth.py
+++ b/.github/skills/mcp-server/scripts/configure_connector_oauth.py
@@ -2,12 +2,16 @@
 
 カスタムコネクタは認可コードフローで動くため、API アプリ登録に以下が必要になる。
 
-1. リダイレクト URI ``https://global.consent.azure-apim.net/redirect``（コネクタ共通の固定値）
+1. リダイレクト URI ``https://global.consent.azure-apim.net/redirect``（OpenAPI インポート方式の共通値）
 2. クライアントシークレット
 3. 自分自身のスコープへの ``requiredResourceAccess``（同意を成立させるため）
 
+オンボーディングウィザードが生成するパス付き Redirect URI は、コネクタ作成後に
+``add_connector_redirect_uri.py`` で追加する。
+
 シークレットは **標準出力に出さず**、``--secret-out`` のファイルにだけ書き出す。
-ファイルは必ず .gitignore の対象に置くこと。
+ファイルは必ず .gitignore の対象に置くこと。既存ファイルは既定で上書きせず、
+意図的な更新時だけ ``--rotate-secret`` を指定する。
 
 使い方:
     python .github/skills/mcp-server/scripts/configure_connector_oauth.py --audience api://<app-id> --secret-out .secrets/connector.json
@@ -19,7 +23,9 @@ import argparse
 import json
 import os
 import stat
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
@@ -27,6 +33,39 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scrip
 from azure_helper import graph_get, graph_patch, graph_post  # noqa: E402
 
 CONNECTOR_REDIRECT_URI = "https://global.consent.azure-apim.net/redirect"
+
+
+def preflight_secret_output(path: Path, rotate_secret: bool) -> str | None:
+    ignored = subprocess.run(
+        ["git", "check-ignore", "--no-index", "-q", "--", str(path)],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if ignored.returncode != 0:
+        raise SystemExit(f"--secret-out が Git ignore されていません: {path}")
+    old_key_id = None
+    if path.exists():
+        if not path.is_file():
+            raise SystemExit(f"--secret-out はファイルを指定してください: {path}")
+        if not rotate_secret:
+            raise SystemExit(
+                f"OAuth 設定ファイルは既に存在します: {path}\n"
+                "既存の Client secret を使うか、意図的に更新する場合だけ --rotate-secret を指定してください"
+            )
+        try:
+            with path.open("r+b"):
+                pass
+            old_key_id = json.loads(path.read_text(encoding="utf-8")).get("keyId")
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SystemExit(f"既存の OAuth 設定ファイルを安全に置換できません: {path}: {exc}") from exc
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with tempfile.NamedTemporaryFile(dir=path.parent):
+            pass
+    except OSError as exc:
+        raise SystemExit(f"--secret-out の親フォルダへ書き込めません: {path.parent}: {exc}") from exc
+    return old_key_id
 
 
 def find_application(audience: str) -> dict:
@@ -75,10 +114,21 @@ def create_secret(app: dict, display_name: str) -> dict:
 
 
 def write_secret_file(path: Path, payload: dict) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
+        temporary = Path(handle.name)
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+    try:
+        if os.name != "nt":
+            temporary.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
     if os.name != "nt":
         path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def remove_secret(app: dict, key_id: str) -> None:
+    graph_post(f"/applications/{app['id']}/removePassword", {"keyId": key_id})
 
 
 def main() -> int:
@@ -87,28 +137,46 @@ def main() -> int:
     parser.add_argument("--scope", default=os.getenv("MCP_API_SCOPE_VALUE", "MCP.Access"))
     parser.add_argument("--secret-out", default=".secrets/connector-oauth.json")
     parser.add_argument("--secret-name", default="power-platform-custom-connector")
+    parser.add_argument("--rotate-secret", action="store_true", help="既存ファイルを置換して新しい secret を発行する")
     args = parser.parse_args()
 
     if not args.audience:
         raise SystemExit("--audience または MCP_API_AUDIENCE を指定してください")
 
+    out = Path(args.secret_out)
+    old_key_id = preflight_secret_output(out, args.rotate_secret)
+    if args.rotate_secret and out.exists() and not old_key_id:
+        print("[warning] 既存ファイルに keyId がないため、以前の credential は Entra で手動削除してください")
     app = find_application(args.audience)
     ensure_redirect_uri(app)
     ensure_self_permission(app, args.scope)
     secret = create_secret(app, args.secret_name)
 
-    out = Path(args.secret_out)
-    write_secret_file(
-        out,
-        {
-            "clientId": app["appId"],
-            "clientSecret": secret["secretText"],
-            "secretExpiresOn": secret["endDateTime"],
-            "resourceUri": args.audience,
-            "scope": f"{args.audience}/{args.scope}",
-            "redirectUri": CONNECTOR_REDIRECT_URI,
-        },
-    )
+    try:
+        write_secret_file(
+            out,
+            {
+                "clientId": app["appId"],
+                "clientSecret": secret["secretText"],
+                "keyId": secret["keyId"],
+                "secretExpiresOn": secret["endDateTime"],
+                "resourceUri": args.audience,
+                "scope": f"{args.audience}/{args.scope}",
+                "redirectUri": CONNECTOR_REDIRECT_URI,
+            },
+        )
+    except OSError as exc:
+        try:
+            remove_secret(app, secret["keyId"])
+        except Exception as rollback_exc:
+            raise SystemExit(
+                "Client secret の保存とロールバックに失敗しました。Entra で新しい credential を削除してください: "
+                f"{rollback_exc}"
+            ) from exc
+        raise SystemExit(f"Client secret を保存できなかったため、発行した credential を削除しました: {exc}") from exc
+    if old_key_id and old_key_id != secret["keyId"]:
+        remove_secret(app, old_key_id)
+        print("[secret] 以前の credential を削除しました")
     print(f"[secret] {out} に書き出しました（値は表示しません）")
     print(f"[info] clientId={app['appId']} / scope={args.audience}/{args.scope}")
     return 0

--- a/.github/skills/mcp-server/scripts/generate_copilot_studio_guide.py
+++ b/.github/skills/mcp-server/scripts/generate_copilot_studio_guide.py
@@ -1,0 +1,262 @@
+"""Copilot Studio MCP オンボーディングウィザード用のローカル入力ガイドを生成する。
+
+Client secret を含むため、出力先が Git ignore されていなければ生成を拒否する。
+MCP Server ごとに別の出力ファイルを指定すること。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+from urllib.parse import urlparse
+
+SERVER_NAME_PATTERN = re.compile(r"^[A-Za-z0-9.\-]{1,64}$")
+
+
+def require(value: str | None, label: str) -> str:
+    if not value or not value.strip():
+        raise SystemExit(f"{label} を指定してください")
+    return value.strip()
+
+
+def validate_server_name(value: str) -> None:
+    if not SERVER_NAME_PATTERN.fullmatch(value):
+        raise SystemExit(
+            "--server-name は 1～64 文字の英字・数字・ハイフン・ドットだけを使用してください。"
+            "日本語や空白は Power Platform の内部コネクタ名で 400 エラーになります"
+        )
+
+
+def validate_server_url(value: str) -> None:
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment:
+        raise SystemExit("--server-url はクエリとフラグメントを含まない完全な HTTPS URL を指定してください")
+
+
+def ensure_ignored(path: Path) -> None:
+    result = subprocess.run(
+        ["git", "check-ignore", "--no-index", "-q", "--", str(path)],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"出力先が Git ignore されていません: {path}\n"
+            "Client secret の漏えいを防ぐため、先に .gitignore へ追加してください"
+        )
+
+
+def load_secret(path: Path) -> dict:
+    if not path.is_file():
+        raise SystemExit(f"OAuth 設定ファイルが見つかりません: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    for key in ("clientId", "clientSecret", "resourceUri", "scope"):
+        require(payload.get(key), key)
+    return payload
+
+
+def validate_redirect_uri(value: str) -> None:
+    parsed = urlparse(value)
+    path_prefix = "/redirect/"
+    connector_id = parsed.path.removeprefix(path_prefix)
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc.lower() != "global.consent.azure-apim.net"
+        or not parsed.path.startswith(path_prefix)
+        or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9.\-]*", connector_id)
+        or ".." in connector_id
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise SystemExit("--redirect-uri には Copilot Studio が表示したパス付き callback URL を指定してください")
+
+
+def build_markdown(
+    *,
+    server_name: str,
+    server_description: str,
+    server_url: str,
+    display_name: str,
+    tenant_id: str,
+    audience: str,
+    full_scope: str,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str | None,
+) -> str:
+    authorization_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize"
+    token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+    redirect_section = (
+        f"""### Redirect URI (Entra ID)
+
+```text
+{redirect_uri}
+```
+"""
+        if redirect_uri
+        else """### Redirect URI (Entra ID)
+
+コネクタ作成後に表示される callback URL、または `AADSTS50011` に表示された Redirect URI を
+Entra アプリ登録の **認証 > Web > リダイレクト URI** に追加する。
+"""
+    )
+    return f"""# {display_name}
+
+## コネクタ接続時に利用可能
+
+### Display name (optional)
+
+```text
+{display_name}
+```
+
+{redirect_section}
+## Add MCP server
+
+### Server name
+
+```text
+{server_name}
+```
+
+### Server description
+
+```text
+{server_description}
+```
+
+### Server URL
+
+```text
+{server_url}
+```
+
+### Authentication
+
+```text
+OAuth 2.0
+```
+
+### Configuration type
+
+```text
+Manual
+```
+
+### Client ID
+
+```text
+{client_id}
+```
+
+### Client secret
+
+```text
+{client_secret}
+```
+
+### Authorization URL
+
+```text
+{authorization_url}
+```
+
+### Token URL
+
+```text
+{token_url}
+```
+
+### Refresh token URL
+
+```text
+{token_url}
+```
+
+### Scopes
+
+```text
+{full_scope}
+```
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Copilot Studio MCP 接続ガイドを安全に生成する")
+    parser.add_argument("--server-name", default=os.getenv("MCP_CONNECTOR_SERVER_NAME"))
+    parser.add_argument(
+        "--server-description",
+        "--description",
+        dest="server_description",
+        default=os.getenv("MCP_CONNECTOR_SERVER_DESCRIPTION"),
+    )
+    parser.add_argument(
+        "--server-url",
+        "--url",
+        dest="server_url",
+        default=os.getenv("MCP_CONNECTOR_SERVER_URL"),
+    )
+    parser.add_argument("--display-name", default=os.getenv("MCP_CONNECTOR_DISPLAY_NAME"))
+    parser.add_argument("--tenant-id", default=os.getenv("ENTRA_TENANT_ID"))
+    parser.add_argument("--audience", default=os.getenv("MCP_API_AUDIENCE"))
+    parser.add_argument("--scope", default=os.getenv("MCP_API_SCOPE_VALUE"))
+    parser.add_argument(
+        "--secret-file",
+        default=os.getenv("CONNECTOR_SECRET_OUT", ".secrets/connector-oauth.json"),
+    )
+    parser.add_argument("--redirect-uri", help="コネクタ作成後に判明した callback URL")
+    parser.add_argument("--output", default=os.getenv("MCP_CONNECTOR_GUIDE_OUT"))
+    args = parser.parse_args()
+
+    server_name = require(args.server_name, "--server-name")
+    server_description = require(args.server_description, "--server-description")
+    server_url = require(args.server_url, "--server-url")
+    tenant_id = require(args.tenant_id, "--tenant-id")
+    audience = require(args.audience, "--audience")
+    output = Path(require(args.output, "--output"))
+    display_name = args.display_name.strip() if args.display_name and args.display_name.strip() else server_name
+
+    validate_server_name(server_name)
+    validate_server_url(server_url)
+    if args.redirect_uri:
+        validate_redirect_uri(args.redirect_uri)
+    ensure_ignored(output)
+    oauth = load_secret(Path(args.secret_file))
+    if oauth["resourceUri"].rstrip("/") != audience.rstrip("/"):
+        raise SystemExit("OAuth 設定ファイルの resourceUri と --audience が一致しません")
+    stored_scope = oauth["scope"]
+    if args.scope:
+        expected_scope = f"{audience.rstrip('/')}/{args.scope}"
+        if stored_scope != expected_scope:
+            raise SystemExit("OAuth 設定ファイルの scope と --scope が一致しません")
+    else:
+        expected_scope = stored_scope
+
+    markdown = build_markdown(
+        server_name=server_name,
+        server_description=server_description,
+        server_url=server_url,
+        display_name=display_name,
+        tenant_id=tenant_id,
+        audience=audience,
+        full_scope=expected_scope,
+        client_id=oauth["clientId"],
+        client_secret=oauth["clientSecret"],
+        redirect_uri=args.redirect_uri,
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(markdown, encoding="utf-8")
+    if os.name != "nt":
+        output.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    print(f"[guide] {output} を生成しました（Client secret は表示しません）")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Wizard-first registration
- Per-server secret-safe copy/paste guide generator
- ASCII server-name precheck
- Manual OAuth/display-name guidance
- Exact callback URI automation
- Secret preflight/rollback/rotation safety
- copilot-studio-v2 cross-reference

## Validation
- alidate_skill.py against mcp-server: PASS
- alidate_skill.py against copilot-studio-v2: PASS
- AST parse of all cloned mcp-server Python scripts: PASS
- git diff --check: PASS
- Staged-content secret/token, user/app GUID, and non-example Azure-host scan: PASS
- Git status verified exactly the 8 requested paths