### PR TITLE
fix(power-automate): validate binary and Dataverse contracts

### DIFF
--- a/.github/skills/power-automate/SKILL.md
+++ b/.github/skills/power-automate/SKILL.md
@@ -106,12 +106,31 @@ python .github/skills/power-automate/scripts/add_flow_to_solution.py <flow-id>
 
 詳細な設定・トラブルシュートは [references/flow-agent-mcp.md](references/flow-agent-mcp.md) を参照。
 
+コネクター接続は [接続作成標準](references/connection-creation.md) に従う。
+Power Apps API で Connected 接続を先に検索し、存在しない場合だけ VS Code 統合ブラウザで
+接続パラメーターを自動入力する。ユーザー操作は OAuth のアカウント選択・同意に限定し、
+Connected 確認後の接続参照・フロー作成・有効化・テストは API で行う。
+OAuth 完了後は子ページを自動で閉じる。自動クローズできない場合は Connected を API で確認してから、
+その画面を閉じてよいことをユーザーへ明示する。
+
+`HTTP with Microsoft Entra ID` の内部 API、要求本文、権限の実測値は
+[非公開接続 API の実測結果](references/http-entra-connection-private-api.md) を参照する。
+
 ---
 
 ## API アプローチ（Flow agent MCP が使えない場合）
 
 以下は MCP サーバーが利用できない環境向けの **フォールバック手順**。
 Python スクリプトで Dataverse Web API を直接操作する。
+
+定義を送信する前に `scripts/validate_flow_definition.py` の
+`assert_base64_content_contract()` を必ず実行する。JSON の `contentBase64` に実行時の本文を渡す場合は
+`@base64(...)` で明示的にエンコードし、コネクタ出力型の違いによる実行時失敗をデプロイ前に止める。
+Dataverse アクションを含む場合は、参照列をメタデータ API で取得し、
+`assert_required_dataverse_columns()` で列の存在を確認してから既存フローを変更する。
+Lookup を `@odata.bind` で書き込む場合は `ManyToOneRelationships` から
+`ReferencingEntityNavigationPropertyName` を取得し、`require_navigation_property()` で検証する。
+Lookup属性の論理名や表示名からナビゲーションプロパティ名を推測しない。
 
 ## 核心原則: 接続参照（Connection Reference）が有効化成功の鍵
 
@@ -191,13 +210,19 @@ Graph API:     https://graph.microsoft.com/.default          ← ユーザー情
 Dataverse API: https://{org}.crm7.dynamics.com/.default      ← workflow テーブル操作・接続参照作成
 ```
 
-### 接続は環境内に事前作成が必要
+### 接続は Connected 状態で環境内に必要
 
 ```
