### PR TITLE
fix(copilot-studio): correct v1 authentication modes

### DIFF
--- a/.github/skills/copilot-studio/SKILL.md
+++ b/.github/skills/copilot-studio/SKILL.md
@@ -316,7 +316,7 @@ if ai_idx >= 0:
 > | 2 | `set_agent_security.py` | 認証モード設定→公開 | `AGENT_AUTH_MODE`（`none` / `microsoft`） |
 > | 3 | `set_agent_channels.py` | チャネル選択→公開 | `AGENT_CHANNELS`（`web,teams,copilot`） |
 >
-> `bots.authenticationmode`: `2`=認証なし（Web 埋め込み必須）／`1`=Microsoft で認証（UI 既定・Teams）。
+> Copilot Studio v1 の `bots.authenticationmode`: `1`=認証なし（Web 埋め込み必須）／`2`=Microsoft で認証（UI 既定・Teams）。
 > 認証変更は**公開後に反映**される。
 
 Instructions テンプレート・既存エージェント改善パターンは [構築リファレンス](references/build-reference.md#instructions-テンプレート) を参照。

--- a/.github/skills/copilot-studio/references/.env.example
+++ b/.github/skills/copilot-studio/references/.env.example
@@ -23,8 +23,8 @@ BOT_SCHEMA={prefix}_{botname}
 
 # === セキュリティ（認証）設定（set_agent_security.py 用）===
 # 認証モード。認証変更は公開後に反映される。
-#   none      … 認証なし（匿名アクセス／Web 埋め込みに必須）  authenticationmode=2
-#   microsoft … Microsoft で認証（Teams + M365・UI 既定）      authenticationmode=1
+#   none      … 認証なし（匿名アクセス／Web 埋め込みに必須）  authenticationmode=1
+#   microsoft … Microsoft で認証（Teams + M365・UI 既定）      authenticationmode=2
 AGENT_AUTH_MODE=none
 
 # === チャネル選択（set_agent_channels.py 用）===

--- a/.github/skills/copilot-studio/references/build-reference.md
+++ b/.github/skills/copilot-studio/references/build-reference.md
@@ -265,7 +265,7 @@ Copilot Studio の「設定 → セキュリティ → 認証」に相当。**�
 
 ```python
 # AGENT_AUTH_MODE=none | microsoft（.env で指定、未設定時は none）
-AUTH_MODE_VALUES = {"microsoft": 1, "none": 2}   # bots.authenticationmode の値
+AUTH_MODE_VALUES = {"microsoft": 2, "none": 1}   # Copilot Studio v1 の bots.authenticationmode
 
 value = AUTH_MODE_VALUES[mode]
 bot = api_get(f"bots({bot_id})?$select=name,authenticationmode")
@@ -274,20 +274,26 @@ if mode == "microsoft":
     body["authenticationtrigger"] = 0
 api_patch(f"bots({bot_id})", body)
 
+# ★ PATCH 後に保存値を再取得し、誤った対応表や更新失敗を検出する
+updated_bot = api_get(f"bots({bot_id})?$select=authenticationmode")
+if updated_bot.get("authenticationmode") != value:
+    raise RuntimeError("認証モードの保存値が期待値と一致しません")
+
 # ★ 認証変更は公開後に反映される
 api_post(f"bots({bot_id})/Microsoft.Dynamics.CRM.PvaPublish", {})
 ```
 
-**`bots.authenticationmode` の値（実機 live 環境で確認済み）:**
+**Copilot Studio v1 の `bots.authenticationmode` の値（実機 live 環境で確認済み）:**
 
 | UI の選択肢 | `authenticationmode` | 用途 |
 |---|---|---|
-| 認証なし（No authentication） | `2` | **Web 埋め込み（匿名アクセス）に必須** |
-| Microsoft で認証（Authenticate with Microsoft） | `1` | **UI 既定**。Teams + M365 チャネル |
+| 認証なし（No authentication） | `1` | **Web 埋め込み（匿名アクセス）に必須** |
+| Microsoft で認証（Authenticate with Microsoft） | `2` | **UI 既定**。Teams + M365 チャネル |
 | 手動で認証（Authenticate manually） | （OAuth 設定が別途必要・本スクリプト対象外） | カスタム OAuth |
 
 ```
-❌ 認証モードを設定しない → UI 既定の Microsoft 認証（=1）で公開され Web 埋め込み不可
+❌ `authenticationmode=1` を Microsoft 認証として設定する → 実際には認証なしで公開される
+❌ 認証モードを設定しない → UI 既定の Microsoft 認証（=2）で公開され Web 埋め込み不可
 ❌ authenticationmode を設定したが公開しない → 変更が反映されない
 ✅ 認証なしの Web 埋め込みが必要なら AGENT_AUTH_MODE=none を明示 → PATCH → 公開
 ✅ bots PATCH には name 必須（省略すると "Empty or null bot name" エラー）
@@ -349,9 +355,9 @@ Teams マニフェスト設定項目:
 ```
 
 ```
-⚠️ Teams / Copilot チャネルは「Microsoft で認証」（authenticationmode=1）が前提。
-   認証なし（=2）のまま teams/copilot を選ぶと利用できないため、set_agent_channels.py は
-   authenticationmode=2 のとき警告を表示する。
+⚠️ Teams / Copilot チャネルは「Microsoft で認証」（authenticationmode=2）が前提。
+    認証なし（=1）のまま teams/copilot を選ぶと利用できないため、set_agent_channels.py は
+    authenticationmode=1 のとき警告を表示する。
 ✅ Web 埋め込み（認証なし）なら AGENT_CHANNELS=web のみで OK（追加のチャネル定義は不要）
 ```
 

--- a/.github/skills/copilot-studio/references/troubleshooting.md
+++ b/.github/skills/copilot-studio/references/troubleshooting.md
@@ -380,8 +380,17 @@ Q: どのように起動しますか？
 ✅ ENV_ID のハイフンを除いた 32 桁を「先頭30桁 . 末尾2桁」に分割してホストにする
    例) aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
        → aaaaaaaabbbbccccddddeeeeeeeeee.ee.environment.api.powerplatform.com
