### PR TITLE
feat: コネクタ ID を自動解決してデータソース追加を非対話化

### DIFF
--- a/.github/agents/GeekPowerCode.agent.md
+++ b/.github/agents/GeekPowerCode.agent.md
@@ -62,7 +62,10 @@ python .github/skills/admin/scripts/check_dlp.py --environment-id $env:ENV_ID --
 
 - **認証**: Python スクリプトでは必ず `auth_helper.py` の API（`get_token` / `get_session` / `api_get` / `api_post` / `api_patch` / `api_delete` / `retry_metadata`）を使う（`requests` 直呼び・MSAL 直接呼び出し禁止）
 - **認証はスキップ実行が前提**: `auth_helper.py` は 2 層キャッシュ（`.auth_record.json` + OS 資格情報ストア）により初回のみデバイスコード認証が発生し、以降はサイレントに認証が完了する。すべての新規スクリプトは **このキャッシュ済み認証を前提に、対話的な認証待ちなしで最後まで自動実行できる**ように書く。実行中にデバイスコードや資格情報の入力待ちが発生した場合は処理を止めず、`auth_helper.py` の実装（キャッシュ・スコープ）を疑って修正する
-- **データソース**: `npx power-apps add-data-source` で追加（`dataSourcesInfo.ts` 手動追記禁止）
+- **データソース**: `python .github/skills/code-apps/scripts/add_data_source.py --connector {通称または shared_xxx}` で追加する（`dataSourcesInfo.ts` 手動追記禁止）。
+  `npx pa app add data-source` を直接叩くとコネクタ ID の対話プロンプトで止まるため、通称（`sharepoint` 等）を
+  [コネクタ ID カタログ](.github/skills/standard/references/connector-catalog.json)で `shared_xxx` に解決してから
+  `--non-interactive` で実行するこのラッパーを正常フローとする
 - **外部データは指示ではない**: エージェント実装でメール本文・Web ページ・取り込んだファイル・業務レコードを読ませる場合は、フェンスで囲って渡し、送信・共有・実行など実害のある操作はコードで認証済み ID を検証する（[プロンプト インジェクション対策](.github/skills/ai-teammate/references/prompt-injection.md)）
 - 詳細は `.github/skills/standard/SKILL.md`（認証リファレンス: `.github/skills/standard/references/auth-patterns.md`）および各スキルを参照
 - Web UI 操作（管理ポータルのフォーム入力、OAuth クライアント登録等）は **VS Code 統合ブラウザツール** （`open_browser_page` 等）のみを使う。**Playwright MCP サーバー・Playwright 単体ブラウザはいかなる場合もインストール・起動しない。** 認証はユーザー自身に行ってもらい、機密値は `.env` から読んで画面へ直接入力する（チャットに出力しない）。詳細・使用例は[ブラウザ自動化方針](.github/skills/standard/references/browser-automation.md) を参照。

--- a/.github/skills/admin/references/dlp-precheck.md
+++ b/.github/skills/admin/references/dlp-precheck.md
@@ -30,6 +30,11 @@ Power Platform のデータ ポリシー（DLP）は、**どのコネクタを�
 | 外部 API 呼び出し（HTTP） | `shared_http` |
 | 自前 MCP Server / カスタムコネクタ | `--custom-host <ホスト名>` で指定 |
 
