### PR TITLE
feat(code-apps): CSP 構成を非対話スクリプト化し実座標マップの教訓を追加

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -463,6 +463,14 @@ Lookup 列の書き込みは従来どおり `parentcustomerid_account@odata.bind
 Power Apps ランタイムはデフォルトで `connect-src 'none'`。外部 API への `fetch` はブロックされる。
 Code Apps が生成する Dataverse SDK / `MicrosoftDataverseService` のような **Power Apps ランタイム経由の API** のみ CSP 安全。
 
+iframe 埋め込み（地図・PDF ビューア等）を入れる場合は、**デプロイする前に** CSP を確認・追加する。
+
+```powershell
+# 不足があれば終了コード 1（デプロイ前チェック）
+python .github/skills/code-apps/scripts/configure_code_app_csp.py `
+  --directive Frame-Src --source https://www.google.com --assert
+```
+
 → 詳細: **[CSP 構成](references/csp.md)**
 
 ### ログインユーザーの systemuserid 取得
@@ -650,6 +658,7 @@ Copilot Studio 応答は JSON 配列文字列で返るため `JSON.parse()` → 
 | スクリプト | 用途 |
 |---|---|
 | [check_code_apps_environment.py](scripts/check_code_apps_environment.py) | マネージド環境 / Code Apps 許可の前提条件を確認（`pa app init` の前に実行） |
+| [configure_code_app_csp.py](scripts/configure_code_app_csp.py) | Code Apps の CSP（`frame-src` 等）を確認・追加・検証。iframe を使うアプリはデプロイ前に `--assert` を通す |
 | [setup_connection_reference.py](scripts/setup_connection_reference.py) | 接続参照をソリューションに用意する（既存流用ファースト→Web API で新規作成）。Step 1 で実行 |
 | [add_data_source.py](scripts/add_data_source.py) | データソースを**非対話**で追加する。コネクタの通称（`sharepoint` 等）を `shared_xxx` に解決し、接続・必須値を確定してから `--non-interactive` で CLI を起動する。Step 3 の標準 |
 | [pre-deploy-check.mjs](scripts/pre-deploy-check.mjs) | `.env` / `power.config.json` / モック実行基盤の本番混入を検証（`npm run predeploy`）。プロジェクト直下の `scripts/` にコピーして使う |

