### PR TITLE
feat(agent): GeekPowerCodeの既定モデルをClaude Opus 5に変更

### DIFF
--- a/.github/agents/GeekPowerCode.agent.md
+++ b/.github/agents/GeekPowerCode.agent.md
@@ -2,7 +2,7 @@
 name: GeekPowerCode
 description: 'Power Platform コードファースト開発。Use when: Power Platform, Dataverse, Code Apps, Power Automate, Copilot Studio, テーブル作成, エージェント, ソリューション'
 tools: [execute, read, agent, edit, search, web, browser, 'flowagent/*']
-model: 'Claude Sonnet 5'
+model: 'Claude Opus 5'
 ---
 
 Power Platform コードファースト開発エキスパート。

--- a/.github/skills/dataverse/references/dataverse-guide.md
+++ b/.github/skills/dataverse/references/dataverse-guide.md
@@ -26,7 +26,7 @@ Dataverse テーブルの作成は **VS Code + GitHub Copilot（GeekPowerCode �
 
 1. VS Code に **GitHub Copilot** 拡張機能がインストール済みであること
 2. `GeekPowerCode` エージェントと開発スキル（`.github/skills/`）がリポジトリに含まれていること
-3. GitHub Copilot が有効化されていること（推奨モデル: **Claude Sonnet 5**）
+3. GitHub Copilot が有効化されていること（推奨モデル: **Claude Opus 5**）
 3. Power Platform 環境に認証済みであること
 
 ### テーブル作成手順

--- a/.github/skills/standard/references/power-platform-development-standard.md
+++ b/.github/skills/standard/references/power-platform-development-standard.md
@@ -4,7 +4,7 @@
 > GitHub Copilot Agent モードとスキルベースの開発ワークフローにより、VS Code から Power Platform / Azure ソリューションを構築する実践ガイド。
 
 > [!NOTE]
-> 推奨モデル: Claude Sonnet 5
+> 推奨モデル: Claude Opus 5
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cp .github/skills/standard/references/gitignore-template .gitignore
 - 既存仕様書がある場合の入力例: `spec-builder を実行して`
 
 > [!NOTE]
-> 推奨モデルは **Claude Sonnet 5** です（`.github/agents/GeekPowerCode.agent.md` の既定モデル）。`.gitignore` を配置しないと `node_modules/`・`dist/`・`.power/`・`.env` 等がコミット対象になるため、必ずコピーしてください。
+> 推奨モデルは **Claude Opus 5** です（`.github/agents/GeekPowerCode.agent.md` の既定モデル）。`.gitignore` を配置しないと `node_modules/`・`dist/`・`.power/`・`.env` 等がコミット対象になるため、必ずコピーしてください。
 
 前提条件・ライセンス要件は GitHub Copilot と共通です（[前提条件](#前提条件) を参照）。
 


### PR DESCRIPTION
## 概要

GeekPowerCode標準エージェントの既定モデルをClaude Sonnet 5からClaude Opus 5に変更する。

## 変更点
- .github/agents/GeekPowerCode.agent.md: frontmatter の model を Claude Opus 5 に変更
- README.md / dataverse-guide.md / power-platform-development-standard.md: 推奨モデルの表記をClaude Opus 5に統一