-❌ API で接続の自動作成はできない
-✅ Power Automate UI で事前に接続を作成 → API ではその接続 ID を参照するのみ
-   https://make.powerautomate.com/connections
+1. Power Apps API で Connected 接続を自動検索する
+2. 見つからない場合だけ、VS Code 統合ブラウザで接続を仮作成する
+3. ユーザーは OAuth のアカウント選択・同意だけを行う
+4. Connected を API で検証し、接続 ID を接続参照へ設定する
 ```
+
+`auth_helper` の既定クライアントには `Connectivity.Connections.Write` がないため、
+新規接続の仮作成はメーカーポータル自身の認証済み API 呼び出しを利用する。
+Microsoft Dataverse も OAuth 接続では同意フローを使用する。詳細は
+[接続作成標準](references/connection-creation.md) を参照する。
 
 ### f-string と式の二重ブレース問題
 

--- a/.github/skills/power-automate/references/.env.example
+++ b/.github/skills/power-automate/references/.env.example
@@ -34,6 +34,16 @@ SP_SITE_URL=https://{tenant}.sharepoint.com/sites/{site}
 SP_LIBRARY_ID={library-id}
 SP_FOLDER_PATH=/Shared Documents/All
 
+# === SharePoint 設計文書自動取り込み（scripts/deploy_document_ingest_flow.py）===
+# HTTP with Microsoft Entra ID 接続は Base Resource URL を Function URL、
+# Microsoft Entra ID Resource URI を MCP_API_AUDIENCE、scope を Document.Ingest にして作成する。
+FILES_MCP_FUNCTION_APP=func-example-files-mcp
+# Connected 接続をAPI検索し、未作成時だけ統合ブラウザでOAuth同意する。
+# 以後は接続IDを再利用する。標準手順: connection-creation.md
+INGEST_HTTP_CONNECTION_ID={shared-webcontents-connection-id}
+# 未指定時は Active な "Extract Drawing Document Metadata" モデルを名前で解決する。
+DOCUMENT_METADATA_AI_MODEL_ID={ai-model-id}
+
 # === Teams 連携（オプション）===
 # 取得元: Teams のチャネル URL / Graph API
 TEAMS_GROUP_ID={group-id}

--- a/.github/skills/power-automate/references/connection-creation.md
+++ b/.github/skills/power-automate/references/connection-creation.md
@@ -1,0 +1,111 @@
+# コネクター接続の作成標準
+
+> 2026-09-07 に `shared_commondataserviceforapps` と `shared_webcontents` で実測した手順。
+
+## 原則
+
+1. Power Apps API で対象環境の Connected 接続を検索する。
+2. Connected 接続があれば、その接続 ID を接続参照へ API で設定して再利用する。
+3. 接続がなければ、VS Code 統合ブラウザでメーカーポータルの接続作成画面を開く。
+4. 接続パラメーターの入力と作成操作はブラウザ自動化で行い、ユーザーは OAuth のアカウント選択・同意だけを行う。
+5. Connected を API で確認し、接続 ID を `.env` に保存する。
+6. 接続参照、フロー作成、有効化、テストは API で行う。
+
+接続の OAuth 同意以外を手動ポータル作業にしない。接続 ID を固定値としてソースコードへ書かず、
+`.env` または Power Apps API の Connected 接続検索から解決する。
+
+**OAuth 完了後はすべて API で実行する。** メーカーポータルを使うのは、Connected 接続が存在しない
+場合の接続パラメーター入力と OAuth 同意フローの開始だけとする。
+
+## auth_helper の責務
+
+`auth_helper.py` の既定クライアントが取得する `https://api.powerplatform.com` トークンには、
+`Connectivity.Connections.Write` が含まれない。そのため、次のように分担する。
+
+| 操作 | 実行経路 |
+|---|---|
+| 既存接続の列挙・Connected 確認 | `auth_helper` + Power Apps API |
+| 新規接続の仮作成 | 統合ブラウザ上のメーカーポータル（ポータル自身の接続 API） |
+| OAuth アカウント選択・同意 | 統合ブラウザの同一コンテキスト子ページ |
+| 認可コードの確定 | メーカーポータルの `confirmConsentCode` |
+| 接続参照・フローの作成 | `auth_helper` + Dataverse / Flow API |
+
+`auth_helper` の権限不足は `HTTP with Microsoft Entra ID` 固有ではない。
+Microsoft Dataverse の OAuth 接続でも、ポータルは同じ接続 API と OAuth フローを使用する。
+
+## Connected 接続を先に検索する
+
+```python
+session = get_session(scope="https://service.powerapps.com/.default")
+response = session.get(
+    f"https://api.powerapps.com/providers/Microsoft.PowerApps/apis/{connector}/connections",
+    params={
+        "api-version": "2016-11-01",
+        "$filter": f"environment eq '{environment_id}'",
+    },
+    timeout=120,
+)
+response.raise_for_status()
+```
+
+`properties.statuses` に `Connected` がある接続だけを採用する。`Error`、`Unauthenticated`、
+異なる Base Resource URL の接続は再利用しない。
+
+## 統合ブラウザで OAuth を完了する
+
+VS Code 統合ブラウザはネイティブの `window.open` をブロックする場合がある。
+その場合も外部ブラウザや Playwright 単体を起動せず、次の手順を使う。
+
+1. メーカーポータルの接続ダイアログへ値を入力する。
+2. `window.open` に渡される OAuth URL とポップアップ ID を一時的に捕捉する。
+3. 同じブラウザコンテキストに子ページを作り、`bringToFront()` でユーザーに表示する。
+4. 子ページへ OAuth URL を遷移させる。
+5. ユーザーが必要なアカウント選択・同意を行う。パスワード、MFA、同意操作は代行しない。
+6. 子ページのリダイレクトが送る次のメッセージを捕捉し、親ページへ同じ origin で転送する。
+
+```json
+{
+  "id": "connectionConsentFlowRedirectParams",
+  "popupId": "{oauth-popup-id}",
+  "code": "{one-time-authorization-code}",
+  "error": null
+}
+```
+
+7. 親ポータルが `POST .../connections/{id}/confirmConsentCode?api-version=1` を実行し、
+   HTTP 200 になることを確認する。
+8. Power Apps API で接続状態が `Connected` になったことを確認する。
+9. OAuth 子ページを自動で閉じ、親の接続ダイアログが閉じたことを確認する。
+
+### OAuth 画面の終了処理
+
+OAuth 子ページの `close()` は統合ブラウザで抑止される場合があるため、接続確定後はブラウザツールから
+子ページを明示的に閉じる。`サインイン中...`、`接続をテスト中...`、空白のリダイレクトページを
+残したまま完了扱いにしない。
+
+ブラウザツールの制約で自動クローズできない場合は、Connected を API で確認した後に、ユーザーへ
+「接続は作成済みです。この OAuth 画面は閉じて問題ありません」と明示する。Connected の確認前に
+閉じてよいとは案内しない。
+
+### 一時秘密値は保存禁止
+
+認可コード、Bearer token、OAuth URL の `data` パラメーターは一時値としてメモリ内だけで扱う。
+チャット、ログ、ファイル、`.env` へ出力・保存しない。
+
+## コネクター別の扱い
+
+| コネクター | 標準 |
+|---|---|
+| Microsoft Dataverse | 既存 Connected 接続を API 検索。なければ統合ブラウザで OAuth を一度完了 |
+| SharePoint / Office 365 系 | 同上。要求されるスコープの同意画面が出た場合だけユーザーが同意 |
+| HTTP with Microsoft Entra ID | Base Resource URL と Resource URI を自動入力し、統合ブラウザで OAuth を一度完了 |
+| API key / Basic / 証明書 | 秘密値を `.env` からブラウザへ直接入力。チャットへ出力しない |
+| サービスプリンシパル対応コネクター | 対話不要の認証を優先できるが、最小権限と秘密情報管理を別途確認 |
+
+## 失敗時のクリーンアップ
+
+OAuth をキャンセルまたは中断して `Error` / `Unauthenticated` の仮接続が残った場合は、
+今回作成した接続 ID と表示名が一致することを確認してから削除する。既存の Connected 接続は削除しない。
+
+非公開 API の URL、要求本文、権限の実測値は
+[HTTP with Microsoft Entra ID 接続の非公開 API](http-entra-connection-private-api.md) を参照する。

