### PR TITLE
fix(admin): include Workflow Agent node in environment preflight

### DIFF
--- a/.github/skills/admin/SKILL.md
+++ b/.github/skills/admin/SKILL.md
@@ -71,6 +71,7 @@ triggers:
 | [scripts/check_environment.py](scripts/check_environment.py) | 環境チェック一式（既定環境 / マネージド環境 / Dataverse / Code Apps / MCP / 監査 / セキュリティ ロール / 管理 API / 適用 DLP） | なし |
 | [scripts/check_dlp.py](scripts/check_dlp.py) | 使用コネクタが DLP で使えるかの事前チェック | なし |
 | [scripts/set_dlp_custom_connector.py](scripts/set_dlp_custom_connector.py) | カスタムコネクタ（自前 MCP Server 等）の DLP 分類を設定 | `--apply` 時のみ |
+| [scripts/check_development_environment.py](scripts/check_development_environment.py) | 標準事前チェック。環境 + Dataverse / 新 Workflow Agent ノードのクラシック DLP + 環境・グループ ACP を順に検査し、失敗時に停止 | なし |
 | [scripts/set_acp_connector.py](scripts/set_acp_connector.py) | ACP（Advanced connector policies）の許可コネクタを確認・追加 | `--apply` 時のみ |
 | [scripts/apply_acp_profile.py](scripts/apply_acp_profile.py) | ACP の許可セットを推奨プロファイル（Microsoft 第一者のみ）で一括設定 | `--apply` 時のみ |
 | [scripts/migrate_dlp_to_acp.py](scripts/migrate_dlp_to_acp.py) | クラシック DLP の分類を ACP の許可リストへ移行 | `--apply` 時のみ |
@@ -101,6 +102,19 @@ triggers:
 ### Step 1: 環境チェックを実行する
 
 対象環境が開発してよい状態かを一括で確認する。**新しい環境で作業を始める最初のステップ**。
+
+README の環境準備プロンプトでは、次の統合コマンドを標準とする。
+`shared_commondataserviceforapps` と `shared_agentnode` を必ず含め、環境チェックに続いて
+Step 2 のクラシック DLP と Step 6 の ACP 読み取りを実行する。追加コネクタは `--connector` で指定する。
+許可リストを変更するコマンドではない。ブロックや取得エラー時は停止して Step 3 の承認ゲートへ進む。
+
+```powershell
+python .github/skills/admin/scripts/check_development_environment.py `
+  --environment-id $env:ENV_ID --tenant-id $env:TENANT_ID
+```
+
+構成上の成功と Workflow の実行成功は別に報告する。新 Workflow の利用時は、公開前の Review と
+外部データ・ツールなしの最小実行を追加ゲートとする。製品固有の必須条件は、以下の個別チェックで指定する。
 
 ```powershell
 python .github/skills/admin/scripts/check_environment.py `
@@ -197,6 +211,11 @@ python .github/skills/admin/scripts/set_acp_connector.py `
 **環境グループ側のポリシーを更新**しないと再同期で元に戻る。
 適用後は必ず再確認し、許可コネクタ数が増えていることを確認する。
 
+ただし、グループに現在 ACP がない場合も、環境には最後の ACP が残る。
+ポリシー名だけで継承中と判断せず、両方の `ConnectorManagement` を確認し、
+環境にだけ残っている場合はその環境を対象にする。グループへの ACP 新設は別途承認が必要。
+標準利用対象 `shared_agentnode` が未許可なら、既存リストを保持する1件追加の dry-run を提示する。
+
 ### Step 7: ACP を推奨プロファイルで一括設定する（任意）
 
 「Microsoft 第一者サービスだけを許可し、Microsoft が公開していても実体がサードパーティの
