### PR TITLE
feat(standard): 開発着手前の DLP 事前チェックを追加

### DIFF
--- a/.github/skills/standard/SKILL.md
+++ b/.github/skills/standard/SKILL.md
@@ -47,6 +47,7 @@ triggers:
 | [インタラクティブ環境セットアップ](references/interactive-setup.md) | PAC CLI + Dataverse API で `.env` を対話的に構成する手順（**プロジェクト開始時に最初に参照**） |
 | [認証リファレンス](references/auth-patterns.md) | auth_helper.py の詳細実装・認証パターン（Dataverse / Flow / **ARM・Azure SQL・Graph・自前 API** のスコープ一覧を含む） |
 | [.env サンプル](references/.env.example) | 全フェーズ共通の `.env` テンプレート（各テーマで `.env` にコピーして値を設定） |
+| [DLP 事前チェック](references/dlp-precheck.md) | **実装着手前**にソリューションが使うコネクタが DLP で使えるかを確認する手順（`check_dlp.py` / `set_dlp_custom_connector.py`） |
 | [Dataverse MCP 登録](references/dataverse-mcp-setup.md) | VS Code / Copilot から Dataverse を直接操作する MCP サーバー登録手順（upsert_skill 等） |
 | [ブラウザ自動化方針](references/browser-automation.md) | ブラウザ起動前に **AskUserQuestion で Edge プロファイルを確認**し、回答前は操作しない。ポータル操作は **VS Code 統合 Playwright ブラウザ**（`playwright-browser_navigate` / `playwright-browser_click` / `playwright-browser_type` / `playwright-browser_handle_dialog` 等）を使う。Playwright MCP サーバー・Playwright 単体ブラウザのインストール・起動は禁止 |
 
@@ -146,6 +147,7 @@ Phase 1（設計）の最初に必ず `architecture` を参照し、IT に詳し
 |---|---|
 | インタラクティブセットアップ | PAC CLI + Dataverse API で `.env` を対話的に構成。環境選択・パブリッシャー/ソリューション選択を AskUserQuestion で進行。詳細は [インタラクティブ環境セットアップ](references/interactive-setup.md) |
 | 共通認証 | `auth_helper.py` による 2 層キャッシュ認証（デバイスコードを繰り返さない）。詳細は [認証リファレンス](references/auth-patterns.md) |
+| DLP 事前チェック | **設計確定後・実装着手前に必ず実行**。`scripts/check_dlp.py` で、使用コネクタがブロックされていないか・Business / Non-business が混在しないかを確認する。詳細は [DLP 事前チェック](references/dlp-precheck.md) |
 | Azure リソース操作 | `scripts/azure_helper.py`（ARM / Graph / Azure SQL / 自前 API）。**`az login` 前提の手順は書かない** — 対話が必要でテナント列挙のハングやセッション失効により非対話完走が崩れるため |
 | `.env` パラメータ | 全フェーズ共通の環境変数（`DATAVERSE_URL` / `TENANT_ID` / `SOLUTION_NAME` / `PUBLISHER_PREFIX` 等）の一元管理 |
 | ソリューション運用 | 全コンポーネントを同一ソリューションに含める。`SOLUTION_NAME` / `PUBLISHER_PREFIX` を全フェーズで統一 |