--- a/.github/skills/power-automate/references/http-entra-connection-private-api.md
+++ b/.github/skills/power-automate/references/http-entra-connection-private-api.md
@@ -1,0 +1,92 @@
+# HTTP with Microsoft Entra ID 接続の非公開 API
+
+> 2026-09-07 に Power Automate メーカーポータルのネットワークから実測した参考情報。
+> 公開・サポート対象 API ではないため、スクリプトから直接呼ばず、メーカーポータル自身の
+> API 呼び出しとして統合ブラウザ上で利用する。
+
+## 実測した API
+
+Environment ID のハイフンを除いた32文字を30文字と2文字に分けてホストを構成する。
+
+```text
+compact = ENV_ID.replace("-", "")
+host = https://{compact[:30]}.{compact[30:]}.environment.api.powerplatform.com
+
+PUT {host}/connectivity/connectors/shared_webcontents/connections/{32-hex-id}?api-version=1
+DELETE {host}/connectivity/connectors/shared_webcontents/connections/{32-hex-id}?api-version=1
+```
+
+作成要求の本文は次の形だった。
+
+```json
+{
+  "properties": {
+    "environment": { "name": "{ENV_ID}" },
+    "connectionParametersSet": {
+      "name": "EntraAuth",
+      "values": {
+        "Token": {
+          "value": "https://global.consent.azure-apim.net/redirect/webcontents"
+        },
+        "BaseResourceUrl": {
+          "value": "https://{FUNCTION_APP}.azurewebsites.net"
+        },
+        "Token:ResourceUri": {
+          "value": "api://{APPLICATION_ID}"
+        },
+        "privacySetting": { "value": "None" }
+      }
+    },
+    "displayName": "{DISPLAY_NAME}"
+  }
+}
+```
+
+## 認証
+
+メーカーポータルの要求は次のBearer tokenを使用していた。
+
+| 項目 | 実測値 |
+|---|---|
+| audience | `https://api.powerplatform.com` |
+| client application ID | `{MAKER_PORTAL_CLIENT_ID}` |
+| required scope | `Connectivity.Connections.Write` |
+
+通常の `auth_helper.get_token(scope="https://api.powerplatform.com/.default")` で同じPUTを実行すると、
+`403 InsufficientDelegatedPermissions` になった。既定クライアントには
+`Connectivity.Connections.Write` が付与されていない。
+
+## PUT 後の状態
+
+PUT自体はポータルから `201 Created` になったが、レスポンスは次の状態だった。
+
+```json
+{
+  "statuses": [
+    {
+      "status": "Error",
+      "target": "Token",
+      "error": {
+        "code": "Unauthenticated",
+        "message": "This connection is not authenticated."
+      }
+    }
+  ]
+}
+```
+
+その後、ポータルはOAuth同意ポップアップを開く。ポップアップをブロックまたはキャンセルすると、
+作成した仮接続へDELETEを送り削除する。したがってPUTだけではConnectedな接続を作れない。
+
+## 採用判断
+
+- **接続の完全な非対話作成は不可**: Power Platform API用の委任権限と、対象リソースへのユーザーOAuth同意が必要。
+- **`auth_helper` からの直接 PUT は採用しない**: 既定クライアントに `Connectivity.Connections.Write` がない。
+- **正常系**: 統合ブラウザでメーカーポータルに接続パラメーターを自動入力し、ユーザー操作をOAuth同意だけに限定する。
+- **一度作成した接続の再利用はAPI化する**: 接続IDを `.env` に保存し、接続参照とフローはDataverse / Flow APIで作成する。
+- **CI/CD**: OAuth接続を事前準備として扱い、Connected接続IDをシークレットストアから参照する。非公開APIをCI/CDから直接呼ばない。
+- PAC CLI 2.8.1 の `pac connection create` はDataverse接続用で、`shared_webcontents` の接続パラメーターは指定できない。
+
+Microsoft Dataverseでも同じ内部PUT、OAuthリダイレクト、`confirmConsentCode` が使われることを実測した。
+統合ブラウザでネイティブポップアップがブロックされる場合の手順は
+[接続作成標準](connection-creation.md) を参照する。