+`--connector` には **通称も渡せる**（`sharepoint` → `shared_sharepointonline`）。
+対応表は [コネクタ ID カタログ](../../standard/references/connector-catalog.json)。
+一覧は `python .github/skills/standard/scripts/connector_catalog.py --list` で確認できる。
+候補が複数になる通称（`azure` など）は問い合わせずに候補を出して停止するため、コネクタ ID で指定し直す。
+
 ## Step 2: 事前チェックを実行する
 
 ```powershell

--- a/.github/skills/admin/scripts/check_dlp.py
+++ b/.github/skills/admin/scripts/check_dlp.py
@@ -35,6 +35,9 @@ from dlp_helper import (  # noqa: E402
     normalize_host,
 )
 
+# dlp_helper が standard/scripts を sys.path に追加済み
+from connector_catalog import ConnectorResolutionError, resolve_connector_id  # noqa: E402
+
 
 def _custom_classification(policy: dict, tenant_id: str | None, host: str) -> tuple[str, str]:
     """カスタムコネクタの実効分類と、その根拠を返す。"""
@@ -61,8 +64,8 @@ def main() -> int:
         "--connector",
         action="append",
         default=[],
-        metavar="shared_xxx",
-        help="ソリューションが使う標準コネクタ名（複数指定可）",
+        metavar="CONNECTOR",
+        help="標準コネクタのコネクタ ID または通称（例: shared_sharepointonline / sharepoint。複数指定可）",
     )
     parser.add_argument(
         "--custom-host",
@@ -78,6 +81,14 @@ def main() -> int:
     if not args.connector and not args.custom_host:
         parser.error("--connector または --custom-host を 1 つ以上指定してください")
 
+    # 通称（sharepoint 等）でもコネクタ ID でも受け付ける。曖昧な場合は問い合わせず停止する。
+    connectors: list[str] = []
+    for name in args.connector:
+        try:
+            connectors.append(resolve_connector_id(name))
+        except ConnectorResolutionError as exc:
+            parser.error(str(exc))
+
     hosts = [normalize_host(host) for host in args.custom_host]
     policies = applied_policies(args.environment_id)
     if not policies:
@@ -90,7 +101,7 @@ def main() -> int:
         print(f"    既定の分類: {label(policy.get('defaultConnectorsClassification') or 'unknown')}")
         groups: set[str] = set()
 
-        for name in args.connector:
+        for name in connectors:
             classification, explicit = classify_connector(policy, connector_id_for(name))
             source = "明示分類" if explicit else "既定"
             print(f"    [標準] {name}: {label(classification)}（{source}）")

--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -13,6 +13,10 @@ triggers:
   - "Code Apps 共有"
   - "add data-source"
   - "add-data-source"
+  - "コネクタ ID"
+  - "コネクタ追加"
+  - "shared_sharepointonline"
+  - "データソース追加"
   - "DataverseService"
   - "Tailwind"
   - "shadcn"
@@ -133,7 +137,7 @@ Code Apps 開発は **設計 → 初回デプロイ → データソース接続
 |---|---|
 | §1 概要（本章） | 標準ワークフロー全体像・大前提・設計フェーズ（デザインテンプレート選択） |
 | [§2 初回デプロイ](#2-初回デプロイ) | 環境前提・scaffold・ソリューション/接続参照の準備・init・初回 build & push |
-| [§3 データソース接続](#3-データソース接続) | add-data-source（接続参照バインド）・MicrosoftDataverseService・Lookup 名前解決 |
+| [§3 データソース接続](#3-データソース接続) | add_data_source.py（コネクタ ID 自動解決・非対話）・接続参照バインド・MicrosoftDataverseService・Lookup 名前解決 |
 | [§4 改善デプロイ](#4-改善デプロイ) | 開発時の必須ルール・再デプロイ・プレデプロイレビュー |
 | [§5 リファレンス](#5-リファレンス) | 全リファレンス索引・技術スタック・.env |
 
@@ -372,7 +376,43 @@ python scripts/review_report.py --verdict-dir .gate --out .gate/review-report.md
 
 ## 3. データソース接続
 
-### 正常系: Microsoft Dataverse connector（`shared_commondataserviceforapps`）
+### 正常系: コネクタ ID は聞かずに解決する（`add_data_source.py`）
+
+`npx pa app add data-source` はコネクタ ID や接続を省略すると **対話プロンプトで停止**し、
+スクリプト実行・CI・エージェント実行が入力待ちのまま固まる。これを避けるため、
+データソース追加は次のラッパーを**正常フロー**とする。コネクタは「SharePoint」「Outlook」などの
+**通称で指定でき、スクリプトが `shared_xxx` に解決**してから `--non-interactive` で CLI を起動する。
+
+```powershell
+# SharePoint（接続は環境内に 1 つなら自動選択）
+python .github/skills/code-apps/scripts/add_data_source.py --connector sharepoint `
+  --dataset "{SITE_URL}" --table "{LIST_ID}"
+
+# Dataverse（ALM 標準: 接続参照バインド。--org-url は .env の DATAVERSE_URL を既定値にする）
+python .github/skills/code-apps/scripts/add_data_source.py --connector dataverse `
+  --connection-ref {CONNECTION_REFERENCE_LOGICAL_NAME} --solution-id {SOLUTION_ID}
+
+# 使えるコネクタの通称一覧 / 実行せずコマンドだけ確認
+python .github/skills/code-apps/scripts/add_data_source.py --list-connectors
+python .github/skills/code-apps/scripts/add_data_source.py --connector teams --dry-run
+```
+
+| 解決すること | 方法 |
+|---|---|
+| コネクタ ID | [コネクタ ID カタログ](../standard/references/connector-catalog.json) の通称・別名で解決。無ければ `pa connector list --search` で環境から解決 |
+| バインド先 | `--connection-ref` + `--solution-id`（ALM 標準）。未指定なら `pa connection list` で接続を 1 つに絞れたときだけ自動選択 |
+| 追加値 | `--org-url` / `--dataset` / `--table` / `--procedure`。コネクタごとの必須項目はカタログの `requires` |
+
+> **ハングしない仕組み**: CLI は必ず `--non-interactive` かつ **標準入力を閉じた状態**で起動し、
+> `--timeout`（既定 600 秒）を超えたら停止する。値が足りないときはプロンプトを出さずに
+> `NG:` と不足項目・取得コマンドを表示して終了コード 1 で止まる。
+> **候補が複数のときも勝手に選ばず**、候補一覧を出して止める（誤ったコネクタへのバインドを防ぐため）。
+
+> **カタログに無いコネクタ**: `--connector shared_xxx` のように ID を直接渡せばそのまま通る。
+> 繰り返し使うものは [connector-catalog.json](../standard/references/connector-catalog.json) に
+> `id` / `displayName` / `aliases` / `requires` を追記する（他スキルの DLP 事前チェックでも同じ通称が使える）。
+
+### Microsoft Dataverse connector（`shared_commondataserviceforapps`）
 
 Dataverse 接続は **`shared_commondataserviceforapps` を 1 回だけ追加する方式を標準**とする。これにより、テーブルごとに `add data-source` を繰り返さなくても、生成された `MicrosoftDataverseService` から `entityName` を実行時に渡して全テーブルへ CRUD できる。
 
@@ -381,7 +421,7 @@ Dataverse 接続は **`shared_commondataserviceforapps` を 1 回だけ追加す
 バインド先は **接続 ID ではなく接続参照（`--connection-ref`）を標準**とする。接続はソリューション コンポーネントになれないが、接続参照はなれるため、環境間移送ができる。
 
 ```bash
-# Step 1 で作成済みの接続参照にバインドする
+# Step 1 で作成済みの接続参照にバインドする（add_data_source.py が内部で実行するコマンド）
 npx pa app add data-source --connector shared_commondataserviceforapps \
   --connection-ref {CONNECTION_REFERENCE_LOGICAL_NAME} \
   --solution-id {SOLUTION_ID} \
@@ -603,6 +643,7 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 |---|---|
 | [check_code_apps_environment.py](scripts/check_code_apps_environment.py) | マネージド環境 / Code Apps 許可の前提条件を確認（`pa app init` の前に実行） |
 | [setup_connection_reference.py](scripts/setup_connection_reference.py) | 接続参照をソリューションに用意する（既存流用ファースト→Web API で新規作成）。Step 1 で実行 |
+| [add_data_source.py](scripts/add_data_source.py) | データソースを**非対話**で追加する。コネクタの通称（`sharepoint` 等）を `shared_xxx` に解決し、接続・必須値を確定してから `--non-interactive` で CLI を起動する。Step 3 の標準 |
 | [pre-deploy-check.mjs](scripts/pre-deploy-check.mjs) | `.env` / `power.config.json` / モック実行基盤の本番混入を検証（`npm run predeploy`）。プロジェクト直下の `scripts/` にコピーして使う |
 | [inspect_table_metadata.py](scripts/inspect_table_metadata.py) | 既存テーブルの EntitySetName / 主キー / 列 / 参照先 / 選択肢を調査（既存テーブル接続時は実装前に必須） |
 | [validate_cli_reference.py](scripts/validate_cli_reference.py) | テンプレート採用版の `pa app share --help` と CLI リファレンスの主要オプション・実行例が一致することを検証 |

