### PR TITLE
docs: 認証方式の確認をユーザーに求めず自動検証に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cp .github/skills/standard/references/gitignore-template .gitignore
 6. `npx degit geekfujiwara/CodeAppsDevelopmentStandard/.github/agents .github/agents` と `npx degit geekfujiwara/CodeAppsDevelopmentStandard/.github/skills .github/skills` を実行し、admin スキルを含むスキル一式とエージェント定義を取得する。
 7. `python -m pip install -r .github/skills/standard/scripts/requirements.txt` を実行する。
 8. クラウド側の準備に進めるよう、`.env` に設定する `TENANT_ID` / `ENV_ID` / `DATAVERSE_URL` の値をユーザーに確認する。
-9. **認証をキャッシュする前に、認証方式をユーザーに確認する。** 既定は **DEVICE CODE 認証**（別デバイス/ブラウザでコードを入力する方式）。組織の条件付きアクセス ポリシー等でデバイスコードフローがブロックされている場合は、ローカルブラウザでの**インタラクティブ認証**に切り替えられる。どちらを使うかをユーザーに確認し、インタラクティブを選んだ場合のみ `.env` に `AUTH_MODE=interactive` を追加する（DEVICE CODE のままでよい場合は `.env` に何も追加しない、または `AUTH_MODE=device_code` を明示してもよい）。この確認は、フェーズ 2 で最初に認証が行われる前に完了させること。
+9. **認証方式はユーザーに確認せず、エージェントが順に検証してキャッシュできる方式を採用する。** まず `.env` に `AUTH_MODE=interactive` を設定し、ローカルブラウザでの**インタラクティブ認証**で `AuthenticationRecord`（認証キャッシュ）が作成できるかを検証する。失敗する、またはブラウザ操作ができない環境（ヘッドレスセッション等）では、`.env` から `AUTH_MODE=interactive` を削除（または `AUTH_MODE=device_code` に変更）し、既定の **DEVICE CODE 認証** で再試行する。どちらの方式でキャッシュに成功したかを結果として報告する。この検証は、フェーズ 2 で最初に認証が行われる前に完了させること。
 
 検証コマンド:
 - git --version / node --version / npm --version / npx --version / degit --version
@@ -137,7 +137,7 @@ cp .github/skills/standard/references/gitignore-template .gitignore
 
 ## フェーズ 2: Power Platform 管理者権限の確認（ここで即座に判断する）
 1. `.github/skills/admin/SKILL.md` と `.github/skills/admin/references/admin-roles.md` を読み込み、これ以降の操作に必要な最小ロール（Power Platform Administrator 等）を把握する。
-2. `python .github/skills/admin/scripts/check_environment.py --environment-id $env:ENV_ID` を実行し、「管理 API アクセス」（管理者ロール相当か）の判定を確認する。（フェーズ 1 の手順 9 で確認した認証方式で初回のみ認証が行われる。以降はキャッシュからサイレントに認証され、再実行時は非対話で完走する。）
+2. `python .github/skills/admin/scripts/check_environment.py --environment-id $env:ENV_ID` を実行し、「管理 API アクセス」（管理者ロール相当か）の判定を確認する。（フェーズ 1 の手順 9 で採用が確定した認証方式で初回のみ認証が行われる。以降はキャッシュからサイレントに認証され、再実行時は非対話で完走する。）
 3. 管理者権限がない、または判定が NG の場合は、**ここで作業を中断**し、次を報告して終了する。無理に自分の端末や権限で回避しようとしないこと。
    - 何が不足しているか（必要ロール名）
    - 管理者に依頼すべき内容（環境作成・セキュリティ ロール割り当て・Copilot Credits 割り当て・ACP 設定など）
@@ -391,10 +391,8 @@ python -m pip install -r .github/skills/standard/scripts/requirements.txt
 - `.env` に **`TENANT_ID`** を設定します。認証キャッシュはテナントごとに
   `~/.power-platform-cli/auth_record_{TENANT_ID}.json` へ分離保存されるため、複数テナントを行き来しても再認証は最小限で済みます。
 - 環境 ID を使うスクリプト（DLP 事前チェックなど）では **`ENV_ID`** も設定します。
-- **初回に認証をキャッシュする前に、DEVICE CODE 認証（既定）とインタラクティブ認証のどちらを使うかを確認してください。**
-  - 既定は **DEVICE CODE 認証**（表示されたコードを別のデバイス／ブラウザで入力する方式）です。`.env` に何も追加しなければこの方式になります。
-  - 組織の条件付きアクセスポリシー等でデバイスコードフローがブロックされている場合は、`.env` に `AUTH_MODE=interactive` を設定すると、ローカルブラウザを起動する**インタラクティブ認証**に切り替わります。
-  - どちらの方式でも、**初回のみ**認証画面が表示されます。以降はキャッシュからサイレントに認証され、スクリプトは非対話で完走します。
+- **初回の認証キャッシュは、ユーザーに確認せず自動で検証します。** まず `.env` に `AUTH_MODE=interactive` を設定してローカルブラウザでの**インタラクティブ認証**を試し、キャッシュ（`AuthenticationRecord`）が作成できるか確認します。ブラウザ操作ができない環境などで失敗した場合は、`AUTH_MODE=interactive` を削除（または `AUTH_MODE=device_code` に変更）し、既定の **DEVICE CODE 認証**（表示されたコードを別のデバイス／ブラウザで入力する方式）にフォールバックします。
+  - どちらの方式でキャッシュされても、**初回のみ**認証画面が表示されます。以降はキャッシュからサイレントに認証され、スクリプトは非対話で完走します。
   毎回認証を求められる場合は、`.env` の `TENANT_ID` が未設定でないかを確認してください。
 - サインインできたら、開発に入る前に [Power Platform 環境のチェック](#power-platform-環境のチェック開発着手前に必須) を実行してください。
 


### PR DESCRIPTION
## 概要

前回PR(#424)でユーザーに確認する形にした認証方式(DEVICE CODE/インタラクティブ)の選択を、ユーザーに確認せずエージェントが自動で検証する形に変更する。

## 変更点
- フェーズ1手順9: まずインタラクティブ認証(AUTH_MODE=interactive)でキャッシュを試行し、失敗すれば既定のDEVICE CODE認証にフォールバックする（ユーザー確認は行わない）
- 『Python パッケージと初回サインイン』節も同様に自動検証・フォールバックの説明に変更