--- a/.github/skills/power-automate/references/troubleshooting.md
+++ b/.github/skills/power-automate/references/troubleshooting.md
@@ -34,6 +34,42 @@ except Exception as e:
 | フロー実行時に接続エラー                | 接続が Error/Disconnected 状態                 | Power Automate UI で接続を再認証                               |
 | `AppLeaseMissing` / `ConnectionNotFound` | 環境が変わった / 接続 ID が古い               | PowerApps API で毎回 Connected 接続を検索                     |
 
+## `contentBase64` が不正、または `$content` を選択できない
+
+SharePoint の `Get file content` は、利用する operation と実行環境により本文が
+`{"$content": "..."}` 形式ではなく平文 `String` として返る場合がある。
+
+| 症状 | 原因 | 対処 |
+| --- | --- | --- |
+| Function が `contentBase64 が不正` を返す | `body('Get_File_Content')` の平文を Base64 契約へそのまま渡した | `@base64(body('Get_File_Content'))` を渡す |
+| `Property '$content' cannot be selected` | 実際の本文型が Object ではなく String | `$content` 選択をやめ、本文全体を `base64()` へ渡す |
+
+恒久対策済み: `scripts/validate_flow_definition.py` の
+`assert_base64_content_contract()` が、実行時の `contentBase64` 値に `@base64(...)` がない定義を
+デプロイ前に拒否する。定義生成スクリプトから毎回呼び出す。
+
+## Dataverse `Could not find a property named ...`
+
+Dataverse コネクタの `$filter` や item で、表示名から推測した列名を使うと実行時に400になる。
+特に図面番号・改訂番号などが専用列ではなくPrimary Name列に格納されている設計では、
+`<prefix>_name` が正しい場合がある。`EntityDefinitions(LogicalName='<table>')/Attributes` から
+実列名を取得し、推測せず照合する。
+
+恒久対策済み: `scripts/validate_flow_definition.py` の
+`assert_required_dataverse_columns()` へメタデータAPIで取得した列集合とフローの必須列集合を渡し、
+既存フローの削除・更新より前に不一致を拒否する。
+
+## Lookup の `@odata.bind` が undeclared property になる
+
+Lookup属性の論理名と `@odata.bind` に使うナビゲーションプロパティ名は一致するとは限らず、
+大文字小文字も区別される。属性名や表示名から組み立てず、対象テーブルの
+`ManyToOneRelationships` を `ReferencedEntity` と `ReferencingAttribute` で絞り、
+`ReferencingEntityNavigationPropertyName` を使用する。
+
+恒久対策済み: `scripts/validate_flow_definition.py` の `require_navigation_property()` が
+空または不正な関係メタデータをデプロイ前に拒否する。デプロイスクリプトはこの関数で解決した値だけを
+`<navigation-property>@odata.bind` に使用する。
+
 ## ジョブ行キューを消化するフローの落とし穴（検証済 2026-08-13）
 
 Dataverse の「行が追加された場合」トリガーでキュー行を拾い、対象を採点して書き戻す