--- a/.github/skills/code-apps/references/cli-reference.md
+++ b/.github/skills/code-apps/references/cli-reference.md
@@ -297,10 +297,17 @@ npx pa app add data-source --connector shared_commondataserviceforapps \
 | `--connector` | コネクタ ID（`shared_commondataserviceforapps`, `shared_sql` など）。旧 `--api-id` の後継 |
 | `-c, --connection-id` | 接続 ID（ソリューションに入らない。PoC 用） |
 | `--connection-ref` | 接続参照名（**ALM 標準**） |
-| `-d, --dataset` | データセット識別子 |
+| `--table` | テーブル名（SharePoint はリスト） |
+| `-d, --dataset` | データセット識別子（SharePoint はサイト URL、SQL は server,database） |
 | `-u, --org-url` | 組織 URL |
-| `-sp, --sql-stored-procedure` | SQL ストアドプロシージャ名 |
+| `--procedure` | SQL ストアドプロシージャ名 |
 | `-s, --solution-id` | ソリューション ID（`--connection-ref` と併用） |
+
+> [!IMPORTANT]
+> **コネクタ ID を省略すると対話プロンプトで停止する**（スクリプト実行が入力待ちで固まる）。
+> 自動化ではコネクタ ID を自動解決するラッパーを使う:
+> `python .github/skills/code-apps/scripts/add_data_source.py --connector sharepoint`
+> （詳細: [SKILL.md §3 データソース接続](../SKILL.md#3-データソース接続)）
 
 > [!WARNING]
 > `--environment-id` は拒否される（`error: unknown option '--environment-id'`）。

--- a/.github/skills/code-apps/references/connector-reference.md
+++ b/.github/skills/code-apps/references/connector-reference.md
@@ -22,15 +22,23 @@ Power Apps Code Apps でサポートされるコネクタの設定方法と使�
 
 ## コネクタ追加の基本手順
 
-すべてのコネクタは以下の統一手順で追加します:
+すべてのコネクタは **非対話ラッパー**で追加する。コネクタは通称で指定でき、
+スクリプトが [コネクタ ID カタログ](../../standard/references/connector-catalog.json) で `shared_xxx` に解決してから
+`--non-interactive` で CLI を起動する（コネクタ ID の入力待ちで止まらない）。
 
-```bash
-# 1. 接続 ID を確認
-pac connection list
+```powershell
+# 使える通称の一覧
+python .github/skills/code-apps/scripts/add_data_source.py --list-connectors
 
-# 2. コネクタを追加
-pac code add-data-source -a {api-name} -c {connection-id}
+# 追加（接続が環境内に 1 つなら自動選択。複数なら候補を出して停止）
+python .github/skills/code-apps/scripts/add_data_source.py --connector {通称または shared_xxx}
 ```
+
+接続を明示する場合は `--connection-id`（PoC）または `--connection-ref` + `--solution-id`（ALM 標準）を渡す。
+接続 ID の一覧は `npx pa connection list --json` で確認できる。
+
+以下の各節にある `pac code add-data-source -a {api-name} -c {connection-id}` は
+**コネクタ ID と生成物を示すための参考表記**であり、実行は上記ラッパーに寄せる。
 
 追加後、以下が自動生成されます:
 

--- a/.github/skills/code-apps/references/data-source-patterns.md
+++ b/.github/skills/code-apps/references/data-source-patterns.md
@@ -2,12 +2,15 @@
 
 ## 原則
 
-1. **Dataverse コネクタは `npx pa app add data-source` で接続参照に 1 回追加** → `.power/schemas/appschemas/dataSourcesInfo.ts` が自動更新
-2. **手動で `dataSourcesInfo.ts` にカスタムテーブル定義を追記してはならない**
-3. **`systemuser` を含む Dataverse テーブルは生成された `MicrosoftDataverseService` から扱う**。
+1. **データソースの追加は `scripts/add_data_source.py`（非対話ラッパー）で行う**。
+  コネクタは通称（`sharepoint` 等）で指定でき、[コネクタ ID カタログ](../../standard/references/connector-catalog.json)
+  で `shared_xxx` に解決してから CLI を起動するため、コネクタ ID の入力待ちで止まらない
+2. **Dataverse コネクタは接続参照に 1 回追加** → `.power/schemas/appschemas/dataSourcesInfo.ts` が自動更新
+3. **手動で `dataSourcesInfo.ts` にカスタムテーブル定義を追記してはならない**
+4. **`systemuser` を含む Dataverse テーブルは生成された `MicrosoftDataverseService` から扱う**。
   `src/lib/dataSourcesInfo.ts` は生成ファイルを re-export するだけでよく、手動定義は不要
-4. **`src/lib/dataSourcesInfo.ts`** への手動追記は、SDK の `pa app add data-source` で追加**できなかった**システムテーブルやコネクタに限る（最後の手段）
-5. 実行前に `pa auth status` / `pa auth switch` で対象テナントを明示する（詳細: [トラブルシューティング #12](troubleshooting.md#12-npx-power-apps-add-data-source-がテナント不一致で-403-エラー)）。
+5. **`src/lib/dataSourcesInfo.ts`** への手動追記は、SDK の `pa app add data-source` で追加**できなかった**システムテーブルやコネクタに限る（最後の手段）
+6. 実行前に `pa auth status` / `pa auth switch` で対象テナントを明示する（詳細: [トラブルシューティング #12](troubleshooting.md#12-npx-power-apps-add-data-source-がテナント不一致で-403-エラー)）。
   日本語 DisplayName で失敗する場合は `toggle_table_lang.py` で英語化してから再実行する。
   `pac code add-data-source` は npm CLI で解消できない場合のみの移行時代替とする。
 

--- a/.github/skills/code-apps/scripts/add_data_source.py
+++ b/.github/skills/code-apps/scripts/add_data_source.py
@@ -1,0 +1,290 @@
+"""Code Apps のデータソースを **対話プロンプトなし** で追加する。
+
+`npx pa app add data-source` はコネクタ ID や接続を省略すると対話プロンプトで停止し、
+スクリプト実行（CI / エージェント実行）が固まる。このラッパーは実行前に
+
+  1. コネクタの通称（SharePoint / Outlook / SQL …）→ コネクタ ID（`shared_xxx`）
+  2. バインド先（接続参照 または 接続 ID）
+  3. コネクタが必須とする追加値（`--org-url` / `--dataset` / `--table`）
+
+をすべて確定させ、`--non-interactive` かつ **標準入力を閉じた状態** で CLI を起動する。
+値が足りないときはプロンプトを出さずに `NG:` を表示して終了コード 1 で止まるため、
+ターミナルが入力待ちでハングすることはない。
+
+使い方:
+  python .github/skills/code-apps/scripts/add_data_source.py --connector sharepoint
+  python .github/skills/code-apps/scripts/add_data_source.py --connector dataverse \
+      --connection-ref {CR_LOGICAL_NAME} --solution-id {SOLUTION_ID}
+  python .github/skills/code-apps/scripts/add_data_source.py --connector sql \
+      --dataset {server},{database} --table {table}
+  python .github/skills/code-apps/scripts/add_data_source.py --list-connectors
+  python .github/skills/code-apps/scripts/add_data_source.py --connector teams --dry-run
+
+`.env` から既定値を読む:
+  DATAVERSE_URL                       --org-url の既定値
+  ENV_ID                              接続一覧の検索対象環境
+  SOLUTION_ID                         --solution-id の既定値
+  CONNECTION_REFERENCE_LOGICAL_NAME   --connection-ref の既定値
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+    sys.stderr.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+
+# --- standard スキルの connector_catalog を import パスへ ---
+for _candidate in (
+    _SCRIPT_DIR.parent.parent / "standard" / "scripts",
+    *[p / ".github" / "skills" / "standard" / "scripts" for p in _SCRIPT_DIR.parents],
+):
+    if (_candidate / "connector_catalog.py").is_file():
+        sys.path.insert(0, str(_candidate))
+        break
+else:  # noqa: PLW0120
+    sys.exit("NG: connector_catalog.py が見つかりません（standard スキルの scripts を確認）")
+
+for _parent in _SCRIPT_DIR.parents:
+    if (_parent / ".env").is_file():
+        load_dotenv(_parent / ".env")
+        break
+
+from connector_catalog import (  # noqa: E402
+    ConnectorResolutionError,
+    format_catalog,
+    resolve_connector,
+)
+
+CONNECTION_ID_KEYS = ("name", "id", "connectionId", "connectionName")
+CONNECTOR_KEYS = ("connectorId", "apiId", "apiName", "connector", "connectorName", "connectorType")
+DISPLAY_KEYS = ("displayName", "connectionDisplayName", "name")
+
+
+def _npx() -> str:
+    npx = shutil.which("npx")
+    if not npx:
+        sys.exit("NG: npx が見つかりません。Node.js 22 以上をインストールしてください。")
+    return npx
+
+
+def _run_cli(args: list[str], timeout: int) -> subprocess.CompletedProcess[str]:
+    """CLI を標準入力を閉じて実行する（プロンプトが出ても待ち続けない）。"""
+    command = [_npx(), "pa", *args]
+    print(f"$ npx pa {' '.join(args)}")
+    try:
+        return subprocess.run(
+            command,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        sys.exit(
+            f"NG: CLI が {timeout} 秒以内に終了しませんでした。"
+            "対話プロンプト待ちの可能性があります。不足している値をフラグで明示してください。"
+        )
+
+
+def _extract_items(payload: object) -> list[dict]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        for key in ("value", "connections", "connectors", "data", "items", "results"):
+            if isinstance(payload.get(key), list):
+                return [item for item in payload[key] if isinstance(item, dict)]
+    return []
+
+
+def _first(item: dict, keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    properties = item.get("properties")
+    if isinstance(properties, dict):
+        for key in keys:
+            value = properties.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            if isinstance(value, dict) and isinstance(value.get("name"), str):
+                return value["name"].strip()
+    return ""
+
+
+def _connector_of(item: dict) -> str:
+    return _first(item, CONNECTOR_KEYS).rsplit("/", 1)[-1].lower()
+
+
+def _list_json(args: list[str], timeout: int) -> list[dict]:
+    result = _run_cli([*args, "--json", "--non-interactive"], timeout)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        sys.exit(f"NG: `pa {' '.join(args)}` が失敗しました。\n{detail}")
+    stdout = (result.stdout or "").strip()
+    start = min((i for i in (stdout.find("["), stdout.find("{")) if i >= 0), default=-1)
+    if start < 0:
+        return []
+    try:
+        return _extract_items(json.loads(stdout[start:]))
+    except json.JSONDecodeError:
+        return []
+
+
+def resolve_connector_id(name: str, env_id: str, timeout: int) -> str:
+    """カタログで解決し、無ければ環境のコネクタ一覧から一意に解決する。"""
+    try:
+        entry = resolve_connector(name)
+        return entry["id"]
+    except ConnectorResolutionError as exc:
+        print(f"  カタログでは解決できませんでした。環境のコネクタ一覧を検索します。\n  {exc}")
+
+    args = ["connector", "list", "--search", name]
+    if env_id:
+        args += ["--environment-id", env_id]
+    matches = {
+        _connector_of(item): _first(item, DISPLAY_KEYS)
+        for item in _list_json(args, timeout)
+        if _connector_of(item)
+    }
+    if len(matches) == 1:
+        connector_id = next(iter(matches))
+        print(f"  環境のコネクタ一覧から解決しました: {connector_id}")
+        return connector_id
+    if not matches:
+        sys.exit(f"NG: コネクタ '{name}' が環境内に見つかりません。--connector にコネクタ ID を指定してください。")
+    listed = "\n".join(f"    - {cid}  ({display})" for cid, display in sorted(matches.items()))
+    sys.exit(f"NG: コネクタ '{name}' の候補が複数あります。コネクタ ID で指定し直してください。\n{listed}")
+
+
+def resolve_connection_id(connector_id: str, env_id: str, timeout: int) -> str:
+    """コネクタに紐づく接続が 1 つだけならその ID を返す。複数・0 なら停止する。"""
+    args = ["connection", "list", "--search", connector_id]
+    if env_id:
+        args += ["--environment-id", env_id]
+    matches = {
+        _first(item, CONNECTION_ID_KEYS): _first(item, DISPLAY_KEYS)
+        for item in _list_json(args, timeout)
+        if _connector_of(item) == connector_id and _first(item, CONNECTION_ID_KEYS)
+    }
+    if len(matches) == 1:
+        connection_id, display = next(iter(matches.items()))
+        print(f"  接続を自動選択しました: {display or connection_id} ({connection_id})")
+        return connection_id
+    if not matches:
+        sys.exit(
+            f"NG: コネクタ '{connector_id}' の接続が環境にありません。\n"
+            f"    先に接続を作成してください: npx pa connection create --connector {connector_id}"
+        )
+    listed = "\n".join(f"    - {cid}  ({display})" for cid, display in sorted(matches.items()))
+    sys.exit(
+        f"NG: コネクタ '{connector_id}' の接続が複数あります。--connection-id で 1 つ選んでください。\n{listed}"
+    )
+
+
+def build_command(args: argparse.Namespace, connector_id: str, binding: list[str]) -> list[str]:
+    command = ["app", "add", "data-source", "--connector", connector_id, *binding]
+    if args.org_url:
+        command += ["--org-url", args.org_url]
+    if args.dataset:
+        command += ["--dataset", args.dataset]
+    if args.table:
+        command += ["--table", args.table]
+    if args.procedure:
+        command += ["--procedure", args.procedure]
+    return command + ["--non-interactive"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Code Apps のデータソースを対話プロンプトなしで追加する",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--connector", help="コネクタの通称またはコネクタ ID（例: sharepoint / shared_sql）")
+    parser.add_argument("--connection-ref", default=os.getenv("CONNECTION_REFERENCE_LOGICAL_NAME", ""))
+    parser.add_argument("--connection-id", default="")
+    parser.add_argument("--solution-id", default=os.getenv("SOLUTION_ID", ""))
+    parser.add_argument("--org-url", default="")
+    parser.add_argument("--dataset", default="", help="データセット（SharePoint はサイト URL、SQL は server,database）")
+    parser.add_argument("--table", default="", help="テーブル / リスト")
+    parser.add_argument("--procedure", default="", help="SQL ストアドプロシージャ")
+    parser.add_argument("--environment-id", default=os.getenv("ENV_ID", ""), help="接続・コネクタ一覧の検索対象環境")
+    parser.add_argument("--timeout", type=int, default=600, help="CLI 1 回あたりの上限秒数（既定 600）")
+    parser.add_argument("--dry-run", action="store_true", help="実行せずコマンドだけ表示する")
+    parser.add_argument("--list-connectors", action="store_true", help="コネクタ ID カタログを表示して終了する")
+    args = parser.parse_args()
+
+    if args.list_connectors:
+        print(format_catalog())
+        return 0
+    if not args.connector:
+        parser.error("--connector を指定してください（--list-connectors で一覧を確認できます）")
+
+    if not Path("power.config.json").is_file():
+        sys.exit("NG: power.config.json が見つかりません。Code App のルートで実行してください。")
+
+    connector_id = resolve_connector_id(args.connector, args.environment_id, args.timeout)
+    try:
+        entry = resolve_connector(connector_id)
+    except ConnectorResolutionError:
+        entry = {"id": connector_id, "displayName": connector_id, "requires": []}
+    requires = entry.get("requires", [])
+    print(f"コネクタ: {entry.get('displayName', connector_id)} -> {connector_id}")
+    if entry.get("note"):
+        print(f"  memo: {entry['note']}")
+
+    if "orgUrl" in requires and not args.org_url:
+        args.org_url = os.getenv("DATAVERSE_URL", "")
+        if not args.org_url:
+            sys.exit("NG: このコネクタには --org-url（または .env の DATAVERSE_URL）が必要です。")
+    for name, value in (("dataset", args.dataset), ("table", args.table)):
+        if name in requires and not value:
+            sys.exit(
+                f"NG: このコネクタには --{name} が必要です。"
+                f"候補は `npx pa connection list-{'datasets' if name == 'dataset' else 'tables'}` で確認できます。"
+            )
+
+    if args.connection_ref:
+        if not args.solution_id:
+            sys.exit("NG: --connection-ref には --solution-id（または .env の SOLUTION_ID）が必要です。")
+        binding = ["--connection-ref", args.connection_ref, "--solution-id", args.solution_id]
+        print(f"  バインド: 接続参照 {args.connection_ref}（ソリューション同梱）")
+    else:
+        connection_id = args.connection_id or resolve_connection_id(
+            connector_id, args.environment_id, args.timeout
+        )
+        binding = ["--connection-id", connection_id]
+        print("  バインド: 接続 ID 直バインド（ソリューションに入らない。ALM 用途では --connection-ref を使う）")
+
+    command = build_command(args, connector_id, binding)
+    if args.dry_run:
+        print(f"\n[dry-run] npx pa {' '.join(command)}")
+        return 0
+
+    result = _run_cli(command, args.timeout)
+    print((result.stdout or "").strip())
+    if result.returncode != 0:
+        print((result.stderr or "").strip(), file=sys.stderr)
+        print(f"\nNG: データソースの追加に失敗しました（exit={result.returncode}）", file=sys.stderr)
+        return 1
+    print(f"\nOK: {connector_id} をデータソースに追加しました。src/generated/ を確認してください。")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/standard/SKILL.md
+++ b/.github/skills/standard/SKILL.md
@@ -47,6 +47,7 @@ triggers:
 | [インタラクティブ環境セットアップ](references/interactive-setup.md) | PAC CLI + Dataverse API で `.env` を対話的に構成する手順（**プロジェクト開始時に最初に参照**） |
 | [認証リファレンス](references/auth-patterns.md) | auth_helper.py の詳細実装・認証パターン（Dataverse / Flow / **ARM・Azure SQL・Graph・自前 API** のスコープ一覧を含む） |
 | [.env サンプル](references/.env.example) | 全フェーズ共通の `.env` テンプレート（各テーマで `.env` にコピーして値を設定） |
+| [コネクタ ID カタログ](references/connector-catalog.json) | コネクタの通称（SharePoint / Outlook / SQL 等）→ `shared_xxx` の対応表。`scripts/connector_catalog.py` で解決する |
 | [DLP 事前チェック・環境チェック](../admin/SKILL.md) | **実装着手前**に環境が使える状態か（既定環境 / マネージド環境 / Code Apps / MCP / ロール）と、使用コネクタが DLP で使えるかを確認する（`admin` スキル） |
 | [Dataverse MCP 登録](references/dataverse-mcp-setup.md) | VS Code / Copilot から Dataverse を直接操作する MCP サーバー登録手順（upsert_skill 等） |
 | [ブラウザ自動化方針](references/browser-automation.md) | ブラウザ起動前に **AskUserQuestion で Edge プロファイルを確認**し、回答前は操作しない。ポータル操作は **VS Code 統合 Playwright ブラウザ**（`playwright-browser_navigate` / `playwright-browser_click` / `playwright-browser_type` / `playwright-browser_handle_dialog` 等）を使う。Playwright MCP サーバー・Playwright 単体ブラウザのインストール・起動は禁止 |
@@ -154,6 +155,7 @@ Phase 1（設計）の最初に必ず `architecture` を参照し、IT に詳し
 | インタラクティブセットアップ | PAC CLI + Dataverse API で `.env` を対話的に構成。環境選択・パブリッシャー/ソリューション選択を AskUserQuestion で進行。詳細は [インタラクティブ環境セットアップ](references/interactive-setup.md) |
 | 共通認証 | `auth_helper.py` による 2 層キャッシュ認証（デバイスコードを繰り返さない）。詳細は [認証リファレンス](references/auth-patterns.md) |
 | 環境チェック・DLP 事前チェック | **設計確定後・実装着手前に必ず実行**。`admin` スキルの `check_environment.py`（既定環境 / マネージド環境 / Dataverse / Code Apps / MCP / セキュリティ ロール）と `check_dlp.py`（コネクタの利用可否）を実行する。詳細は [admin スキル](../admin/SKILL.md) |
+| コネクタ ID の解決 | コネクタ ID（`shared_xxx`）を対話プロンプトで聞かずに確定させる。`scripts/connector_catalog.py --resolve sharepoint` で `shared_sharepointonline` を得る。Code Apps のデータソース追加は [`add_data_source.py`](../code-apps/scripts/add_data_source.py) がこれを使って非対話で完走する |
 | Azure リソース操作 | `scripts/azure_helper.py`（ARM / Graph / Azure SQL / 自前 API）。**`az login` 前提の手順は書かない** — 対話が必要でテナント列挙のハングやセッション失効により非対話完走が崩れるため |
 | `.env` パラメータ | 全フェーズ共通の環境変数（`DATAVERSE_URL` / `TENANT_ID` / `SOLUTION_NAME` / `PUBLISHER_PREFIX` 等）の一元管理 |
 | ソリューション運用 | 全コンポーネントを同一ソリューションに含める。`SOLUTION_NAME` / `PUBLISHER_PREFIX` を全フェーズで統一 |

--- a/.github/skills/standard/references/connector-catalog.json
+++ b/.github/skills/standard/references/connector-catalog.json
@@ -1,0 +1,220 @@
+{
+  "version": "1.0",
+  "note": [
+    "コネクタの通称（SharePoint / Outlook / SQL など）から コネクタ ID（shared_xxx）を解決するための共通カタログ。",
+    "CLI やスクリプトが対話プロンプトでコネクタ ID を尋ねてこないよう、実行前に ID を確定させる目的で使う。",
+    "ここに無いコネクタは scripts/connector_catalog.py のフォールバック（pa connector list --search）で解決する。",
+    "requires: pa app add data-source で追加指定が必要な項目。orgUrl / dataset / table のいずれか。"
+  ],
+  "connectors": [
+    {
+      "id": "shared_commondataserviceforapps",
+      "displayName": "Microsoft Dataverse",
+      "aliases": ["dataverse", "cds", "commondataservice", "microsoftdataverse", "dataverseconnector"],
+      "requires": ["orgUrl"],
+      "note": "Code Apps では 1 回追加すれば MicrosoftDataverseService で全テーブルを扱える（テーブルごとの追加は不要）"
+    },
+    {
+      "id": "shared_sharepointonline",
+      "displayName": "SharePoint",
+      "aliases": ["sharepoint", "sharepointonline", "spo", "sp"],
+      "requires": ["dataset", "table"],
+      "note": "--dataset にサイト URL、--table にリスト ID（またはリスト名）を指定する"
+    },
+    {
+      "id": "shared_office365",
+      "displayName": "Office 365 Outlook",
+      "aliases": ["outlook", "office365outlook", "o365outlook", "mail", "email", "メール"],
+      "requires": []
+    },
+    {
+      "id": "shared_office365users",
+      "displayName": "Office 365 Users",
+      "aliases": ["office365users", "o365users", "users", "userprofile", "ユーザー"],
+      "requires": []
+    },
+    {
+      "id": "shared_office365groups",
+      "displayName": "Office 365 Groups",
+      "aliases": ["office365groups", "o365groups", "groups"],
+      "requires": []
+    },
+    {
+      "id": "shared_teams",
+      "displayName": "Microsoft Teams",
+      "aliases": ["teams", "msteams", "microsoftteams"],
+      "requires": []
+    },
+    {
+      "id": "shared_sql",
+      "displayName": "SQL Server",
+      "aliases": ["sql", "sqlserver", "azuresql", "mssql"],
+      "requires": ["dataset", "table"],
+      "note": "--dataset にサーバー/データベース、--table にテーブル。ストアドプロシージャは --procedure"
+    },
+    {
+      "id": "shared_onedriveforbusiness",
+      "displayName": "OneDrive for Business",
+      "aliases": ["onedriveforbusiness", "odfb", "onedrivebusiness"],
+      "requires": []
+    },
+    {
+      "id": "shared_onedrive",
+      "displayName": "OneDrive",
+      "aliases": ["onedrive"],
+      "requires": []
+    },
+    {
+      "id": "shared_excelonlinebusiness",
+      "displayName": "Excel Online (Business)",
+      "aliases": ["excel", "excelonline", "excelonlinebusiness"],
+      "requires": ["dataset", "table"]
+    },
+    {
+      "id": "shared_approvals",
+      "displayName": "Approvals",
+      "aliases": ["approvals", "approval", "承認"],
+      "requires": []
+    },
+    {
+      "id": "shared_planner",
+      "displayName": "Planner",
+      "aliases": ["planner"],
+      "requires": []
+    },
+    {
+      "id": "shared_microsoftforms",
+      "displayName": "Microsoft Forms",
+      "aliases": ["forms", "microsoftforms", "msforms"],
+      "requires": []
+    },
+    {
+      "id": "shared_powerbi",
+      "displayName": "Power BI",
+      "aliases": ["powerbi", "pbi"],
+      "requires": []
+    },
+    {
+      "id": "shared_powervirtualagents",
+      "displayName": "Power Virtual Agents",
+      "aliases": ["powervirtualagents", "pva"],
+      "requires": []
+    },
+    {
+      "id": "shared_microsoftcopilotstudio",
+      "displayName": "Microsoft Copilot Studio",
+      "aliases": ["copilotstudio", "microsoftcopilotstudio", "mcs", "agent", "エージェント"],
+      "requires": []
+    },
+    {
+      "id": "shared_logicflows",
+      "displayName": "Power Automate (cloud flows)",
+      "aliases": ["logicflows", "flow", "flows", "powerautomate", "クラウドフロー"],
+      "requires": [],
+      "note": "Code Apps からフローを呼ぶときは pa app add flow を使う（add data-source ではない）"
+    },
+    {
+      "id": "shared_azureblob",
+      "displayName": "Azure Blob Storage",
+      "aliases": ["azureblob", "blob", "blobstorage"],
+      "requires": []
+    },
+    {
+      "id": "shared_azurequeues",
+      "displayName": "Azure Queues",
+      "aliases": ["azurequeues", "queues"],
+      "requires": []
+    },
+    {
+      "id": "shared_azuretables",
+      "displayName": "Azure Table Storage",
+      "aliases": ["azuretables", "tablestorage"],
+      "requires": []
+    },
+    {
+      "id": "shared_kusto",
+      "displayName": "Azure Data Explorer",
+      "aliases": ["kusto", "azuredataexplorer", "adx"],
+      "requires": []
+    },
+    {
+      "id": "shared_documentdb",
+      "displayName": "Azure Cosmos DB",
+      "aliases": ["cosmosdb", "documentdb", "cosmos"],
+      "requires": []
+    },
+    {
+      "id": "shared_azurekeyvault",
+      "displayName": "Azure Key Vault",
+      "aliases": ["keyvault", "azurekeyvault", "akv"],
+      "requires": []
+    },
+    {
+      "id": "shared_azureopenai",
+      "displayName": "Azure OpenAI",
+      "aliases": ["azureopenai", "aoai", "openai"],
+      "requires": []
+    },
+    {
+      "id": "shared_azuread",
+      "displayName": "Microsoft Entra ID",
+      "aliases": ["azuread", "entra", "entraid", "aad"],
+      "requires": []
+    },
+    {
+      "id": "shared_dynamicscrmonline",
+      "displayName": "Dynamics 365",
+      "aliases": ["dynamics", "dynamics365", "crm", "dynamicscrmonline"],
+      "requires": []
+    },
+    {
+      "id": "shared_visualstudioteamservices",
+      "displayName": "Azure DevOps",
+      "aliases": ["azuredevops", "ado", "vsts", "visualstudioteamservices"],
+      "requires": []
+    },
+    {
+      "id": "shared_github",
+      "displayName": "GitHub",
+      "aliases": ["github", "gh"],
+      "requires": []
+    },
+    {
+      "id": "shared_salesforce",
+      "displayName": "Salesforce",
+      "aliases": ["salesforce", "sfdc"],
+      "requires": []
+    },
+    {
+      "id": "shared_servicenow",
+      "displayName": "ServiceNow",
+      "aliases": ["servicenow", "snow"],
+      "requires": []
+    },
+    {
+      "id": "shared_msnweather",
+      "displayName": "MSN Weather",
+      "aliases": ["msnweather", "weather", "天気"],
+      "requires": []
+    },
+    {
+      "id": "shared_microsofttranslatorv2",
+      "displayName": "Microsoft Translator V2",
+      "aliases": ["translator", "microsofttranslator", "microsofttranslatorv2", "翻訳"],
+      "requires": []
+    },
+    {
+      "id": "shared_rss",
+      "displayName": "RSS",
+      "aliases": ["rss"],
+      "requires": []
+    },
+    {
+      "id": "shared_http",
+      "displayName": "HTTP",
+      "aliases": ["http"],
+      "requires": [],
+      "note": "DLP 事前チェック用。Code Apps のデータソースにはできない（CSP でブロックされる）"
+    }
+  ]
+}

--- a/.github/skills/standard/scripts/connector_catalog.py
+++ b/.github/skills/standard/scripts/connector_catalog.py
@@ -1,0 +1,160 @@
+"""コネクタの通称からコネクタ ID（`shared_xxx`）を解決する共通モジュール。
+
+CLI やスクリプトが「コネクタ ID を入力してください」と対話プロンプトで止まるのを防ぐため、
+実行前にコネクタ ID を確定させる。カタログは `references/connector-catalog.json`。
+
+```python
+from connector_catalog import resolve_connector
+
+entry = resolve_connector("SharePoint")   # -> {"id": "shared_sharepointonline", ...}
+entry = resolve_connector("shared_sql")   # -> ID 直指定もそのまま通る
+```
+
+解決順:
+  1. コネクタ ID 直指定（`shared_xxx` / `/providers/Microsoft.PowerApps/apis/shared_xxx`）
+  2. カタログの別名・表示名の完全一致（大文字小文字・記号を無視）
+  3. カタログの部分一致（候補が 1 つに絞れる場合のみ）
+
+候補が 0 個または 2 個以上のときは `ConnectorResolutionError` を送出する。
+呼び出し側は例外メッセージをそのまま表示して終了し、**プロンプトを出さない**こと。
+
+CLI としても使える:
+  python connector_catalog.py --list
+  python connector_catalog.py --resolve sharepoint
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+CATALOG_PATH = Path(__file__).resolve().parent.parent / "references" / "connector-catalog.json"
+
+_ARM_PREFIX = "/providers/microsoft.powerapps/apis/"
+_CONNECTOR_ID_PATTERN = re.compile(r"^shared_[a-z0-9\-]+$")
+
+
+class ConnectorResolutionError(Exception):
+    """コネクタ ID を一意に決められなかった。"""
+
+
+def _normalize(value: str) -> str:
+    """比較用にゆらぎを落とす（空白・記号・大文字小文字を無視、日本語はそのまま残す）。"""
+    return re.sub(r"[\W_]", "", value.lower(), flags=re.UNICODE)
+
+
+@lru_cache(maxsize=1)
+def load_catalog() -> tuple[dict, ...]:
+    data = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    return tuple(data.get("connectors", []))
+
+
+def _as_connector_id(name: str) -> str | None:
+    """`shared_xxx` 形式（ARM パス付きを含む）ならコネクタ ID を返す。"""
+    candidate = name.strip()
+    lowered = candidate.lower()
+    if lowered.startswith(_ARM_PREFIX):
+        candidate = candidate[len(_ARM_PREFIX) :]
+    elif "/" in candidate:
+        candidate = candidate.rsplit("/", 1)[-1]
+    candidate = candidate.strip().lower()
+    return candidate if _CONNECTOR_ID_PATTERN.match(candidate) else None
+
+
+def _entry_for_id(connector_id: str) -> dict:
+    for entry in load_catalog():
+        if entry["id"] == connector_id:
+            return dict(entry)
+    return {"id": connector_id, "displayName": connector_id, "aliases": [], "requires": []}
+
+
+def _keys(entry: dict) -> set[str]:
+    keys = {_normalize(entry["id"]), _normalize(entry["id"].removeprefix("shared_"))}
+    keys.add(_normalize(entry.get("displayName", "")))
+    keys.update(_normalize(alias) for alias in entry.get("aliases", []))
+    return {key for key in keys if key}
+
+
+def find_candidates(name: str) -> list[dict]:
+    """部分一致でカタログを検索する（曖昧さの提示用）。"""
+    needle = _normalize(name)
+    if not needle:
+        return []
+    return [
+        dict(entry)
+        for entry in load_catalog()
+        if any(needle in key or key in needle for key in _keys(entry))
+    ]
+
+
+def resolve_connector(name: str) -> dict:
+    """コネクタの通称・ID からカタログエントリを返す。
+
+    見つからない／複数候補のときは ``ConnectorResolutionError`` を送出する。
+    """
+    if not name or not name.strip():
+        raise ConnectorResolutionError("コネクタ名が空です。--connector を指定してください。")
+
+    connector_id = _as_connector_id(name)
+    if connector_id:
+        return _entry_for_id(connector_id)
+
+    needle = _normalize(name)
+    exact = [dict(entry) for entry in load_catalog() if needle in _keys(entry)]
+    if len(exact) == 1:
+        return exact[0]
+
+    candidates = exact or find_candidates(name)
+    if len(candidates) == 1:
+        return candidates[0]
+    if not candidates:
+        raise ConnectorResolutionError(
+            f"コネクタ '{name}' をカタログから解決できませんでした。\n"
+            f"  - コネクタ ID を直接指定する（例: --connector shared_sharepointonline）\n"
+            f"  - 環境内の一覧から探す: npx pa connector list --search {name} --json\n"
+            f"  - カタログに追加する: {CATALOG_PATH}"
+        )
+    listed = "\n".join(f"    - {c['id']}  ({c.get('displayName', '')})" for c in candidates)
+    raise ConnectorResolutionError(
+        f"コネクタ '{name}' の候補が複数あります。コネクタ ID で指定し直してください。\n{listed}"
+    )
+
+
+def resolve_connector_id(name: str) -> str:
+    return resolve_connector(name)["id"]
+
+
+def format_catalog() -> str:
+    lines = [f"{'コネクタ ID':<40} 表示名 / 別名"]
+    for entry in load_catalog():
+        aliases = ", ".join(entry.get("aliases", []))
+        lines.append(f"{entry['id']:<40} {entry.get('displayName', '')} [{aliases}]")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="コネクタ ID カタログの参照・解決")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--list", action="store_true", help="カタログを一覧表示する")
+    group.add_argument("--resolve", metavar="NAME", help="通称からコネクタ ID を解決する")
+    args = parser.parse_args()
+
+    if args.list:
+        print(format_catalog())
+        return 0
+    try:
+        print(resolve_connector_id(args.resolve))
+    except ConnectorResolutionError as exc:
+        print(f"NG: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+    raise SystemExit(main())


### PR DESCRIPTION
## 背景

`npx pa app add data-source` はコネクタ ID や接続を省略すると **対話プロンプトで停止**する。
スクリプト実行・CI・エージェント実行では入力待ちのまま固まり、正常フローが完走しない。

## 変更内容

| ファイル | 内容 |
|---|---|
| `standard/references/connector-catalog.json` | コネクタの通称（SharePoint / Outlook / SQL / 天気 …）→ `shared_xxx` の共通カタログ。34 コネクタ、日本語別名対応。`requires` で `--org-url` / `--dataset` / `--table` の必須有無も保持 |
| `standard/scripts/connector_catalog.py` | 通称・表示名・ARM パス・ID 直指定を一意解決。曖昧なときは**問い合わせず**候補を出して終了コード 1 で停止 |
| `code-apps/scripts/add_data_source.py` | データソース追加の**非対話ラッパー**。コネクタ ID・バインド先・必須値を実行前に確定し、`--non-interactive` かつ **stdin を閉じて** CLI を起動（`--timeout` 既定 600 秒） |
| `admin/scripts/check_dlp.py` | `--connector` で通称も受け付ける（`sharepoint` → `shared_sharepointonline`） |
| 各 `SKILL.md` / `references` / `GeekPowerCode.agent.md` | ラッパーを**正常フロー**として明記 |
| `code-apps/references/cli-reference.md` | `add data-source` のオプションを実測に修正（`--table` 追加、`-sp` → `--procedure`） |

## 使い方

```powershell
# 通称でそのまま追加（コネクタ ID の入力待ちにならない）
python .github/skills/code-apps/scripts/add_data_source.py --connector sharepoint

# ALM 標準（接続参照バインド）
python .github/skills/code-apps/scripts/add_data_source.py --connector dataverse `
  --connection-ref {CR_LOGICAL_NAME} --solution-id {SOLUTION_ID}

# 通称の一覧 / 実行せずコマンドだけ確認
python .github/skills/code-apps/scripts/add_data_source.py --list-connectors
python .github/skills/code-apps/scripts/add_data_source.py --connector teams --dry-run
```

## 恒久対策（再発防止）

- CLI は常に `--non-interactive` + `stdin=DEVNULL` + タイムアウト付きで起動するため、**プロンプトが出ても待ち続けない**
- 値が足りないときはプロンプトを出さず `NG:` と不足項目・取得コマンドを表示して終了コード 1
- 候補が複数のときも**勝手に選ばず**候補一覧を出して停止（誤ったコネクタ／接続へのバインドを防ぐ）
- カタログに無いコネクタは `--connector shared_xxx` の ID 直指定と `pa connector list --search` フォールバックで解決

## 検証

- `validate_skill.py` : `code-apps` / `standard` / `admin` すべて ✅
- 通称解決: `sharepoint` / `SharePoint Online` / `/providers/.../shared_sharepointonline` / `dataverse` / `outlook` / `onedrive`（`onedriveforbusiness` と誤解決しない）/ `excel` / `天気` / `メール` / `承認` → 期待どおり
- 曖昧な入力（`azure`）・未知の入力 → 候補提示または解決不可メッセージで exit 1（ハングなし）
- CLI オプションは `pa app add data-source --help`（v1.0.1）の実測と一致

## マージ順

他のオープン PR なし。単独でマージ可能。