@@ -204,6 +223,8 @@ python .github/skills/admin/scripts/set_acp_connector.py `
 非推奨コネクタ（Dynamics 365 レガシー）はブロックする」推奨セットを 1 コマンドで適用する。
 
 定義は [references/acp-profiles.json](references/acp-profiles.json)。
+`microsoft-first-party` は新 Workflow Agent ノードの `shared_agentnode` を `allowConnectors` に明記し、
+カタログや既存許可リストにない場合も許可候補へ含める。明示拒否・除外ソース・安全弁は引き続き優先する。
 `publisher` では第一者判定できない（Google Drive も YouTube も publisher は `Microsoft`）ため、
 コネクタ ID のパターンで判定している。
 

--- a/.github/skills/admin/references/acp-profiles.json
+++ b/.github/skills/admin/references/acp-profiles.json
@@ -3,6 +3,7 @@
     "ACP（Advanced connector policies）の推奨許可セット定義。",
     "ACP は default-deny のため、ここに載らないコネクタはすべてブロックされる。",
     "allowPatterns はコネクタ ID（shared_xxx）に対する完全一致の正規表現。",
+    "allowConnectors はカタログ未掲載時も候補に含める明示的なコネクタ ID。拒否規則と除外ソースは優先する。",
     "publisher や metadata.stackOwner では第一者判定できない（Google Drive / YouTube も publisher は Microsoft）ため、ID パターンで定義する。",
     "テナント固有のカスタムコネクタはここに書かず、--include-connector か --keep-custom で扱う。",
     "判定は「コネクタ カタログ」と「現在 ACP で許可中の ID」の和集合に対して行う。カタログに現れないプレビュー コネクタを取りこぼさないため。"
@@ -12,6 +13,7 @@
       "displayName": "Microsoft 第一者サービスのみ許可",
       "description": "Microsoft が提供する自社サービス系コネクタだけを許可し、Microsoft が公開していても実体がサードパーティのサービス（Google Drive / Facebook / Mailchimp / YouTube / Workday / Zendesk など）と非推奨コネクタはブロックする。",
       "excludeSources": ["independentpublisher", "powerapps-user-defined"],
+      "allowConnectors": ["shared_agentnode"],
       "allowPatterns": [
         "office365.*",
         "sharepoint.*",

--- a/.github/skills/admin/references/troubleshooting.md
+++ b/.github/skills/admin/references/troubleshooting.md
@@ -1,5 +1,28 @@
 # 異常系・詰まりどころ
 
+## 新 Workflow の Agent ノードが事前チェックを通過した後にブロックされる
+
+新 Copilot Studio Workflow の Agent ノードは `shared_agentnode` を使う。
+Dataverse や `shared_powervirtualagents` の許可だけでは利用可能と判定しない。
+
+**恒久対策済み**: `check_development_environment.py` の `check_commands()` は Dataverse と
+`shared_agentnode` をクラシック DLP と環境・グループ ACP の検査へ必ず渡し、失敗時は停止する。
+`apply_acp_profile.py` の `resolve_allow_set()` は `microsoft-first-party` の `allowConnectors` を参照し、
+カタログ未掲載・初回未許可でも Agent ノードを許可候補に含める。拒否規則は優先し、適用は明示承認後のみ。
+回帰テスト: `python -m unittest discover -s .github/skills/admin/tests -p test_agent_node_preflight.py -v`。
+
+環境グループに現在 ACP がない場合でも、環境には最後の設定が残るのが仕様。
+`Synced Environment Policy` という名前だけでグループへ ACP を新設しない。
+両方のルールを確認し、有効な継承元がある場合はグループ、環境にだけ残る場合は環境を対象にする。
+
+構成チェックと管理センターの `Applied`、Studio の Review 成功は実行成功の代わりにならない。
+外部データ・ツールなしの最小実行が HTTP 442（DLP/ACP）で失敗する場合は、対象コネクタ、実行 ID、
+エラーの `Last refresh` とポリシー変更時刻を記録する。古い取得日時だけで原因を断定せず、
+反映後に再検証し、継続する場合はサポートへ確認する。ACP 無効化・全許可化で回避しない。
+
+公式資料: [ACP の環境設定と保持仕様](https://learn.microsoft.com/en-us/power-platform/admin/advanced-connector-policies)、
+[API によるポリシー更新](https://learn.microsoft.com/en-us/power-platform/admin/programmability-tutorial-manage-advanced-connector-policies)。
+
 ## 1. Copilot Studio で「データ損失防止ポリシーによりブロックされています」と出る
 
 **症状**: カスタムコネクタ（自前 MCP Server 等）をツールとして追加すると、DLP でブロックされたと表示される。

--- a/.github/skills/admin/scripts/apply_acp_profile.py
+++ b/.github/skills/admin/scripts/apply_acp_profile.py
@@ -66,8 +66,10 @@ def resolve_allow_set(profile: dict, names: set[str], sources: dict[str, str]) -
 
     allow = {
         name
-        for name in names
-        if pattern.match(name) and name not in deny and sources.get(name, "") not in excluded
+        for name in names | set(profile.get("allowConnectors") or [])
+        if (pattern.match(name) or name in (profile.get("allowConnectors") or []))
+        and name not in deny
+        and sources.get(name, "") not in excluded
     }
     violations = sorted(allow & set(profile.get("mustNotAllow") or []))
     return allow, violations

--- a/.github/skills/admin/scripts/check_development_environment.py
+++ b/.github/skills/admin/scripts/check_development_environment.py
@@ -1,0 +1,44 @@
+"""Run read-only environment, classic DLP and ACP checks with baseline connectors."""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+BASELINE_CONNECTORS = ("shared_commondataserviceforapps", "shared_agentnode")
+
+
+def check_commands(environment_id, tenant_id, connectors):
+    connector_args = []
+    for connector in dict.fromkeys((*BASELINE_CONNECTORS, *connectors)):
+        connector_args.extend(["--connector", connector])
+    common = ["--environment-id", environment_id]
+    tenant_args = ["--tenant-id", tenant_id] if tenant_id else []
+    return [
+        [sys.executable, str(SCRIPT_ROOT / "check_environment.py"), *common],
+        [sys.executable, str(SCRIPT_ROOT / "check_dlp.py"), *common, *tenant_args, *connector_args],
+        [sys.executable, str(SCRIPT_ROOT / "set_acp_connector.py"), *common, "--include-group", *connector_args],
+    ]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--environment-id", default=os.getenv("ENV_ID"))
+    parser.add_argument("--tenant-id", default=os.getenv("TENANT_ID"))
+    parser.add_argument("--connector", action="append", default=[])
+    args = parser.parse_args()
+    if not args.environment_id:
+        parser.error("--environment-id or ENV_ID is required")
+    for command in check_commands(args.environment_id, args.tenant_id, args.connector):
+        result = subprocess.run(command, check=False)
+        if result.returncode:
+            print("NG: Preflight failed. Review the output; no policy changes were applied.")
+            return result.returncode
+    print("OK: Configuration checks passed. Workflow runtime acceptance is still required.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/skills/admin/tests/test_agent_node_preflight.py
+++ b/.github/skills/admin/tests/test_agent_node_preflight.py
@@ -1,0 +1,87 @@
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_ROOT / "scripts"))
+
+from apply_acp_profile import DEFAULT_PROFILE_FILE, load_profile, resolve_allow_set
+from check_development_environment import check_commands, main
+
+
+class DevelopmentPreflightTests(unittest.TestCase):
+    def test_documented_preflight_command_and_markdown_fences(self):
+        root = SKILL_ROOT.parents[2]
+        for path in (root / "README.md", SKILL_ROOT / "SKILL.md"):
+            text = path.read_text(encoding="utf-8")
+            self.assertIn("python .github/skills/admin/scripts/check_development_environment.py", text)
+            self.assertIn("shared_agentnode", text)
+            fences = [line for line in text.splitlines() if line.startswith("```")]
+            self.assertEqual(len(fences) % 2, 0, str(path))
+
+    def test_baseline_connectors_checked_in_dlp_and_acp_without_writes(self):
+        commands = check_commands("environment-placeholder", "tenant-placeholder", ["shared_teams"])
+        self.assertEqual(len(commands), 3)
+        for command in commands[1:]:
+            for connector in ("shared_commondataserviceforapps", "shared_agentnode", "shared_teams"):
+                self.assertIn(connector, command)
+            self.assertNotIn("--apply", command)
+        self.assertIn("--include-group", commands[2])
+
+    def test_failure_stops_preflight(self):
+        for failure_index in range(3):
+            with self.subTest(failure_index=failure_index):
+                with patch("sys.argv", ["preflight", "--environment-id", "placeholder"]):
+                    with patch("check_development_environment.subprocess.run") as run:
+                        run.side_effect = [SimpleNamespace(returncode=0)] * failure_index + [
+                            SimpleNamespace(returncode=1)
+                        ]
+                        self.assertEqual(main(), 1)
+                        self.assertEqual(run.call_count, failure_index + 1)
+
+    def test_success_requires_all_three_checks(self):
+        with patch("sys.argv", ["preflight", "--environment-id", "placeholder"]):
+            with patch("check_development_environment.subprocess.run") as run:
+                run.return_value.returncode = 0
+                self.assertEqual(main(), 0)
+                self.assertEqual(run.call_count, 3)
+
+
+class AgentNodeProfileTests(unittest.TestCase):
+    def setUp(self):
+        self.profile = load_profile(DEFAULT_PROFILE_FILE, "microsoft-first-party")
+
+    def test_agent_node_is_included_without_catalog_or_existing_permission(self):
+        allowed, violations = resolve_allow_set(self.profile, set(), {})
+        self.assertEqual(allowed, {"shared_agentnode"})
+        self.assertEqual(violations, [])
+
+    def test_unrelated_agent_connectors_are_not_allowed(self):
+        allowed, violations = resolve_allow_set(
+            self.profile,
+            {"shared_agentnode", "shared_agentnodecustom", "shared_googledrive"},
+            {},
+        )
+        self.assertEqual(allowed, {"shared_agentnode"})
+        self.assertEqual(violations, [])
+
+    def test_explicit_deny_and_excluded_sources_still_win(self):
+        self.profile["denyConnectors"].append("shared_agentnode")
+        allowed, _ = resolve_allow_set(self.profile, set(), {})
+        self.assertNotIn("shared_agentnode", allowed)
+        self.profile["denyConnectors"].remove("shared_agentnode")
+        allowed, _ = resolve_allow_set(
+            self.profile, set(), {"shared_agentnode": "independentpublisher"}
+        )
+        self.assertNotIn("shared_agentnode", allowed)
+
+    def test_must_not_allow_guard_still_detects_explicit_entries(self):
+        self.profile["allowConnectors"].append("shared_googledrive")
+        _, violations = resolve_allow_set(self.profile, set(), {})
+        self.assertEqual(violations, ["shared_googledrive"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ cp .github/skills/standard/references/gitignore-template .gitignore
 
 1. 今回開発に使う環境を確認する: 既存の Dataverse 環境から選ぶか、専用の Developer/Sandbox 環境を新規作成するかをユーザーに確認する（新規作成する場合は README の「専用環境を作成する」の手順を管理者へ案内）。決定したら `.env` の `ENV_ID` / `DATAVERSE_URL` / `TENANT_ID` を設定する。
 2. `check_environment.py --environment-id $env:ENV_ID` を実行し、その環境で開発するにあたり最低限解消すべき問題点（既定環境ではないか・マネージド環境・Dataverse / Code Apps / MCP の有効化・セキュリティ ロール・管理 API アクセス・適用される DLP）を確認する。
-3. `check_dlp.py --environment-id $env:ENV_ID --tenant-id $env:TENANT_ID --connector shared_commondataserviceforapps` で、これから使う予定のコネクタが DLP でブロックされないかを確認する。
-4. `NG` があれば、その内容と解消方法（開発者へのセキュリティ ロール割り当て・管理者への依頼内容など）を整理して報告する。`NG` がなければ、その環境で開発を始めてよい旨を報告する。
+3. `python .github/skills/admin/scripts/check_development_environment.py --environment-id $env:ENV_ID --tenant-id $env:TENANT_ID` を実行する。標準利用対象の Dataverse (`shared_commondataserviceforapps`) と新 Copilot Studio Workflow の Agent ノード (`shared_agentnode`) を、環境チェック・クラシック DLP・環境とグループの ACP のすべてで確認する。追加コネクタは `--connector shared_xxx` で列挙する。このコマンドは読み取り専用で、許可追加はしない。
+4. `NG` や取得エラーがあれば停止し、解消方法を報告する。ACP で `shared_agentnode` が未許可なら、継承元と影響範囲を確認し、既存の許可設定を保持した1件追加の dry-run を提示する。明示承認後だけ適用し、再チェックする。グループから ACP が削除されても環境側に残る場合があるため、グループへの無条件な新設や全許可化はしない。
+5. すべて成功したら構成上の事前チェック完了を報告する。新 Workflow の利用時は、公開前の Review と外部データ・ツールなしの最小実行も確認する。管理画面の Applied やチェック成功だけで実行可能とは断定しない。実行時の DLP/ACP エラーはエラーコードと Last refresh を記録し、追加の権限緩和はしない。
 
 ## 完了報告
 - フェーズ 1〜3 それぞれの成否を報告する。
@@ -273,7 +274,7 @@ Copilot Studio のエージェントを作成・実行する環境には、購�
 
 DLP（データ損失防止）のコネクタ制御には、原則として **Advanced Connector Policy（ACP）** を使用します。ACP は許可リスト方式のため、明示的に追加していないコネクタとアクションは既定でブロックされます。
 
-1. 対象環境で利用するコネクタとアクションを事前に棚卸しする
+1. 対象環境で利用するコネクタとアクションを事前に棚卸しする。標準利用対象には Dataverse (`shared_commondataserviceforapps`) と新 Copilot Studio Workflow の Agent ノード (`shared_agentnode`) を含める。`microsoft-first-party` 推奨プロファイルも Agent ノードを既定の許可候補に含む（適用は dry-run・承認後）。`shared_powervirtualagents` の許可だけでは代替できない
 2. [Power Platform 管理センター](https://admin.powerplatform.microsoft.com/) を開く
 3. **セキュリティ** > **データとプライバシー** > **Advanced connector policies** を選択
 4. 対象環境を選び、**Add connectors** から必要な認定コネクタを許可リストへ追加する
@@ -514,15 +515,17 @@ python .github/skills/admin/scripts/check_environment.py --environment-id $env:E
 Code Apps・MCP・マネージド環境が要件の場合は `--require-code-apps` / `--require-mcp` / `--require-managed`
 を付けると、警告を `NG` に昇格させて確実に止められます。
 
-続けて、ソリューションが使うコネクタが DLP でブロックされないかを確認します。
+続けて、標準利用対象の Dataverse と新 Copilot Studio Workflow の Agent ノードを含め、環境・クラシック DLP・ACP をまとめて確認します。追加コネクタは `--connector shared_xxx` で指定します。
 
 ```powershell
-python .github/skills/admin/scripts/check_dlp.py --environment-id $env:ENV_ID --tenant-id $env:TENANT_ID --connector shared_commondataserviceforapps
+python .github/skills/admin/scripts/check_development_environment.py --environment-id $env:ENV_ID --tenant-id $env:TENANT_ID
 ```
+
+`shared_agentnode` は標準チェック対象であり、自動的に許可を付与するものではありません。未許可なら影響範囲と dry-run を確認して明示承認後に追加します。構成チェック成功後も Workflow の Review と最小実行で確認してください。実行時 HTTP 442（DLP/ACP）では `Last refresh` を記録し、反映・同期状態を確認します。実行成功前は準備完了と断定しません。
 
 > [!TIP]
 > Copilot チャットで `@GeekPowerCode` に「開発を始める前に環境をチェックして」と依頼すれば、
-> 上記 2 つを実行して結果を要約し、`NG` があれば解消方針まで提示します。
+> 上記の統合チェックを実行して結果を要約し、`NG` があれば解消方針まで提示します。
 
 ---
 


### PR DESCRIPTION
## Changes
- README の環境準備プロンプトと事前チェックを統合コマンドへ変更。
- Dataverse と shared_agentnode を標準対象に、環境・クラシック DLP・環境/グループ ACP を読み取り検査。各段階の失敗で停止。
- microsoft-first-party の許可候補に shared_agentnode を追加。カタログ未掲載時も対象に含め、既存の拒否・除外規則は保持。
- 許可変更は dry-run と明示承認後のみ。構成チェックと Workflow 実行成功を区別し、実行時442・Last refresh の確認手順を記載。

## Validation
- unittest: 8 tests passed (including failure at each preflight stage).
- Live read-only environment / classic DLP / ACP checks passed; Workflow runtime acceptance is separate.
- validate_skill.py passed locally and in the clean publication clone.
- git diff --check and added-line sensitive-data scan passed.
- Official Microsoft Learn ACP documentation checked via web fetch (Learn MCP unavailable).

## Scope
No tenant identifiers, app data, credentials or environment policy changes are included. No app deployment.

## Merge Order
Standalone PR; no open PRs touching admin were found. No prerequisite PR.