--- a/.github/skills/standard/references/dlp-precheck.md
+++ b/.github/skills/standard/references/dlp-precheck.md
@@ -1,0 +1,82 @@
+# DLP 事前チェック（開発着手前に必ず実行）
+
+Power Platform のデータ ポリシー（DLP）は、**どのコネクタを組み合わせられるか**を環境単位で制限する。
+設計が終わってから発覚すると、コネクタ選定・アーキテクチャごとやり直しになるため、
+**実装を始める前に**、そのソリューションが使うコネクタが利用可能かを確認する。
+
+## いつ実行するか
+
+- `architecture` スキルで構成を決めた直後（Phase 1 の最後）。
+- 自前 MCP Server / カスタムコネクタを新規に作る前と、Copilot Studio へ登録する前。
+- 既存ソリューションに新しいコネクタを追加するとき。
+
+## 前提
+
+- 認証は `auth_helper.py` のキャッシュを使う。`Add-PowerAppsAccount` や `az login` は使わない。
+- 管理 API の読み取りには Power Platform 管理者相当の権限が必要。権限がない場合は、
+  管理者にこのスクリプトを実行してもらい、出力を共有してもらう。
+- `.env` に `ENV_ID`（対象環境 ID）と `TENANT_ID` を設定しておく。
+
+## Step 1: ソリューションが使うコネクタを洗い出す
+
+| 構成要素 | 確認するコネクタ |
+|---|---|
+| Dataverse（Code Apps / MDA / エージェント） | `shared_commondataserviceforapps` |
+| Copilot Studio エージェント | `shared_powervirtualagents` |
+| Outlook / メール送信 | `shared_office365` |
+| Teams 通知・チャット | `shared_teams` |
+| SharePoint / ファイル | `shared_sharepointonline` |
+| Azure SQL | `shared_sql` |
+| 外部 API 呼び出し（HTTP） | `shared_http` |
+| 自前 MCP Server / カスタムコネクタ | `--custom-host <ホスト名>` で指定 |
+
+## Step 2: 事前チェックを実行する
+
+```powershell
+python .github/skills/standard/scripts/check_dlp.py `
+  --environment-id $env:ENV_ID `
+  --tenant-id $env:TENANT_ID `
+  --connector shared_commondataserviceforapps `
+  --connector shared_office365 `
+  --custom-host func-example-mcp.azurewebsites.net
+```
+
+読み取り専用でポリシーは変更しない。終了コードは 0（問題なし）/ 1（要解消）。
+
+スクリプトは対象環境に**適用される**ポリシーだけを評価する
+（`OnlyEnvironments` は一覧にあるとき、`ExceptEnvironments` は一覧にないときに適用）。
+
+## Step 3: 結果をユーザーに提示する
+
+判定は 3 種類。実装に入る前に、該当する場合はユーザー（および管理者）と解消方針を合意する。
+
+| 判定 | 意味 | 対応 |
+|---|---|---|
+| `Blocked` | そのコネクタはこの環境で使えない | 代替コネクタへ設計変更、または管理者にポリシー変更を依頼 |
+| Business / Non-business の混在 | 同一アプリ・フロー・エージェントで併用できない | どちらかのグループへ寄せる。寄せられないなら構成を分割する |
+| 未分類（カスタムコネクタ） | `Ignore *` に委ねられ分類が確定していない。Copilot Studio でツールがブロック表示になることがある | Step 4 で明示分類する |
+
+## Step 4: カスタムコネクタを明示分類する（必要な場合）
+
+```powershell
+# 既定は dry-run。変更前後の URL 規則を表示するだけ
+python .github/skills/standard/scripts/set_dlp_custom_connector.py `
+  --tenant-id $env:TENANT_ID `
+  --policy "<ポリシーの表示名>" `
+  --host func-example-mcp.azurewebsites.net `
+  --classification General
+
+# 内容を確認してから --apply を付けて適用する
+```
+
+- `--classification` は **併用する他のコネクタと同じグループ**にする
+  （Dataverse が Non-business なら `General`）。違うグループにすると今度は混在で使えなくなる。
+- 既存規則と末尾の `*` 規則は保持され、対象ホストの規則だけが先頭に追加される。
+- テナント全体のポリシーを変更するため、**適用前に必ず dry-run の出力をユーザーに確認してもらう**。
+- 反映には通常 1 時間程度（最大 24 時間）かかる。反映後に Step 2 を再実行して確認する。
+
+## 参考
+
+- [Connector classification](https://learn.microsoft.com/power-platform/admin/dlp-connector-classification)
+- [Custom connector classification](https://learn.microsoft.com/power-platform/admin/dlp-custom-connector-parity)
+- [Configure data policies for agents](https://learn.microsoft.com/microsoft-copilot-studio/admin-data-loss-prevention)

--- a/.github/skills/standard/scripts/check_dlp.py
+++ b/.github/skills/standard/scripts/check_dlp.py
@@ -1,0 +1,133 @@
+"""ソリューション開発前の DLP（データ ポリシー）事前チェック。
+
+対象環境に **適用される** DLP ポリシーを読み取り、そのソリューションが使う
+コネクタが「ブロックされていないか」「同一グループに揃っているか」を判定する。
+読み取り専用でポリシーは一切変更しない。手順の詳細は references/dlp-precheck.md を参照。
+
+```powershell
+python .github/skills/standard/scripts/check_dlp.py `
+  --environment-id $env:ENV_ID `
+  --tenant-id $env:TENANT_ID `
+  --connector shared_commondataserviceforapps `
+  --connector shared_office365 `
+  --custom-host func-example-mcp.azurewebsites.net
+```
+
+終了コード: 0 = 問題なし / 1 = 開発前に解消が必要な問題を検出。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from dlp_helper import (  # noqa: E402
+    applied_policies,
+    classify_connector,
+    connector_id_for,
+    label,
+    list_url_rules,
+    matching_url_rule,
+    normalize_host,
+)
+
+
+def _custom_classification(policy: dict, tenant_id: str | None, host: str) -> tuple[str, str]:
+    """カスタムコネクタの実効分類と、その根拠を返す。"""
+    default = policy.get("defaultConnectorsClassification") or "unknown"
+    if not tenant_id:
+        return default, "既定（--tenant-id 未指定のため URL 規則は未評価）"
+    rule = matching_url_rule(list_url_rules(tenant_id, policy["name"]), host)
+    if rule is None:
+        return default, "既定（一致する URL 規則なし）"
+    classification = rule.get("customConnectorRuleClassification") or "unknown"
+    pattern = rule.get("pattern")
+    if classification == "Ignore":
+        return default, f"既定（URL 規則 '{pattern}' が Ignore のため未分類）"
+    return classification, f"URL 規則 '{pattern}'"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="開発前に DLP ポリシーの影響を確認する（読み取り専用）")
+    parser.add_argument(
+        "--environment-id", default=os.getenv("ENV_ID") or os.getenv("POWER_PLATFORM_ENVIRONMENT_ID")
+    )
+    parser.add_argument("--tenant-id", default=os.getenv("TENANT_ID") or os.getenv("ENTRA_TENANT_ID"))
+    parser.add_argument(
+        "--connector",
+        action="append",
+        default=[],
+        metavar="shared_xxx",
+        help="ソリューションが使う標準コネクタ名（複数指定可）",
+    )
+    parser.add_argument(
+        "--custom-host",
+        action="append",
+        default=[],
+        metavar="HOST",
+        help="カスタムコネクタ／MCP Server のホスト名（複数指定可）",
+    )
+    args = parser.parse_args()
+
+    if not args.environment_id:
+        parser.error("--environment-id（または ENV_ID）が必要です")
+    if not args.connector and not args.custom_host:
+        parser.error("--connector または --custom-host を 1 つ以上指定してください")
+
+    hosts = [normalize_host(host) for host in args.custom_host]
+    policies = applied_policies(args.environment_id)
+    if not policies:
+        print(f"環境 {args.environment_id} に適用される DLP ポリシーはありません。制約なしで開発できます。")
+        return 0
+
+    problems: list[str] = []
+    for policy in policies:
+        print(f"\n=== ポリシー: {policy.get('displayName')} [{policy.get('environmentType')}] ===")
+        print(f"    既定の分類: {label(policy.get('defaultConnectorsClassification') or 'unknown')}")
+        groups: set[str] = set()
+
+        for name in args.connector:
+            classification, explicit = classify_connector(policy, connector_id_for(name))
+            source = "明示分類" if explicit else "既定"
+            print(f"    [標準] {name}: {label(classification)}（{source}）")
+            groups.add(classification)
+            if classification == "Blocked":
+                problems.append(f"{policy.get('displayName')}: {name} がブロックされています")
+
+        for host in hosts:
+            classification, source = _custom_classification(policy, args.tenant_id, host)
+            print(f"    [カスタム] {host}: {label(classification)}（{source}）")
+            groups.add(classification)
+            if classification == "Blocked":
+                problems.append(f"{policy.get('displayName')}: {host} がブロックされています")
+            elif "未分類" in source:
+                problems.append(
+                    f"{policy.get('displayName')}: {host} が未分類です"
+                    "（Copilot Studio 等でツールがブロック扱いになる場合があります）"
+                )
+
+        usable = groups - {"Blocked"}
+        if {"Confidential", "General"} <= usable:
+            problems.append(
+                f"{policy.get('displayName')}: Business と Non-business のコネクタが混在しています"
+                "（同一アプリ／フロー／エージェントでは併用できません）"
+            )
+
+    print("\n--- 判定 ---")
+    if problems:
+        for problem in problems:
+            print(f"NG: {problem}")
+        print("\n開発を始める前に、上記を管理者と解消してください。")
+        print("カスタムコネクタの分類は set_dlp_custom_connector.py で設定できます。")
+        return 1
+
+    print("OK: このソリューションのコネクタ構成は、適用中の DLP ポリシーで利用できます。")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills/standard/scripts/dlp_helper.py
+++ b/.github/skills/standard/scripts/dlp_helper.py
@@ -1,0 +1,207 @@
+"""Power Platform データ ポリシー（DLP）の共通ヘルパー。
+
+``auth_helper`` のキャッシュ済み認証を使うため、``Add-PowerAppsAccount`` や
+``az login`` などの対話サインインは不要。読み取りは常に非対話で完走する。
+
+```python
+from dlp_helper import applied_policies, classify_connector, find_custom_connector
+```
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from auth_helper import get_token  # noqa: E402
+
+BAP_BASE = "https://api.bap.microsoft.com"
+BAP_SCOPE = "https://api.bap.microsoft.com/.default"
+POWERAPPS_BASE = "https://api.powerapps.com"
+POWERAPPS_SCOPE = "https://service.powerapps.com/.default"
+GOVERNANCE = "/providers/PowerPlatform.Governance/v1"
+GOVERNANCE_API_VERSION = "2016-11-01"
+CONNECTOR_API_VERSION = "2017-05-01"
+_TIMEOUT = 60
+
+# 管理センターの表示名と API 上の分類値の対応。
+CLASSIFICATION_LABELS = {
+    "Confidential": "Business",
+    "General": "Non-business",
+    "Blocked": "Blocked",
+    "Ignore": "Ignore",
+}
+DATA_GROUPS = ("Confidential", "General", "Blocked")
+
+
+def _request(method: str, url: str, scope: str, body: dict | None = None) -> Any:
+    response = requests.request(
+        method,
+        url,
+        headers={"Authorization": f"Bearer {get_token(scope=scope)}", "Content-Type": "application/json"},
+        json=body,
+        timeout=_TIMEOUT,
+    )
+    if response.status_code >= 400:
+        raise RuntimeError(f"{method} {url.split('?')[0]} が失敗しました: HTTP {response.status_code}")
+    if not response.content:
+        return None
+    return response.json()
+
+
+def list_policies() -> list[dict[str, Any]]:
+    """テナントから参照できる DLP ポリシーを列挙する。"""
+    url = f"{BAP_BASE}{GOVERNANCE}/policies?$top=50&api-version={GOVERNANCE_API_VERSION}"
+    return (_request("GET", url, BAP_SCOPE) or {}).get("value") or []
+
+
+def environment_names(policy: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for environment in policy.get("environments") or []:
+        if isinstance(environment, str):
+            names.append(environment)
+        elif environment.get("name"):
+            names.append(environment["name"])
+        elif environment.get("id"):
+            names.append(environment["id"].rstrip("/").split("/")[-1])
+    return names
+
+
+def policy_applies(policy: dict[str, Any], environment_id: str) -> bool:
+    """ポリシーのスコープ種別を解釈して、対象環境に適用されるかを判定する。"""
+    names = environment_names(policy)
+    environment_type = policy.get("environmentType")
+    if environment_type == "OnlyEnvironments":
+        return environment_id in names
+    if environment_type == "ExceptEnvironments":
+        return environment_id not in names
+    return True
+
+
+def applied_policies(environment_id: str) -> list[dict[str, Any]]:
+    return [policy for policy in list_policies() if policy_applies(policy, environment_id)]
+
+
+def list_custom_connectors(environment_id: str) -> list[dict[str, Any]]:
+    url = (
+        f"{POWERAPPS_BASE}/providers/Microsoft.PowerApps/scopes/admin/environments/"
+        f"{environment_id}/apis?api-version={CONNECTOR_API_VERSION}"
+    )
+    return (_request("GET", url, POWERAPPS_SCOPE) or {}).get("value") or []
+
+
+def normalize_host(value: str) -> str:
+    """``https://host/path`` でもホスト名だけを返す。不正な文字は拒否する。"""
+    host = value.strip().lower()
+    if host.startswith(("https://", "http://")):
+        from urllib.parse import urlparse
+
+        host = urlparse(host).hostname or ""
+    if not re.fullmatch(r"[a-z0-9.-]+", host):
+        raise ValueError(f"ホスト名として解釈できません: {value}")
+    return host
+
+
+def connector_host(connector: dict[str, Any]) -> str:
+    """カスタムコネクタのバックエンドホストを返す（取得できない場合は空文字）。"""
+    properties = connector.get("properties") or {}
+    for candidate in (
+        properties.get("primaryRuntimeUrl"),
+        (properties.get("backendService") or {}).get("serviceUrl"),
+        *(properties.get("runtimeUrls") or []),
+    ):
+        if candidate:
+            try:
+                return normalize_host(candidate)
+            except ValueError:
+                continue
+    return ""
+
+
+def find_custom_connector(
+    environment_id: str, *, host: str | None = None, connector_name: str | None = None
+) -> dict[str, Any]:
+    """ホスト名またはコネクタ名からカスタムコネクタを 1 件に特定する。"""
+    if not host and not connector_name:
+        raise ValueError("host または connector_name のいずれかを指定してください")
+    target_host = normalize_host(host) if host else None
+    matches = []
+    for connector in list_custom_connectors(environment_id):
+        if connector_name:
+            if connector.get("name") == connector_name:
+                matches.append(connector)
+        elif target_host and (
+            connector_host(connector) == target_host
+            or target_host in json.dumps(connector, ensure_ascii=True).lower()
+        ):
+            matches.append(connector)
+    if not matches:
+        raise RuntimeError(f"カスタムコネクタが見つかりません: {connector_name or target_host}")
+    if len(matches) > 1:
+        raise RuntimeError("条件に一致するコネクタが複数あります。コネクタ名で指定してください")
+    return matches[0]
+
+
+def classify_connector(policy: dict[str, Any], connector_id: str) -> tuple[str, bool]:
+    """(分類, 明示分類かどうか) を返す。未分類なら既定グループを返す。"""
+    for group in policy.get("connectorGroups") or []:
+        for classified in group.get("connectors") or []:
+            if classified.get("id") == connector_id or classified.get("name") == connector_id:
+                return group.get("classification") or "unknown", True
+    return policy.get("defaultConnectorsClassification") or "unknown", False
+
+
+def connector_id_for(name: str) -> str:
+    """``shared_xxx`` 形式の名前を DLP が保持する id 形式へ正規化する。"""
+    if name.startswith("/providers/"):
+        return name
+    return f"/providers/Microsoft.PowerApps/apis/{name}"
+
+
+def list_url_rules(tenant_id: str, policy_name: str) -> list[dict[str, Any]]:
+    """テナントレベルのカスタムコネクタ URL パターン規則を取得する。"""
+    url = (
+        f"{BAP_BASE}{GOVERNANCE}/tenants/{tenant_id}/policies/{policy_name}"
+        f"/urlPatterns?api-version={GOVERNANCE_API_VERSION}"
+    )
+    payload = _request("GET", url, BAP_SCOPE) or {}
+    rules = payload.get("rules")
+    if rules is None:
+        rules = (payload.get("value") or {}).get("rules") or []
+    return sorted(rules, key=lambda rule: rule.get("order", 0))
+
+
+def replace_url_rules(tenant_id: str, policy_name: str, rules: list[dict[str, Any]]) -> Any:
+    """URL パターン規則を丸ごと置き換える（API が全置換のため、既存規則も必ず含めて渡す）。"""
+    url = (
+        f"{BAP_BASE}{GOVERNANCE}/tenants/{tenant_id}/policies/{policy_name}"
+        f"/urlPatterns?api-version={GOVERNANCE_API_VERSION}"
+    )
+    return _request("POST", url, BAP_SCOPE, {"rules": rules})
+
+
+def pattern_matches(pattern: str, host: str) -> bool:
+    """DLP の URL パターン（``*`` ワイルドカード）がホストに一致するかを判定する。"""
+    if pattern == "*":
+        return True
+    regex = "".join(".*" if part == "*" else re.escape(part) for part in re.split(r"(\*)", pattern))
+    return re.fullmatch(regex, f"https://{host}", flags=re.IGNORECASE) is not None
+
+
+def matching_url_rule(rules: list[dict[str, Any]], host: str) -> dict[str, Any] | None:
+    """評価順（先勝ち）で最初に一致した規則を返す。"""
+    for rule in sorted(rules, key=lambda item: item.get("order", 0)):
+        if pattern_matches(str(rule.get("pattern") or ""), host):
+            return rule
+    return None
+
+
+def label(classification: str) -> str:
+    return CLASSIFICATION_LABELS.get(classification, classification)