-✅ 「認証なし」エージェント（authenticationmode=2）でも
+✅ 「認証なし」エージェント（Copilot Studio v1: authenticationmode=1）でも
    /powervirtualagents/botsbyschema/{SCHEMA}/directline/token は HTTP 200 でトークンを返す
+```
+
+### Microsoft 認証を設定したのに「認証なし」になる
+
+```
+❌ Copilot Studio v1 で authenticationmode=1 を Microsoft 認証として PATCH
+   → 1 は「認証なし」のため、匿名アクセスとして公開される
+✅ v1 は 1=認証なし、2=Microsoft で認証として設定する
+✅ set_agent_security.py は PATCH 後に authenticationmode を再取得し、期待値と異なれば公開前に停止する
 ```
 
 ### `az login` が使えない / az CLI が未認証

--- a/.github/skills/copilot-studio/scripts/set_agent_channels.py
+++ b/.github/skills/copilot-studio/scripts/set_agent_channels.py
@@ -32,6 +32,7 @@ from deploy_agent import (
     TEAMS_SHORT_DESCRIPTION, TEAMS_LONG_DESCRIPTION, TEAMS_ACCENT_COLOR,
     TEAMS_DEVELOPER_NAME, TEAMS_WEBSITE, TEAMS_PRIVACY_URL, TEAMS_TERMS_URL,
 )
+from set_agent_security import AUTH_MODE_VALUES
 
 load_dotenv()
 
@@ -155,7 +156,7 @@ def main():
 
     # 認証モードとチャネルの整合性チェック
     bot = api_get(f"bots({bot_id})?$select=authenticationmode")
-    if bot.get("authenticationmode") == 2 and (channels & {"teams", "copilot"}):
+    if bot.get("authenticationmode") == AUTH_MODE_VALUES["none"] and (channels & {"teams", "copilot"}):
         print("\n  ⚠️ 現在「認証なし」です。Teams / Copilot チャネルは Microsoft 認証が前提です。")
         print("     Teams / Copilot を使うには set_agent_security.py（AGENT_AUTH_MODE=microsoft）を先に実行してください。")
 

--- a/.github/skills/copilot-studio/scripts/set_agent_security.py
+++ b/.github/skills/copilot-studio/scripts/set_agent_security.py
@@ -4,8 +4,8 @@ Copilot Studio エージェント — セキュリティ（ユーザー認証）
 Copilot Studio の「設定 → セキュリティ → 認証」に相当。
 認証モードを設定してから公開する（認証変更は公開後に反映される）。
 
-  AGENT_AUTH_MODE=none       … 認証なし（匿名アクセス／Web 埋め込みに必須）   authenticationmode=2
-  AGENT_AUTH_MODE=microsoft  … Microsoft で認証（Teams + M365 チャネル・既定） authenticationmode=1
+    AGENT_AUTH_MODE=none       … 認証なし（匿名アクセス／Web 埋め込みに必須）   authenticationmode=1
+    AGENT_AUTH_MODE=microsoft  … Microsoft で認証（Teams + M365 チャネル・既定） authenticationmode=2
 
 前提:
   - deploy_agent.py で構築済み（BOT_ID を .env に設定済み）
@@ -27,11 +27,11 @@ from deploy_agent import find_bot, api_get, api_patch, api_post, BOT_NAME
 load_dotenv()
 
 # 認証モード → Dataverse bots.authenticationmode の値
-#   1 = Microsoft で認証（Authenticate with Microsoft）
-#   2 = 認証なし（No authentication）
-# ※ 実機（live 環境）で確認済み。UI 既定は Microsoft 認証（=1）のため、
+#   1 = 認証なし（No authentication）
+#   2 = Microsoft で認証（Authenticate with Microsoft）
+# ※ Copilot Studio v1 の実機（live 環境）で確認済み。UI 既定は Microsoft 認証（=2）のため、
 #   認証なしの Web 埋め込みが必要な場合は必ず none を指定する。
-AUTH_MODE_VALUES = {"microsoft": 1, "none": 2}
+AUTH_MODE_VALUES = {"microsoft": 2, "none": 1}
 
 
 def set_security(bot_id: str, mode: str):
@@ -45,6 +45,12 @@ def set_security(bot_id: str, mode: str):
         # Teams では常に認証されるため trigger は 0（As needed）
         body["authenticationtrigger"] = 0
     api_patch(f"bots({bot_id})", body)
+    updated_bot = api_get(f"bots({bot_id})?$select=authenticationmode")
+    if updated_bot.get("authenticationmode") != value:
+        raise RuntimeError(
+            "認証モードの保存値が期待値と一致しません: "
+            f"expected={value}, actual={updated_bot.get('authenticationmode')}"
+        )
     label = "認証なし（匿名アクセス）" if mode == "none" else "Microsoft で認証"
     print(f"  ✅ 認証モードを設定: {label}")
 


### PR DESCRIPTION
v1 の認証モード値を none=1、Microsoft=2 に修正しました。共有チャネルのチェックを追加し、PATCH 後の検証を実施します。テストとして validate_skill.py、py_compile、AST マッピング assertion、git diff --check を実行済みです。