--- a/.github/skills/code-apps/references/csp.md
+++ b/.github/skills/code-apps/references/csp.md
@@ -214,47 +214,49 @@ async function copyToClipboard(text: string): Promise<boolean> {
 
 > **注意**: カスタム値はデフォルト値とマージされる。デフォルトが消えることはない。
 
-### 方法 B: REST API（PowerShell）
+### 方法 B: スクリプト（非対話・推奨）
 
-Power Platform API で CSP をプログラム的に設定できる。
+[scripts/configure_code_app_csp.py](../scripts/configure_code_app_csp.py) が確認・追加・検証を一括で行う。
+環境 ID は `.env` の `ENV_ID` から読む。
 
-**1. 認証トークン取得**:
 ```powershell
-$tenantId = "<your-tenant-id>"
-$clientId = "<powerplatform-cli-client-id>"  # Power Platform CLI の public client ID
-$token = azureauth aad --resource "https://api.powerplatform.com/" --tenant $tenantId --client $clientId --output token | ConvertTo-SecureString -AsPlainText -Force
+# 現状確認（dry-run）
+python .github/skills/code-apps/scripts/configure_code_app_csp.py
+
+# デプロイ前チェック: 不足があれば終了コード 1（--assert は何も変更しない）
+python .github/skills/code-apps/scripts/configure_code_app_csp.py `
+  --directive Frame-Src --source https://www.google.com --source https://maps.google.com --assert
+
+# 追加を適用（適用後に再取得して反映を検証する）
+python .github/skills/code-apps/scripts/configure_code_app_csp.py `
+  --directive Frame-Src --source https://www.google.com --source https://maps.google.com --apply
 ```
 
-**2. 現在の設定を取得**:
+> **警告**: `PowerApps_CSPConfigCodeApps` の PATCH は**ディレクティブ コレクション全体を置換**する。
+> スクリプトは必ず GET → マージ → PATCH の順で処理する（自前で PATCH を書く場合も同様）。
+
+**認証（詰まりどころ）**: このエンドポイントは `EnvironmentManagement.Settings.Read` / `All.All.ReadWrite`
+の委任アクセス許可を要求し、`auth_helper` の既定クライアント（Azure CLI 互換）や `az account get-access-token`
+では `403 InsufficientDelegatedPermissions` になる。スクリプトは 403 を検出したら Power Platform CLI の
+パブリック クライアント（`9cee029c-6210-4654-90bb-17e6e9d36617`）へ自動フォールバックする。
+そのクライアントの認証キャッシュが無い初回だけ、`AUTH_MODE=interactive` を付けてブラウザ SSO で通すと
+デバイスコード入力待ちで止まらない（→ [認証パターン](../../standard/references/auth-patterns.md)）。
+
 ```powershell
-# Get-CodeAppContentSecurityPolicy 関数（下記参照）を読み込み済みの前提
-Get-CodeAppContentSecurityPolicy -Token $token -Env "<environment-id>"
+$env:AUTH_MODE="interactive"; python .github/skills/code-apps/scripts/configure_code_app_csp.py; Remove-Item Env:AUTH_MODE
 ```
 
-**3. ディレクティブを更新**（例: Google Maps iframe 許可）:
-```powershell
-$env = "<environment-id>"
-$directives = (Get-CodeAppContentSecurityPolicy -Token $token -Env $env).Directives
-
-# frame-src に Google Maps を追加
-$directives['Frame-Src'] = @('https://www.google.com', 'https://maps.google.com')
-
-Set-CodeAppContentSecurityPolicy -Token $token -Env $env -Directives $directives
-```
-
-> **警告**: `-Directives` はディレクティブコレクション全体を置換する。
-> 必ず既存の設定を GET してからマージして PATCH すること。
-
-**PowerShell ヘルパー関数**: https://learn.microsoft.com/ja-jp/power-apps/developer/code-apps/how-to/content-security-policy#powershell-helper-functions
+**公式ドキュメント**: https://learn.microsoft.com/ja-jp/power-apps/developer/code-apps/how-to/content-security-policy
 
 ## 実装手順チェックリスト
 
 iframe 埋め込み（地図等）を実装する場合の手順:
 
-1. **CSP 設定を先に追加** — Power Platform 管理センターで `frame-src` にドメインを追加
+1. **CSP 設定を先に追加** — `configure_code_app_csp.py --apply` か管理センターで `frame-src` にドメインを追加
 2. **コード実装** — iframe コンポーネントを作成
-3. **ビルド＆デプロイ** — `npm run build && pac code push`
-4. **動作確認** — ブラウザの DevTools > Console で CSP 違反エラーがないことを確認
+3. **デプロイ前チェック** — `configure_code_app_csp.py ... --assert` を通す（不足があれば終了コード 1）
+4. **ビルド＆デプロイ** — `npm run build && pac code push`
+5. **動作確認** — ブラウザの DevTools > Console で CSP 違反エラーがないことを確認
 
 > **重要**: CSP 設定なしでデプロイすると iframe がブロックされて何も表示されない。
 > 必ず **CSP 設定 → デプロイ** の順序で行う。
@@ -276,7 +278,19 @@ iframe 埋め込み（地図等）を実装する場合の手順:
 
 - 設定変更後、**数分のラグ** がある場合がある
 - ブラウザのハードリロード（Ctrl+Shift+R）を試す
-- Power Platform 管理センターで設定が保存されているか再確認
+- `pac code push` 直後は Power Apps 側が旧バージョンをキャッシュしており
+  「You're using an old version of this app」バナーが出る。**Refresh を押してから**確認する
+- `configure_code_app_csp.py`（引数なし）で保存済みディレクティブを再確認する
+
+### CSP 設定を確認しようとして 403 / デバイスコード待ちで止まる
+
+- `403 InsufficientDelegatedPermissions` → 既定クライアントに権限が無い。PAC CLI クライアントへの
+  フォールバックが働いているか確認する（スクリプトは自動）
+- デバイスコードの入力待ちで止まる → `AUTH_MODE=interactive` を付けてブラウザ SSO で 1 回だけ通す。
+  以降は `~/.power-platform-cli/auth_record_{TENANT_ID}_{CLIENT_ID}.json` から無操作で再利用される
+- `pac auth token` サブコマンドは **PAC CLI 2.8 系には存在しない**ため、PAC からトークンを直接取り出す前提の手順は書かない
+- `pac env list-settings` に出るのは **Dataverse 組織設定**（`iscontentsecuritypolicyenabled` 等 =
+  モデル駆動/キャンバス用）で、Code Apps の CSP ではない。混同しない
 
 ## 教訓（検証済み 2026-04-23）
 
@@ -285,3 +299,9 @@ iframe 埋め込み（地図等）を実装する場合の手順:
 - **CSP 設定は環境レベル**。同一環境内の全 Code Apps に適用される
 - **`sandbox` 属性を適切に設定**。`allow-scripts allow-same-origin allow-popups` で地図操作・ポップアップを許可
 - **iframe の代替手段も検討**。CSP 設定が困難な場合は SVG 地図やリンクボタンで代替できる
+- **Code Apps の CSP は Power Platform API（`PowerApps_CSPConfigCodeApps`）にある**。Dataverse の組織設定
+  （`iscontentsecuritypolicyenabled` / `contentsecuritypolicyconfiguration`）はモデル駆動・キャンバス用で無関係
+- **設定済みかどうかは推測せず毎回スクリプトで確認する**。`--assert` をデプロイ前チェックに組み込むと、
+  CSP 未設定のまま push して「真っ白な iframe」を調べ直す事故が起きない
+- 複数拠点にピンを打つ地図が必要な場合は素の埋め込みでは実現できない
+  （→ [Google マップ埋め込み + 実座標ピン](japan-map-pattern.md#パターン-7-google-マップ埋め込み--実座標ピン)）

--- a/.github/skills/code-apps/references/japan-map-pattern.md
+++ b/.github/skills/code-apps/references/japan-map-pattern.md
@@ -367,12 +367,84 @@ export default function RegionDashboard() {
 
 ---
 
+## パターン 7: Google マップ埋め込み + 実座標ピン
+
+**向いている場面**: 拠点・工場・店舗を**実際の緯度経度**でマップに置き、ピンをクリックして詳細へ遷移させたい場合。
+都道府県単位で足りるなら SVG の `JapanMap`（パターン 6）を使う。実住所・実座標が要るときだけこちらを使う。
+
+> 前提: `frame-src` に `https://www.google.com` と `https://maps.google.com` を追加しておく
+> （→ [CSP 構成](csp.md)）。CSP 未設定だと iframe は**無言で真っ白**になる。
+
+### 制約: 素の Google マップ埋め込みに複数ピンは打てない
+
+`output=embed` の埋め込み URL は「1 箇所を中心に表示」しかできず、複数マーカー・マーカーのクリックイベントを
+扱えない。Maps JavaScript API を使えば可能だが、API キーの発行・課金・`script-src` / `connect-src` の追加が要る。
+
+**割り切り**: 埋め込み iframe を**静的な背景**として敷き、ピンは自前の DOM 要素を Web メルカトル投影で
+絶対配置する。ズーム/全体表示は自前ボタンで行い、iframe の URL を作り直すことでピンとのズレを防ぐ。
+
+### 実装の要点
+
+```tsx
+// src/components/plant-map.tsx
+const TILE_SIZE = 256
+const JAPAN_VIEW = { latitude: 37.2, longitude: 137.6, zoom: 5 } // 日本全体が収まる中心とズーム
+
+/** 緯度経度 → Web メルカトルのピクセル座標（Google マップと同じ投影） */
+function project(lat: number, lng: number, zoom: number) {
+  const scale = TILE_SIZE * 2 ** zoom
+  const siny = Math.min(Math.max(Math.sin((lat * Math.PI) / 180), -0.9999), 0.9999)
+  return {
+    x: scale * (0.5 + lng / 360),
+    y: scale * (0.5 - Math.log((1 + siny) / (1 - siny)) / (4 * Math.PI)),
+  }
+}
+
+// 中心とズームは state で持ち、iframe の URL と ピンの座標計算で必ず同じ値を使う
+const embedUrl = `https://www.google.com/maps?ll=${view.latitude},${view.longitude}&z=${view.zoom}&hl=ja&output=embed`
+```
+
+```tsx
+<div className="relative">
+  {/* iframe はあくまで背景。pointer-events を切らないとドラッグでピンとズレる */}
+  <iframe src={embedUrl} title="拠点マップ" loading="lazy" className="pointer-events-none absolute inset-0 h-full w-full" />
+  {visibleSites.map((site) => {
+    const p = project(site.latitude, site.longitude, view.zoom)
+    return (
+      <button
+        key={site.id}
+        type="button"
+        style={{ left: center.x + (p.x - origin.x), top: center.y + (p.y - origin.y) }}
+        className="absolute -translate-x-1/2 -translate-y-full"
+        onClick={() => onSelect(site.id)}
+      >
+        <MapPin style={{ color: STATUS_COLOR[site.status] }} />
+      </button>
+    )
+  })}
+</div>
+```
+
+### 守るポイント
+
+| ポイント | 理由 |
+|---|---|
+| iframe に `pointer-events: none` を付ける | ユーザーが地図をドラッグ/ズームすると中心が変わり、ピンだけ取り残されてズレる |
+| ズーム・全体表示は自前ボタンにする | `view` state を単一の真実にして iframe とピンを同期させる |
+| `ResizeObserver` でコンテナ実寸を取る | 中心ピクセルが分からないとピンを配置できない |
+| 表示範囲外のピンは描画しない | ズームインしたとき遠方のピンがコンテナ端に張り付くのを防ぐ |
+| 「Google マップで開く」リンクを別途置く | 経路検索など本格的な地図操作はナビゲーション（CSP 対象外）へ逃がす |
+| 拠点マスタは Dataverse テーブルに持つ | 住所・緯度経度・稼働状況を業務側で保守できるようにする（座標をコードに埋めない） |
+
+---
+
 ## コンポーネント選定ガイドへの追加
 
 | やりたいこと | 推奨コンポーネント |
 |------------|-----------------|
 | 地域別データを地図で可視化 | `JapanMap`（SVG 都道府県クリック + 色分け + 地方フィルタ） |
 | 地図の凡例表示 | `MapLegend`（カラースケール + ラベル） |
+| 実座標の拠点をピン留めして詳細へ遷移 | Google マップ埋め込み + 自前ピン（パターン 7） |
 
 ---
 

--- a/.github/skills/code-apps/scripts/configure_code_app_csp.py
+++ b/.github/skills/code-apps/scripts/configure_code_app_csp.py
@@ -1,0 +1,145 @@
+"""Code Apps のコンテンツ セキュリティ ポリシー（CSP）を Power Platform API で確認・設定する。
+
+管理センターの「環境 > 設定 > プライバシー + セキュリティ > コンテンツ セキュリティ ポリシー > アプリ」に相当する。
+Dataverse の組織設定（`iscontentsecuritypolicyenabled` 等 = モデル駆動/キャンバス用）とは**別物**なので、
+`pac env list-settings` で確認しても Code Apps の CSP は出てこない。
+
+使い方:
+    # 現状確認（dry-run）
+    python .github/skills/code-apps/scripts/configure_code_app_csp.py
+
+    # デプロイ前チェック: 必要なオリジンが無ければ終了コード 1（CI / pre-deploy 用）
+    python .github/skills/code-apps/scripts/configure_code_app_csp.py \
+        --directive Frame-Src --source https://www.google.com --source https://maps.google.com --assert
+
+    # 実際に追加する
+    python .github/skills/code-apps/scripts/configure_code_app_csp.py \
+        --directive Frame-Src --source https://www.google.com --source https://maps.google.com --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(ROOT / ".github" / "skills" / "standard" / "scripts"))
+load_dotenv(ROOT / ".env")
+
+from auth_helper import get_token  # noqa: E402
+
+API_BASE = "https://api.powerplatform.com"
+API_VERSION = "2022-03-01-preview"
+SETTINGS = ["PowerApps_CSPReportingEndpoint", "PowerApps_CSPEnabledCodeApps", "PowerApps_CSPConfigCodeApps"]
+# 既定の Azure CLI 互換クライアントには EnvironmentManagement.Settings.* の委任アクセス許可が無く 403 になる。
+# キャッシュ済みトークンで先に試し、403 のときだけ Power Platform CLI のパブリック クライアントへ切り替える。
+PAC_CLIENT_ID = "9cee029c-6210-4654-90bb-17e6e9d36617"
+_client_ids: list[str | None] = [None, PAC_CLIENT_ID]
+
+
+def _url(environment_id: str) -> str:
+    return f"{API_BASE}/environmentmanagement/environments/{environment_id}/settings?api-version={API_VERSION}"
+
+
+def _headers(client_id: str | None) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {get_token(scope=f'{API_BASE}/.default', client_id=client_id)}",
+        "Content-Type": "application/json",
+    }
+
+
+def _send(method: str, url: str, **kwargs) -> requests.Response:
+    """権限のあるクライアントが見つかるまで client_id を切り替えて要求する。"""
+    last: requests.Response | None = None
+    for client_id in list(_client_ids):
+        res = requests.request(method, url, headers=_headers(client_id), timeout=120, **kwargs)
+        if res.status_code != 403:
+            _client_ids[:] = [client_id]  # 以降は成功したクライアントに固定して再認証を避ける
+            res.raise_for_status()
+            return res
+        last = res
+        if client_id is None:
+            print("  既定クライアントは権限不足のため PAC CLI クライアントで再試行します", file=sys.stderr)
+    assert last is not None
+    last.raise_for_status()
+    return last
+
+
+def get_settings(environment_id: str) -> dict:
+    res = _send("GET", f"{_url(environment_id)}&$select={','.join(SETTINGS)}")
+    return res.json().get("objectResult", [{}])[0]
+
+
+def parse_directives(raw: str | None) -> dict[str, list[str]]:
+    if not raw:
+        return {}
+    parsed = json.loads(raw)
+    return {name: [s["source"] for s in body.get("sources", [])] for name, body in parsed.items()}
+
+
+def patch_directives(environment_id: str, directives: dict[str, list[str]]) -> None:
+    config = {name: {"sources": [{"source": s} for s in sources]} for name, sources in directives.items()}
+    body = {"PowerApps_CSPConfigCodeApps": json.dumps(config, separators=(",", ":"))}
+    _send("PATCH", _url(environment_id), json=body)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Code Apps の CSP を確認・設定する")
+    parser.add_argument("--environment-id", default=os.getenv("ENV_ID", "") or os.getenv("ENVIRONMENT_ID", ""))
+    parser.add_argument("--directive", default="Frame-Src", help="対象ディレクティブ（例: Frame-Src / Connect-Src）")
+    parser.add_argument("--source", action="append", default=[], help="追加するオリジン（複数可）")
+    parser.add_argument("--assert", dest="assert_only", action="store_true",
+                        help="不足があれば終了コード 1（変更しない・デプロイ前チェック用）")
+    parser.add_argument("--apply", action="store_true", help="実際に適用する（既定は dry-run）")
+    args = parser.parse_args()
+
+    if not args.environment_id:
+        print("ENV_ID が未設定です（.env か --environment-id で指定してください）")
+        return 1
+
+    current = get_settings(args.environment_id)
+    directives = parse_directives(current.get("PowerApps_CSPConfigCodeApps"))
+    print(f"環境: {args.environment_id}")
+    print(f"  CSP 強制: {current.get('PowerApps_CSPEnabledCodeApps')}")
+    print(f"  レポート先: {current.get('PowerApps_CSPReportingEndpoint') or '(なし)'}")
+    print(f"  カスタム ディレクティブ: {json.dumps(directives, ensure_ascii=False) if directives else '(なし・既定値のみ)'}")
+
+    if not args.source:
+        return 0
+
+    existing = directives.get(args.directive, [])
+    missing = [origin for origin in args.source if origin not in existing]
+    if not missing:
+        print(f"  ✅ {args.directive}: 要求されたオリジンはすべて設定済み")
+        return 0
+
+    print(f"  ⚠️ {args.directive} に不足: {missing}")
+    if args.assert_only:
+        print("     CSP 未設定のままデプロイすると該当リソースは無言でブロックされます（--apply で追加）")
+        return 1
+
+    # PATCH はディレクティブ コレクション全体を置換するため、必ず現在値とマージする。
+    merged = dict(directives)
+    merged[args.directive] = [*existing, *missing]
+    print(f"\n変更内容: {args.directive} = {merged[args.directive]}")
+    if not args.apply:
+        print("dry-run です。適用するには --apply を付けてください。")
+        return 0
+
+    patch_directives(args.environment_id, merged)
+    after = parse_directives(get_settings(args.environment_id).get("PowerApps_CSPConfigCodeApps"))
+    if any(origin not in after.get(args.directive, []) for origin in args.source):
+        print(f"  ❌ 適用後の検証に失敗しました: {after.get(args.directive)}")
+        return 1
+    print("適用しました。反映まで数分かかる場合があります。")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/standard/references/auth-patterns.md
+++ b/.github/skills/standard/references/auth-patterns.md
@@ -72,6 +72,8 @@ flow_api_call("GET", f"/providers/Microsoft.ProcessSimple/environments/{env_id}/
 | Azure Resource Manager（リソース作成・設定取得） | `https://management.azure.com/.default` |
 | Azure SQL Database（Entra ID 認証） | `https://database.windows.net/.default` |
 | Microsoft Graph（アプリ登録・権限操作） | `https://graph.microsoft.com/.default` |
+| Power Platform 管理 API（環境設定・Code Apps の CSP 等） | `https://api.powerplatform.com/.default` |
+| BAP 管理 API（環境一覧・環境プロパティ） | `https://service.powerapps.com/.default` |
 | 自前 API（Azure Functions 上の MCP Server 等） | `api://{app-id}/.default` |
 
 `scripts/azure_helper.py` が ARM / Graph の薄いラッパーを提供する。
@@ -223,6 +225,47 @@ pac auth --help
 **対策**: 現状は DeviceCode フォールバックで機能上の問題はない（テナント別キャッシュ分離により
 往復しても再認証されない）。`pac auth token` に対応した pac CLI バージョンに更新できる場合は
 更新するとトークン取得が高速化する。
+
+#### Power Platform 管理 API が `403 InsufficientDelegatedPermissions` になる（★ 2026-09 検証済み）
+
+**症状**: `https://api.powerplatform.com/environmentmanagement/...` を叩くと 403 が返る。
+
+```json
+{"code":"Forbidden","innererror":{"code":"InsufficientDelegatedPermissions",
+ "message":"Application missing required delegated permissions: [EnvironmentManagement.Settings.Read, All.All.ReadWrite]"}}
+```
+
+**原因**: `auth_helper.get_token()` の既定クライアント（azure-identity の Azure CLI 互換クライアント）と
+`az account get-access-token` は同じアプリで、Power Platform API の `EnvironmentManagement.*` 委任アクセス許可を
+持っていない。トークン自体は問題なく発行されるので、認証エラーではなく**認可エラー**として現れる。
+
+**対策**: 403 を検出したら Power Platform CLI のパブリック クライアント
+`9cee029c-6210-4654-90bb-17e6e9d36617` を `client_id` に指定して再試行する。
+既定クライアントで通る API まで巻き込まないよう、**先に既定クライアントで試し 403 のときだけ切り替える**。
+
+```python
+CLIENT_IDS = [None, "9cee029c-6210-4654-90bb-17e6e9d36617"]  # 既定 → PAC CLI の順で試す
+
+def send(method, url, **kwargs):
+    for client_id in CLIENT_IDS:
+        token = get_token(scope="https://api.powerplatform.com/.default", client_id=client_id)
+        res = requests.request(method, url, headers={"Authorization": f"Bearer {token}"}, **kwargs)
+        if res.status_code != 403:
+            res.raise_for_status()
+            return res
+    res.raise_for_status()
+```
+
+**初回だけ対話が必要**: `client_id` を変えると `AuthenticationRecord` も
+`auth_record_{TENANT_ID}_{CLIENT_ID}.json` に分離されるため、そのクライアント初回はサインインが走る。
+**デバイスコードの入力待ちで止まってしまう**ため、その回だけ `AUTH_MODE=interactive` を付けて
+ブラウザ SSO で通す。2 回目以降はキャッシュから無操作で解決される。
+
+```powershell
+$env:AUTH_MODE="interactive"; python scripts/<script>.py; Remove-Item Env:AUTH_MODE
+```
+
+**実装例**: [Code Apps の CSP 構成スクリプト](../../code-apps/scripts/configure_code_app_csp.py)
 
 #### `az login` は auth_helper.py と全く別の資格情報ストア（★ 2026-07 検証済み）
 

--- a/.github/skills/update-skills/scripts/validate_skill.py
+++ b/.github/skills/update-skills/scripts/validate_skill.py
@@ -55,6 +55,9 @@ ALLOWLIST = {
     "14dad69e-099b-42c9-810b-d002981feec1",  # Microsoft Graph profile 委任スコープ ID（固定）
     "78ce3f0f-a1ce-49c2-8cde-64b5c0896db4",  # Dynamics CRM user_impersonation 委任スコープ ID（固定）
     "b7e6dc6d-f1e8-4753-8033-0f276bb0955b",  # Azure 組み込みロール Storage Blob Data Owner のロール定義 ID（固定）
+    "9cee029c-6210-4654-90bb-17e6e9d36617",  # Power Platform CLI のパブリック クライアント ID（固定）
+    "14d82eec-204b-4c2f-b7e8-296a70dab67e",  # Microsoft Graph PowerShell のパブリック クライアント ID（固定）
+    "04b07795-8ddb-461a-bbee-02f9e1bf7b46",  # Azure CLI のパブリック クライアント ID（固定）
     "00000000-0000-0000-0000-000000000000",  # 空 GUID（既定値プレースホルダー）
     "00000000-0000-0000-0000-000000000001",  # 開発用モックの定番 ID（プレースホルダー）
     "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",   # プレースホルダー


### PR DESCRIPTION
## 背景

Code Apps のダッシュボードに Google マップ埋め込みを実装した際の教訓を反映する。

## 変更内容

### 1. CSP 構成の非対話スクリプト化（新規）

`code-apps/scripts/configure_code_app_csp.py`

- 確認（dry-run） / `--assert`（不足なら終了コード 1・デプロイ前チェック用） / `--apply`（適用後に再取得して検証）
- `PowerApps_CSPConfigCodeApps` の PATCH はコレクション全体を置換するため、必ず GET → マージ → PATCH

### 2. 再発防止（恒久チェック）

CSP 未設定のまま `pac code push` して「真っ白な iframe」を調べ直す事故を防ぐため、
`--assert` をデプロイ前チェックに組み込む手順を SKILL.md とチェックリストに追加した。

### 3. 認証の落とし穴を記録

- Power Platform API は `EnvironmentManagement.Settings.Read` / `All.All.ReadWrite` の委任アクセス許可が必要で、
  既定クライアント（Azure CLI 互換）と `az account get-access-token` はどちらも `403 InsufficientDelegatedPermissions`
- 403 を検出したときだけ PAC CLI のパブリック クライアントへフォールバックする実装に統一
- そのクライアントの初回だけ `AUTH_MODE=interactive` でブラウザ SSO を通す（デバイスコードの入力待ちで止まらない）
- `pac env list-settings` に出るのは Dataverse 組織設定であって Code Apps の CSP ではない

### 4. 実座標マップのパターン追加

`japan-map-pattern.md` にパターン 7 を追加。素の Google マップ埋め込みは複数ピンを打てないため、
iframe を `pointer-events: none` の静的背景にして Web メルカトル投影の自前ピンを重ねる方式と、守るポイントを整理。

### 5. 検証スクリプトの誤検出解消

`validate_skill.py` の許可リストに well-known パブリック クライアント ID（PAC CLI / Graph PowerShell / Azure CLI）を追加。

## 検証

- `validate_skill.py --all` → 全 22 スキル ✅
- `configure_code_app_csp.py` を実環境で実行し、確認 / `--assert` 成功（exit 0）/ `--assert` 不足（exit 1）/ `--apply` を確認
- 実際に Code App をデプロイし、Google マップの iframe がブロックされずに表示されることをブラウザで確認

## マージ順

オープン PR なし・単独で完結するため依存なし。