--- a/.github/skills/power-automate/scripts/validate_flow_definition.py
+++ b/.github/skills/power-automate/scripts/validate_flow_definition.py
@@ -1,0 +1,78 @@
+"""Power Automate definition checks that run before deployment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _walk(value: Any, path: str = "$"):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}"
+            yield child_path, key, child
+            yield from _walk(child, child_path)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            yield from _walk(child, f"{path}[{index}]")
+
+
+def assert_base64_content_contract(definition: dict[str, Any]) -> None:
+    """Reject contentBase64 fields that pass a runtime body without encoding it."""
+    errors: list[str] = []
+    for path, key, value in _walk(definition):
+        if key != "contentBase64":
+            continue
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"{path}: contentBase64 must be a non-empty string")
+            continue
+        expression = value.strip()
+        if expression.startswith("@"):
+            normalized = expression.replace(" ", "").lower()
+            if not normalized.startswith("@base64("):
+                errors.append(f"{path}: runtime contentBase64 values must use @base64(...)")
+    if errors:
+        raise ValueError("Invalid flow binary-content contract:\n" + "\n".join(errors))
+
+
+def assert_required_dataverse_columns(
+    available: dict[str, set[str]],
+    required: dict[str, set[str]],
+) -> None:
+    """Reject a flow deployment when referenced Dataverse columns are absent."""
+    errors: list[str] = []
+    for table, expected in required.items():
+        missing = sorted(expected - available.get(table, set()))
+        if missing:
+            errors.append(f"{table}: {', '.join(missing)}")
+    if errors:
+        raise ValueError("Missing Dataverse columns:\n" + "\n".join(errors))
+
+
+def require_navigation_property(rows: list[dict[str, Any]], context: str) -> str:
+    """Return a Dataverse navigation property or fail before flow deployment."""
+    if not rows:
+        raise ValueError(f"Dataverse navigation property not found: {context}")
+    value = rows[0].get("ReferencingEntityNavigationPropertyName")
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Invalid Dataverse navigation property: {context}")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a Power Automate workflow definition JSON file")
+    parser.add_argument("definition", type=Path)
+    args = parser.parse_args()
+    payload = json.loads(args.definition.read_text(encoding="utf-8"))
+    definition = payload.get("properties", {}).get("definition", payload)
+    if not isinstance(definition, dict):
+        raise SystemExit("Workflow definition must be a JSON object")
+    assert_base64_content_contract(definition)
+    print("OK: flow definition validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Power Automate フローのデプロイ前に contentBase64、Dataverse 列、Lookup navigation property を検証する恒久対策を追加します。SharePoint Get file content の実行時出力型差異と @odata.bind の推測による失敗を、正常系の毎回の検証で防止します。マージ順: #412 の後に本 PR。