--- a/.github/skills/standard/scripts/set_dlp_custom_connector.py
+++ b/.github/skills/standard/scripts/set_dlp_custom_connector.py
@@ -1,0 +1,103 @@
+"""テナントレベル DLP ポリシーで、カスタムコネクタ（自前 MCP Server 等）の分類を設定する。
+
+`Ignore *` だけのポリシーではカスタムコネクタが未分類のままになり、
+Copilot Studio でツールが「データ損失防止ポリシーによりブロック」と表示されることがある。
+対象ホストだけに URL パターン規則を 1 本追加して、明示的に分類する。
+
+```powershell
+python .github/skills/standard/scripts/set_dlp_custom_connector.py `
+  --tenant-id $env:TENANT_ID `
+  --policy "Tenant policy" `
+  --host func-example-mcp.azurewebsites.net `
+  --classification General            # 既定は変更内容の表示のみ（dry-run）
+```
+
+実際に適用するときだけ `--apply` を付ける。既存規則と末尾の `*` 規則は保持する。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from dlp_helper import (  # noqa: E402
+    DATA_GROUPS,
+    label,
+    list_policies,
+    list_url_rules,
+    normalize_host,
+    replace_url_rules,
+)
+
+WILDCARD = "*"
+
+
+def _resolve_policy(identifier: str) -> dict:
+    matches = [
+        policy
+        for policy in list_policies()
+        if identifier in (policy.get("name"), policy.get("displayName"))
+    ]
+    if not matches:
+        raise SystemExit(f"ポリシーが見つかりません: {identifier}")
+    if len(matches) > 1:
+        raise SystemExit("同名のポリシーが複数あります。ポリシー名（GUID）で指定してください")
+    return matches[0]
+
+
+def _build_rules(existing: list[dict], pattern: str, classification: str) -> list[dict]:
+    """対象パターンを先頭に、既存規則を維持したまま並べ直す（`*` は必ず末尾）。"""
+    others = [dict(rule) for rule in existing if str(rule.get("pattern")) not in (pattern, WILDCARD)]
+    wildcard = [dict(rule) for rule in existing if str(rule.get("pattern")) == WILDCARD]
+    new_rule = {"customConnectorRuleClassification": classification, "pattern": pattern}
+    ordered = [new_rule, *others, *wildcard]
+    for index, rule in enumerate(ordered, start=1):
+        rule["order"] = index
+    return ordered
+
+
+def _print_rules(title: str, rules: list[dict]) -> None:
+    print(title)
+    for rule in rules:
+        classification = rule.get("customConnectorRuleClassification")
+        print(f"    {rule.get('order')}. {label(classification)} <- {rule.get('pattern')}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="カスタムコネクタの DLP 分類を設定する")
+    parser.add_argument("--tenant-id", default=os.getenv("TENANT_ID") or os.getenv("ENTRA_TENANT_ID"))
+    parser.add_argument("--policy", required=True, help="ポリシーの表示名または名前（GUID）")
+    parser.add_argument("--host", required=True, help="カスタムコネクタのホスト名")
+    parser.add_argument("--classification", required=True, choices=DATA_GROUPS)
+    parser.add_argument("--apply", action="store_true", help="実際にポリシーを更新する")
+    args = parser.parse_args()
+
+    if not args.tenant_id:
+        parser.error("--tenant-id（または TENANT_ID）が必要です")
+
+    host = normalize_host(args.host)
+    pattern = f"https://{host}*"
+    policy = _resolve_policy(args.policy)
+    existing = list_url_rules(args.tenant_id, policy["name"])
+    updated = _build_rules(existing, pattern, args.classification)
+
+    print(f"ポリシー: {policy.get('displayName')} [{policy.get('environmentType')}]")
+    _print_rules("  現在の URL 規則:", existing)
+    _print_rules("  変更後の URL 規則:", updated)
+
+    if not args.apply:
+        print("\ndry-run のため変更していません。適用するには --apply を付けて再実行してください。")
+        return 0
+
+    replace_url_rules(args.tenant_id, policy["name"], updated)
+    _print_rules("\n適用後（再取得）:", list_url_rules(args.tenant_id, policy["name"]))
+    print("\n反映まで通常 1 時間程度（最大 24 時間）かかります。")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
対象環境に適用される DLP ポリシーを auth_helper のキャッシュ認証で読み取り、ソリューションが使うコネクタが利用可能かを実装着手前に判定できるようにした。check_dlp.py（読み取り専用・ブロック/グループ混在/カスタムコネクタ未分類を検出）、set_dlp_custom_connector.py（既定 dry-run、--apply 指定時のみ対象ホストの URL 規則を 1 本追加）、共通ロジックの dlp_helper.py、手順書 eferences/dlp-precheck.md を追加。実環境で「未分類の検出 → 明示分類 → OK 判定」まで検証済み。