### PR TITLE
feat(agent-flows): API-first new Workflow lifecycle

### DIFF
--- a/.github/agents/GeekPowerCode.agent.md
+++ b/.github/agents/GeekPowerCode.agent.md
@@ -80,6 +80,7 @@ python .github/skills/admin/scripts/check_dlp.py --environment-id $env:ENV_ID --
 | Power Automate | .github/skills/power-automate/SKILL.md |
 | Copilot Studio (v1/旧) | .github/skills/copilot-studio/SKILL.md |
 | Copilot Studio v2 (新アーキ/自動構築) | .github/skills/copilot-studio-v2/SKILL.md |
+| Agent flows / 新 UI Workflow API | .github/skills/agent-flows/SKILL.md |
 | AI Builder | .github/skills/ai-builder/SKILL.md |
 | Generative Page | .github/skills/generative-page/SKILL.md |
 | Power Pages | .github/skills/power-pages/SKILL.md |

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -150,6 +150,7 @@ triggers:                      # スキル発動条件キーワード（必須�
 |--------|------|
 | [copilot-studio](copilot-studio/SKILL.md) | Copilot Studio エージェントを生成オーケストレーション前提で構築・運用する。 |
 | [copilot-studio-v2](copilot-studio-v2/SKILL.md) | Copilot Studio の新アーキテクチャ（cliagent）エージェントを Dataverse API だけで UI 操作なし完全自動構築する。フラット Python スキル添付まで対応。MCP サーバー等のツール追加は Copilot Studio UI での手動作業。 |
+| [agent-flows](agent-flows/SKILL.md) | Copilot Studio 新 UI の Agent flows / Workflows を API で別名作成・公開・実行する。手動 Start + inline Agent、接続参照、承認付き dry-run と出力検証を扱う。既存 v2 bot 呼び出しは別途検証する。 |
 | [power-automate](power-automate/SKILL.md) | Power Automate クラウドフローをソリューション対応で作成・デプロイする。 |
 | [cowork](cowork/SKILL.md) | 目的特化型の Copilot Cowork プラグイン（Agent Skills + Dataverse MCP）を開発し、Entra ID SSO を構成して M365 管理センターのエージェント画面から公開・更新する。 |
 | [ai-teammate](ai-teammate/SKILL.md) | Microsoft Foundry のエージェン トを SDK/REST ベースで作成・バージョン管理し、Agent 365 のエージェント ID ブループリントと Teams アプリパッケージを介して Teams / Microsoft 365 Copilot に公開する。エージェントテンプレート開発を担当し、秘匿化・CI/CD は `alm` スキルに委譲する。ライト実装（PoC）と本格実装の 2 ルートに対応。 |

--- a/.github/skills/agent-flows/SKILL.md
+++ b/.github/skills/agent-flows/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: agent-flows
+description: "Copilot Studio 新 UI の Agent flows / Workflows を Dataverse と Flow 管理 API で作成・公開・実行する。手動 Start と inline Agent の最小定義、接続参照、new UI 属性、承認付き dry-run、実行結果の検証を扱う。Code Apps との非同期連携を設計する場合にも使用する。"
+category: automation
+triggers:
+  - "Agent flows"
+  - "Agentflow"
+  - "新 UI Workflow"
+  - "Workflows API"
+  - "shared_agentnode"
+  - "InvokeDefinition"
+---
+
+# Agent Flows: 新 UI Workflow の API 構築
+
+対象は新 Copilot Studio Workflow の **手動 Start + 外部ツールなし inline Agent**。
+既存の最小フローを信頼済みテンプレートとして読み、同一ソリューション内へ別名作成する。
+モデルと接続参照はテンプレートから継承する。既存フローの更新・削除は行わない。
+一般クラウドフローは [power-automate](../power-automate/SKILL.md)、既存 bot の構築は
+[copilot-studio-v2](../copilot-studio-v2/SKILL.md) を使う。
+
+## Step 1: 対象と実行ゲートを確認する
+
+[standard](../standard/SKILL.md) の共通認証と `.env` を使い、
+[admin](../admin/SKILL.md) で環境・クラシック DLP・グループ継承を含む ACP を確認する。
+使用コネクタは `shared_agentnode`。ポリシー変更は別の明示承認で行う。
+設定の読み戻しと実行基盤の判定は別ゲートとして記録する。
+
+```powershell
+python .github/skills/admin/scripts/check_development_environment.py --environment-id $env:ENV_ID --connector shared_agentnode
+```
+
+作成名、テンプレート、ソリューション、モデル、固定応答、実行回数をユーザーに提示する。
+テナント固有値は [references/.env.example](references/.env.example) に従い `.env` へ置く。
+既存テンプレートに Start / Agent / edge / nodeActionMapping / 接続参照が揃っていることを CLI で検証する。
+
+## Step 2: API で別名作成する
+
+```powershell
+python .github/skills/agent-flows/scripts/agent_flow.py create --report-file .local/agent-flow/create-plan.json
+python .github/skills/agent-flows/scripts/agent_flow.py create --apply --expected-hash <approved-hash> --report-file .local/agent-flow/create-result.json
+```
+
+`create-plan.json` の定義と影響を確認してから適用する。計画ハッシュは環境、ソリューション、
+テンプレート定義、接続参照、作成名に結び付く。書き込み直前に再読み取りする。
+`created-verified` の `flowId` を `.env` の `AGENT_FLOW_ID` に設定する。
+新規名の重複を拒否し、`category=5 / type=1 / modernflowtype=1` と Draft を読み戻し検証する。
+
+## Step 3: 新 UI と公開を検証する
+
+ブラウザ起動前に使用する Edge プロファイルを質問して確定する。同一タスクで確認済みなら再質問しない。
+VS Code 統合ブラウザで `/environments/{ENV_ID}/flows/{AGENT_FLOW_ID}` を開き、
+Start と Agent のキャンバスおよび Review を確認する。独立ブラウザや Playwright MCP は導入しない。
+ネットワーク証跡は必要な操作と同一呼び出し内で採取し、method / origin+path / status のみ記録する。
+Authorization、Cookie、署名クエリは取得・保存・表示しない。
+
+```powershell
+python .github/skills/agent-flows/scripts/agent_flow.py publish --report-file .local/agent-flow/publish-plan.json
+python .github/skills/agent-flows/scripts/agent_flow.py publish --apply --expected-hash <approved-hash> --report-file .local/agent-flow/publish-result.json
+```
+
+Dataverse の Active と Flow API の Started を照合する。画面でも Published を確認する。
+
+## Step 4: 一度実行して出力を確認する
+
+```powershell
+python .github/skills/agent-flows/scripts/agent_flow.py run --report-file .local/agent-flow/run-plan.json
+python .github/skills/agent-flows/scripts/agent_flow.py run --apply --expected-hash <approved-hash> --report-file .local/agent-flow/run-result.json
+python .github/skills/agent-flows/scripts/agent_flow.py inspect --report-file .local/agent-flow/history.json
+python .github/skills/agent-flows/scripts/agent_flow.py inspect --run-id <run-id> --report-file .local/agent-flow/output.json
+```
+
+実行受付は `run-accepted` として記録し、成功扱いにしない。履歴の開始時刻と対象 ID を照合して run を指定する。
+run / Agent の Succeeded と固定 JSON 一致で `output-verified` になる。
+履歴の最新1件を無条件に今回の run とみなさず、同時実行時は明示的に識別する。
+成功以外は [異常系](references/troubleshooting.md) に従う。自動リトライ・待機ループ・許可範囲拡大は行わない。
+
+## Step 5: 業務連携へ進む
+
+[非同期連携の契約](references/code-apps-integration.md) に従い、Code Apps からの要求・結果と既存 v2 bot 呼び出しを別段階で実装する。
+inline `InvokeDefinition` の成功を既存 v2 bot / MCP / スキルの実行成功と同一視しない。
+ACP 反映待ちでもユーザーの承認に基づき実装・モックテストを進められるが、実応答・本人認可・本番受入のゲートは保持する。
+
+## Step 6: 検証と結果報告
+
+```powershell
+python -m unittest discover -s .github/skills/agent-flows/tests -v
+python .github/skills/update-skills/scripts/validate_skill.py .github/skills/agent-flows
+```
+
+報告は「作成 / 新 UI / 公開 / 実行受付 / 実行完了 / 出力検証 / 業務連携」を分ける。
+ローカルの計画・結果には環境固有情報があるため Git 公開対象から除外する。
+仕様・実測・未検証の区分は [API 契約](references/api-contract.md) を参照する。

--- a/.github/skills/agent-flows/references/.env.example
+++ b/.github/skills/agent-flows/references/.env.example
@@ -1,0 +1,17 @@
+# Shared auth_helper configuration; obtain from environment session details.
+TENANT_ID=<tenant-id>
+ENV_ID=<environment-id>
+DATAVERSE_URL=https://<org>.crm.dynamics.com
+SOLUTION_NAME=<solution-unique-name>
+
+# Trusted new-UI manual + inline Agent template in the same environment.
+# Model and an existing connected connection reference are inherited.
+AGENT_FLOW_SOURCE_ID=<template-workflow-id>
+AGENT_FLOW_NAME=<new-isolated-smoke-name>
+AGENT_FLOW_EXPECTED_JSON={"ok":true,"message":"agent-flow-ready"}
+
+# Set only after create returned created-verified.
+AGENT_FLOW_ID=<created-workflow-id>
+
+# Local evidence contains environment/connection IDs; exclude from Git.
+# Add .local/agent-flow/ to the project's .gitignore.

--- a/.github/skills/agent-flows/references/api-contract.md
+++ b/.github/skills/agent-flows/references/api-contract.md
@@ -1,0 +1,64 @@
+# API Contract And Evidence
+
+## Verification Boundary
+
+Validated in a new-UI-enabled environment on 2026-09-09:
+
+| Operation | Evidence |
+|---|---|
+| Create Dataverse workflow in a solution | HTTP 204 and exact clientdata readback |
+| New UI discriminator | modernflowtype 0 opened classic fallback; 1 opened Start + Agent canvas |
+| Designer validation | Review: Ready to publish, no problems |
+| Publish through Dataverse | Active readback, Flow API Started, UI Published |
+| Management manual run | HTTP 200, a run and Agent action created |
+| Agent output | HTTP 442 runtime policy block; fixed JSON not yet verified |
+| New UI network contract capture | Not completed; do not claim network corroboration |
+
+Configuration and inherited ACP allowed the connector while runtime still returned an older policy refresh.
+Development continuation during propagation is allowed with user approval. This does not convert a failed run into a successful acceptance test.
+This package is an experimental, source-template-based implementation, not a Microsoft-supported new designer authoring SDK.
+
+## Sources
+
+- [Create, read, update, and delete cloud flows](https://learn.microsoft.com/en-us/power-automate/manage-flows-with-code): Dataverse workflow category 5, clientdata, connection references, state management.
+- [Workflow table](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/workflow): category=5 is Modern Flow; modernflowtype=1 is CopilotStudioFlow (0=PowerAutomateFlow, 2=M365CopilotAgentFlow). These values are documented, while the graph contract is an observation.
+- [Advanced connector policies](https://learn.microsoft.com/en-us/power-platform/admin/advanced-connector-policies): governance is separate from flow definition validation.
+- [Microsoft power-platform-skills](https://github.com/microsoft/power-platform-skills/tree/main/plugins/power-automate): create-flow and manage-flows separate creation, publish, run and inspection.
+- [Official bundled FlowAgent implementation](https://github.com/microsoft/power-platform-skills/blob/main/plugins/power-automate/server/mcp.mjs): inspected `runFlow`, `triggerFlowRun` and `classicFlowRpRequest`; input-free runs use management `/triggers/{name}/run`. Input-bearing Direct-API triggers require a different transport. The sample does not implement it.
+
+Learn MCP was not available during verification; public documentation was used as fallback. New UI graph details below are environment observations, not guaranteed public contracts.
+
+The cloud-flow article explicitly states that `api.flow.microsoft.com` is **unsupported and subject to breaking changes**.
+Its use in the official FlowAgent bundle is evidence of an implementation pattern, not a support guarantee.
+Creation/state updates use documented Dataverse APIs; Started checks, run and history in this experimental CLI use the unsupported Flow RP API.
+For supported production management, assess the documented Power Automate Management connectors separately.
+
+## Requests
+
+All Python authentication uses `standard/scripts/auth_helper.py`. No independent token cache or credentials.
+
+| API | Request |
+|---|---|
+| Dataverse | POST `/api/data/v9.2/workflows`, header `MSCRM.SolutionUniqueName` |
+| Body fields | workflowid, name, category=5, type=1, modernflowtype=1, primaryentity=none, clientdata as JSON string |
+| Publish | PATCH `/workflows({id})`, statecode=1, statuscode=2 |
+| Flow management | `https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/{env}/flows/{id}` |
+| Management API version / scope | `2016-11-01` / `https://service.flow.microsoft.com/.default` |
+| Manual invocation | POST `.../triggers/manual/run`, empty JSON object, no trigger inputs |
+| Status | GET `.../runs`, `.../runs/{run}`, `.../runs/{run}/actions/Agent` |
+
+Runtime definition: `properties.definition.triggers.manual` is Request/Button; `actions.Agent` is OpenApiConnection with `shared_agentnode / InvokeDefinition`.
+`body/botDefinition` contains only model and an empty tools array. `body/message` matches graph inlineInstructions.
+Designer graph: `triggers.manual.metadata.associatedData.graph`, Start + Agent nodes and one directed edge, with matching `nodeActionMapping` and action metadata.nodeId.
+Graph and runtime connectionReferences must match. Existing connected reference must resolve to the embedded connection ID.
+Server resource IDs are not cloned. Node IDs are scoped to each separate flow and remain from the trusted source.
+
+## Safety And Limits
+
+- Create is separate from publish and run, each requires a fresh reviewed hash. Target-name collisions stop.
+- A second snapshot narrows stale-write risk; these APIs do not provide a transaction across workflows and references. Do not edit the template or target concurrently during apply.
+- The create source must be a trusted, reviewed minimal template. Structural checks are not a sandbox for arbitrary imported definitions.
+- No automatic retry on ambiguous writes. Preserve the pending report with allocated workflow ID and reconcile before attempting another write.
+- Output links may contain SAS credentials. Restrict to the observed environment-specific `environment.api.powerplatformusercontent.com` host, omit bearer and redirects, never log the URL or output body.
+- `body.message` is the expected response shape, still awaiting a successful live Agent response. A different successful output schema must be inspected and tested, not silently accepted.
+- Model availability, license/credits, connection ownership, new UI rollout and runtime ACP propagation remain environmental prerequisites.

--- a/.github/skills/agent-flows/references/code-apps-integration.md
+++ b/.github/skills/agent-flows/references/code-apps-integration.md
@@ -1,0 +1,28 @@
+# Code Apps And Existing Bot Integration
+
+## Implementation Sequence
+
+1. Keep the existing app and v1 channel available. Develop the new path behind a disabled-by-default feature setting.
+2. Code Apps creates a user-owned Dataverse request with a server-generated ID, client correlation key, base design revision/hash, operation, bounded input JSON and Pending status.
+3. A Dataverse-triggered flow claims the request using a conditional update. Duplicate events must not start duplicate billable Agent calls or overwrite a completed result.
+4. Invoke the chosen engine and persist a terminal result through a separate result table or a server-validated transition. An inline Agent is not an existing v2 bot.
+5. The app reads only authorized results, supports bounded polling/cancellation/timeouts and ignores stale responses after navigation or base design changes.
+6. Parse the response through the app's existing design schema and domain validators. AI output is a proposal; adoption remains an explicit user action.
+
+## Required Existing V2 Bot Proof
+
+The new designer offers a separate Copilot node. Capture its selected-bot connector operation, bot schema name, inputs and output shape from a dedicated draft.
+Verify the exact existing bot with a fixed response and then its skill/MCP execution. Do not infer that `InvokeDefinition` calls that bot, or that classic `ExecuteCopilotAsyncV2` supports the new architecture.
+Until this contract is verified, implement and test the request/result adapter independently; do not substitute another model silently.
+
+## Security And Acceptance
+
+- Request CreatedBy comes from Dataverse, never a client-supplied identity. Client correlation keys require an alternate key including requester scope.
+- Restrict request payload operations and sizes server-side. Ordinary users must not set Completed/result/engine identity fields.
+- A maker-owned connector runs with maker permissions, not requester permissions. Filter/authorize data retrieval for the requester or restrict the operation to the submitted design payload. This must be proven before enabling real knowledge retrieval.
+- Results need explicit sharing/ownership matching the requesting user. Test with a second ordinary user that cross-user reads and writes fail.
+- Conditional state transitions, retries, cancellation, timeouts and late completion must have deterministic behavior. UI cancellation alone does not cancel remote processing.
+- Design results must preserve locked modules, specified boundary/exclusions, base revision and output limits. No automatic adoption, saving, email or resource changes by the AI.
+- Acceptance gates: Dataverse round-trip, duplicate delivery, failure/timeout, stale response, ordinary-user authorization, exact existing bot/skill invocation, desktop/mobile workflow, explicit adoption.
+
+The bundled CLI currently automates only the manual inline smoke lifecycle. Dataverse trigger generation, request tables, existing-bot invocation and app deployment are not claimed as implemented by this skill.

--- a/.github/skills/agent-flows/references/troubleshooting.md
+++ b/.github/skills/agent-flows/references/troubleshooting.md
@@ -1,0 +1,34 @@
+# Troubleshooting
+
+## Classic Experience Instead Of New Workflow
+
+Cause observed: `modernflowtype` defaulted to 0. `category=5` and graph metadata alone are insufficient.
+Permanent guard: `workflow_body` sets modernflowtype=1 and `validate_workflow` verifies it in every lifecycle operation.
+Do not copy resourceid/resourcecontainer from another flow. Repair only an explicitly identified test resource.
+
+## Runtime 442 After Review Passes
+
+Record configuration readback, inherited group policy, run ID, Agent status and runtime policy refresh timestamp.
+`classify_output` returns runtime-policy-blocked even when deployment and Review succeeded.
+Allow implementation to continue under explicit user approval while propagation is pending; keep runtime acceptance pending.
+Do not add more connectors, disable DLP/ACP or reapply policies automatically. Retest once after propagation is confirmed or at an agreed checkpoint.
+Persistent divergence belongs in a support case. Setting save, new UI Review and runtime execution are three different checks.
+
+## Template Or Readback Rejected
+
+`validate_client` checks graph/runtime instruction, model, connection and mapping parity, empty tools, no web/human assistance and the input-free trigger.
+`validate_workflow` checks name, category, type, modernflowtype, state and clientdata.
+Do not bypass these checks for a richer workflow. Discover the new node contract and implement a separately tested adapter.
+
+## Write Failed Or Timed Out
+
+The report is saved as write-request-pending before a request. A failed response is failed-or-unverified, not proof that nothing happened.
+Read the allocated resource ID/name or run history before another action. Reports are not overwritten; no automatic POST retries.
+Existing flows are never deleted to achieve idempotency. Concurrent source edits require a fresh dry-run and reviewed hash.
+
+## Accepted Run Is Not An Answer
+
+The management endpoint may return an empty HTTP 200 body. Use run history and explicit run ID, not the response alone.
+`classify_output` requires successful run and action plus parsed JSON equality; boolean and number differences are rejected.
+Output mismatch is not repaired by stripping markdown or inventing missing fields.
+Code Apps inputs must not be sent using this input-free smoke transport.

--- a/.github/skills/agent-flows/scripts/agent_flow.py
+++ b/.github/skills/agent-flows/scripts/agent_flow.py
@@ -1,0 +1,276 @@
+"""Plan, create, publish, run and inspect an isolated new-UI inline Agent flow."""
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+from uuid import UUID, uuid4
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard/scripts"))
+
+FLOW_SCOPE = "https://service.flow.microsoft.com/.default"
+SELECT = "name,clientdata,category,type,modernflowtype,statecode,statuscode"
+
+
+def digest(value):
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def validate_client(client):
+    properties = client["properties"]
+    definition = properties["definition"]
+    if set(definition["triggers"]) != {"manual"} or set(definition["actions"]) != {"Agent"}:
+        raise ValueError("Exactly one manual trigger and one Agent action required")
+    trigger = definition["triggers"]["manual"]
+    if trigger["type"] != "Request" or trigger["kind"] != "Button":
+        raise ValueError("Request/Button trigger required")
+    if trigger["inputs"]["schema"] != {"type": "object", "properties": {}, "required": []}:
+        raise ValueError("Only input-free smoke triggers are supported")
+    action = definition["actions"]["Agent"]
+    host = action["inputs"]["host"]
+    if action["type"] != "OpenApiConnection" or host != {
+        "apiId": "/providers/Microsoft.PowerApps/apis/shared_agentnode",
+        "connectionName": "shared_agentnode", "operationId": "InvokeDefinition"
+    }:
+        raise ValueError("Inline shared_agentnode/InvokeDefinition required")
+    parameters = action["inputs"]["parameters"]
+    if set(parameters) != {"body/botDefinition", "body/message"}:
+        raise ValueError("Unexpected Agent parameters")
+    bot = json.loads(parameters["body/botDefinition"])
+    if set(bot) != {"model", "tools"} or bot["tools"] != [] or not bot["model"]:
+        raise ValueError("Explicit model and empty tools required")
+    associated = trigger["metadata"]["associatedData"]
+    graph = associated["graph"]
+    if sorted(node["type"] for node in graph["nodes"]) != ["agent", "start"]:
+        raise ValueError("Only Start and inline Agent nodes supported")
+    start = next(node for node in graph["nodes"] if node["type"] == "start")
+    agent = next(node for node in graph["nodes"] if node["type"] == "agent")
+    if start["id"] == agent["id"] or start["data"]["config"] != {"triggerType": "manual"}:
+        raise ValueError("Distinct nodes and manual graph trigger required")
+    edges = graph["edges"]
+    if len(edges) != 1 or edges[0]["source"] != start["id"] or edges[0]["target"] != agent["id"]:
+        raise ValueError("Start to Agent edge required")
+    if associated["nodeActionMapping"] != {agent["id"]: ["Agent"]} or action["metadata"]["nodeId"] != agent["id"]:
+        raise ValueError("Graph/runtime node mapping mismatch")
+    config = agent["data"]["config"]
+    if (config["mode"] != "inline" or config.get("botSchemaName") or config.get("instructions")
+            or config.get("webSearchEnabled") or config.get("isHitlEscalationEnabled")
+            or config["inlineModel"] != bot["model"] or config["outputMode"] != "text"
+            or config["inlineInstructions"] != parameters["body/message"]
+            or config["connectionName"] != "shared_agentnode"):
+        raise ValueError("Inline graph settings differ from the runtime or enable additional capabilities")
+    references = properties["connectionReferences"]
+    if set(references) != {"shared_agentnode"} or graph["connectionReferences"] != references:
+        raise ValueError("Graph/runtime connection references mismatch")
+    reference = references["shared_agentnode"]
+    if reference["api"]["name"] != "shared_agentnode" or reference["runtimeSource"] != "embedded":
+        raise ValueError("Embedded agentnode connection required")
+    logical = reference["connection"]["connectionReferenceLogicalName"]
+    if not re.fullmatch(r"[A-Za-z0-9_]+", logical):
+        raise ValueError("Invalid connection reference logical name")
+    if definition.get("outputs") or action.get("runAfter"):
+        raise ValueError("Unexpected output or action dependency")
+    return logical
+
+
+def build_client(source, name, message):
+    validate_client(source)
+    client = copy.deepcopy(source)
+    definition = client["properties"]["definition"]
+    graph = definition["triggers"]["manual"]["metadata"]["associatedData"]["graph"]
+    graph["name"] = name
+    next(node for node in graph["nodes"] if node["type"] == "agent")["data"]["config"]["inlineInstructions"] = message
+    definition["actions"]["Agent"]["inputs"]["parameters"]["body/message"] = message
+    validate_client(client)
+    return client
+
+
+def workflow_body(flow_id, name, client):
+    validate_client(client)
+    return {"workflowid": flow_id, "name": name, "category": 5, "type": 1,
+            "modernflowtype": 1, "primaryentity": "none", "clientdata": json.dumps(client)}
+
+
+def validate_workflow(actual, name, client, state):
+    if (actual["name"] != name or json.loads(actual["clientdata"]) != client
+            or actual["category"] != 5 or actual["type"] != 1
+            or actual["modernflowtype"] != 1 or actual["statecode"] != state):
+        raise ValueError("Workflow identity, new-UI discriminator, state or definition mismatch")
+    validate_client(client)
+
+
+def require_approval(plan, expected_hash):
+    if not expected_hash or digest(plan) != expected_hash:
+        raise ValueError("Plan changed or approval hash missing; create a fresh dry-run")
+
+
+def classify_output(run_status, action_status, output, expected):
+    if output.get("statusCode") == 442:
+        return {"status": "runtime-policy-blocked", "httpStatus": 442}
+    if run_status != "Succeeded" or action_status != "Succeeded":
+        return {"status": "run-not-succeeded"}
+    body = output.get("body", {})
+    message = body.get("message") if isinstance(body, dict) else None
+    try:
+        actual = json.loads(message) if isinstance(message, str) else None
+    except ValueError:
+        actual = None
+    return {"status": "output-verified" if digest(actual) == digest(expected) else "output-mismatch"}
+
+
+def safe_output_url(url, environment):
+    parsed = urlsplit(url)
+    compact = str(UUID(environment)).replace("-", "")
+    host = compact[:30] + "." + compact[30:] + ".environment.api.powerplatformusercontent.com"
+    if parsed.scheme != "https" or parsed.hostname != host or parsed.port not in (None, 443) or parsed.username or parsed.password:
+        raise ValueError("Output URL must use the verified environment content host")
+    return url
+
+
+class Api:
+    def __init__(self, environment):
+        from auth_helper import DATAVERSE_URL, get_session
+        self.dataverse = DATAVERSE_URL.rstrip("/") + "/api/data/v9.2/"
+        self.flow = ("https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/"
+                     + environment + "/flows/")
+        self.dv_session = get_session()
+        self.flow_session = get_session(FLOW_SCOPE)
+
+    def request(self, method, path, body=None, flow=False, solution=None):
+        session = self.flow_session if flow else self.dv_session
+        url = (self.flow if flow else self.dataverse) + path
+        if flow:
+            url += ("&" if "?" in url else "?") + "api-version=2016-11-01"
+        headers = {"MSCRM.SolutionUniqueName": solution} if solution else {}
+        response = session.request(method, url, json=body, headers=headers, timeout=120, allow_redirects=False)
+        if not 200 <= response.status_code < 300:
+            raise ValueError("API request failed: HTTP " + str(response.status_code))
+        return response.json() if response.content else {}
+
+    def workflow(self, flow_id):
+        return self.request("GET", f"workflows({flow_id})?$select={SELECT}")
+
+
+def main():
+    from auth_helper import DATAVERSE_URL
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["create", "publish", "run", "inspect"])
+    parser.add_argument("--report-file", required=True, type=Path)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--expected-hash")
+    parser.add_argument("--run-id")
+    args = parser.parse_args()
+    if args.report_file.exists():
+        parser.error("Report already exists; use a new path (never automatically retry a write)")
+    environment = str(UUID(os.environ["ENV_ID"]))
+    name = os.environ["AGENT_FLOW_NAME"]
+    solution = os.environ["SOLUTION_NAME"]
+    expected = json.loads(os.environ["AGENT_FLOW_EXPECTED_JSON"])
+    if not isinstance(expected, dict) or not expected or len(json.dumps(expected)) > 4096:
+        parser.error("Expected JSON must be a nonempty object of at most 4096 characters")
+    message = ("Return only this exact JSON without markdown: " + json.dumps(expected)
+               + ". Do not use tools, knowledge, web search, email, or human assistance.")
+    api = Api(environment)
+    report = {"status": "dry-run", "command": args.command}
+    args.report_file.parent.mkdir(parents=True, exist_ok=True)
+
+    def save():
+        args.report_file.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    def snapshot():
+        if args.command == "create":
+            source_id = str(UUID(os.environ["AGENT_FLOW_SOURCE_ID"]))
+            source = api.workflow(source_id)
+            source_client = json.loads(source["clientdata"])
+            validate_workflow(source, source["name"], source_client, source["statecode"])
+            client = build_client(source_client, name, message)
+            logical = validate_client(client)
+            refs = api.request("GET", "connectionreferences?$filter=connectionreferencelogicalname eq '"
+                               + logical + "'&$select=connectionreferenceid,connectionid,connectorid").get("value", [])
+            if len(refs) != 1 or not refs[0].get("connectionid") or not refs[0]["connectorid"].endswith("/shared_agentnode"):
+                raise ValueError("Unique agentnode connection reference required")
+            embedded = client["properties"]["connectionReferences"]["shared_agentnode"].get("connectionName")
+            if embedded and embedded != refs[0]["connectionid"]:
+                raise ValueError("Embedded connection differs from connection reference")
+            escaped = name.replace("'", "''")
+            if api.request("GET", f"workflows?$filter=name eq '{escaped}'&$select=workflowid").get("value"):
+                raise ValueError("Target already exists; no overwrite or delete supported")
+            return {"command": args.command, "environment": environment, "dataverse": DATAVERSE_URL,
+                    "solution": solution, "sourceId": source_id, "sourceHash": digest(source),
+                    "reference": refs[0], "name": name, "clientdata": client}
+        flow_id = str(UUID(os.environ["AGENT_FLOW_ID"]))
+        actual = api.workflow(flow_id)
+        client = json.loads(actual["clientdata"])
+        validate_workflow(actual, name, client, 0 if args.command == "publish" else 1)
+        if client != build_client(client, name, message):
+            raise ValueError("Configured smoke instructions differ from target")
+        return {"command": args.command, "environment": environment, "dataverse": DATAVERSE_URL,
+                "flowId": flow_id, "workflowHash": digest(actual)}
+
+    try:
+        plan = snapshot()
+        report.update(plan=plan, expectedHash=digest(plan))
+        save()
+        if args.command == "inspect":
+            flow_id = plan["flowId"]
+            if not args.run_id:
+                runs = api.request("GET", flow_id + "/runs?$top=10", flow=True).get("value", [])
+                report.update(status="history-read", runs=[{"id": run["name"], "status": run["properties"]["status"],
+                              "startTime": run["properties"].get("startTime")} for run in runs])
+            else:
+                if not re.fullmatch(r"[A-Za-z0-9-]+", args.run_id):
+                    raise ValueError("Invalid run ID")
+                path = flow_id + "/runs/" + args.run_id
+                run = api.request("GET", path, flow=True)["properties"]
+                action = api.request("GET", path + "/actions/Agent", flow=True)["properties"]
+                report.update(runId=args.run_id, runStatus=run["status"], actionStatus=action["status"])
+                output = {}
+                if action.get("outputsLink"):
+                    url = safe_output_url(action["outputsLink"]["uri"], environment)
+                    response = api.flow_session.get(url, headers={"Authorization": None}, timeout=120, allow_redirects=False)
+                    if response.status_code != 200:
+                        raise ValueError("Output download failed: HTTP " + str(response.status_code))
+                    output = response.json()
+                report.update(classify_output(run["status"], action["status"], output, expected))
+        elif args.apply:
+            require_approval(plan, args.expected_hash)
+            require_approval(snapshot(), args.expected_hash)
+            report["status"] = "write-request-pending"
+            if args.command == "create":
+                report["flowId"] = str(uuid4())
+            save()
+            if args.command == "create":
+                flow_id = report["flowId"]
+                api.request("POST", "workflows", workflow_body(flow_id, name, plan["clientdata"]), solution=solution)
+                validate_workflow(api.workflow(flow_id), name, plan["clientdata"], 0)
+                if digest(api.workflow(plan["sourceId"])) != plan["sourceHash"]:
+                    raise ValueError("Source changed during create")
+                report["status"] = "created-verified"
+            elif args.command == "publish":
+                before = api.workflow(plan["flowId"])
+                api.request("PATCH", "workflows(" + plan["flowId"] + ")", {"statecode": 1, "statuscode": 2})
+                validate_workflow(api.workflow(plan["flowId"]), name, json.loads(before["clientdata"]), 1)
+                state = api.request("GET", plan["flowId"], flow=True)["properties"]["state"]
+                if state != "Started":
+                    raise ValueError("Flow has not reached Started")
+                report["status"] = "published-verified"
+            else:
+                api.request("POST", plan["flowId"] + "/triggers/manual/run", {}, flow=True)
+                report["status"] = "run-accepted"
+        print(json.dumps({key: value for key, value in report.items() if key != "plan"}, indent=2))
+        return 0 if report["status"] not in {"runtime-policy-blocked", "run-not-succeeded", "output-mismatch"} else 2
+    except Exception as error:
+        report.update(status="failed-or-unverified", errorType=type(error).__name__)
+        print("Failed or unverified; inspect the report and resource before retrying.", file=sys.stderr)
+        return 1
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/agent-flows/tests/test_agent_flow.py
+++ b/.github/skills/agent-flows/tests/test_agent_flow.py
@@ -1,0 +1,121 @@
+import copy
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from agent_flow import build_client, classify_output, digest, main, require_approval, safe_output_url, validate_client, validate_workflow, workflow_body
+
+
+def fixture():
+    refs = {"shared_agentnode": {"api": {"name": "shared_agentnode"}, "runtimeSource": "embedded",
+                               "connection": {"connectionReferenceLogicalName": "sample_reference"}}}
+    config = {"mode": "inline", "inlineModel": "sample-model", "inlineInstructions": "old",
+              "outputMode": "text", "connectionName": "shared_agentnode"}
+    graph = {"name": "source", "nodes": [
+        {"id": "start", "type": "start", "data": {"config": {"triggerType": "manual"}}},
+        {"id": "agent", "type": "agent", "data": {"config": config}}],
+        "edges": [{"source": "start", "target": "agent"}], "connectionReferences": refs}
+    return {"properties": {"connectionReferences": refs, "definition": {
+        "triggers": {"manual": {"type": "Request", "kind": "Button", "inputs": {
+            "schema": {"type": "object", "properties": {}, "required": []}}, "metadata": {
+                "associatedData": {"graph": graph, "nodeActionMapping": {"agent": ["Agent"]}}}}},
+        "actions": {"Agent": {"type": "OpenApiConnection", "metadata": {"nodeId": "agent"}, "inputs": {
+            "host": {"apiId": "/providers/Microsoft.PowerApps/apis/shared_agentnode", "connectionName": "shared_agentnode", "operationId": "InvokeDefinition"},
+            "parameters": {"body/botDefinition": json.dumps({"model": "sample-model", "tools": []}), "body/message": "old"}}}}, "outputs": {}}}}
+
+
+class AgentFlowTests(unittest.TestCase):
+    def test_clone_and_readback(self):
+        source = fixture()
+        before = copy.deepcopy(source)
+        client = build_client(source, "new", "new message")
+        self.assertEqual(source, before)
+        actual = dict(workflow_body("sample-id", "new", client), statecode=0)
+        validate_workflow(actual, "new", client, 0)
+        for key, value in [("modernflowtype", 0), ("statecode", 1), ("category", 0), ("name", "other")]:
+            with self.subTest(key=key), self.assertRaises(ValueError):
+                validate_workflow(dict(actual, **{key: value}), "new", client, 0)
+
+    def test_graph_runtime_mismatch_rejected(self):
+        for mutation in ["model", "mapping", "tools", "edge", "web", "extra-action", "reference"]:
+            source = fixture()
+            definition = source["properties"]["definition"]
+            associated = definition["triggers"]["manual"]["metadata"]["associatedData"]
+            config = associated["graph"]["nodes"][1]["data"]["config"]
+            if mutation == "model":
+                config["inlineModel"] = "other"
+            elif mutation == "mapping":
+                associated["nodeActionMapping"] = {}
+            elif mutation == "tools":
+                definition["actions"]["Agent"]["inputs"]["parameters"]["body/botDefinition"] = '{"model":"sample-model","tools":[{}]}'
+            elif mutation == "edge":
+                associated["graph"]["edges"][0]["target"] = "start"
+            elif mutation == "web":
+                config["webSearchEnabled"] = True
+            elif mutation == "reference":
+                associated["graph"]["connectionReferences"] = {}
+            else:
+                definition["actions"]["Other"] = {}
+            with self.subTest(mutation=mutation), self.assertRaises(ValueError):
+                validate_client(source)
+
+    def test_approval_binds_scope_and_definition(self):
+        plan = {"environment": "sample", "clientdata": fixture()}
+        require_approval(plan, digest(plan))
+        with self.assertRaises(ValueError):
+            require_approval(dict(plan, environment="other"), digest(plan))
+        with self.assertRaises(ValueError):
+            require_approval(plan, None)
+
+    def test_output_requires_success_and_exact_json(self):
+        expected = {"ok": True}
+        self.assertEqual(classify_output("Succeeded", "Succeeded", {"body": {"message": '{"ok":true}'}}, expected)["status"], "output-verified")
+        for message in ['{"ok":1}', '```json\n{"ok":true}\n```', '{}']:
+            self.assertEqual(classify_output("Succeeded", "Succeeded", {"body": {"message": message}}, expected)["status"], "output-mismatch")
+        self.assertEqual(classify_output("Running", "Succeeded", {}, expected)["status"], "run-not-succeeded")
+        self.assertEqual(classify_output("Failed", "Failed", {"statusCode": 442}, expected)["status"], "runtime-policy-blocked")
+
+    def test_output_host_is_environment_bound(self):
+        environment = "00000000-0000-0000-0000-000000000000"
+        url = "https://" + "0" * 30 + ".00.environment.api.powerplatformusercontent.com/output?sig=example"
+        self.assertEqual(safe_output_url(url, environment), url)
+        for bad in [url.replace("https:", "http:"), url.replace("/output", ".example.com/output"), url.replace("https://", "https://user@")]:
+            with self.subTest(url=bad), self.assertRaises(ValueError):
+                safe_output_url(bad, environment)
+
+    def test_run_cli_requires_approval_and_reports_acceptance_only(self):
+        identifier = "00000000-0000-0000-0000-000000000000"
+        settings = {"ENV_ID": identifier, "AGENT_FLOW_ID": identifier, "AGENT_FLOW_NAME": "sample",
+                    "SOLUTION_NAME": "Sample", "AGENT_FLOW_EXPECTED_JSON": '{"ok":true}'}
+        message = 'Return only this exact JSON without markdown: {"ok": true}. Do not use tools, knowledge, web search, email, or human assistance.'
+        actual = dict(workflow_body(identifier, "sample", build_client(fixture(), "sample", message)), statecode=1)
+        auth = types.ModuleType("auth_helper")
+        auth.DATAVERSE_URL = "https://example.com"
+        with tempfile.TemporaryDirectory() as directory, patch.dict(os.environ, settings), patch.dict(sys.modules, {"auth_helper": auth}), patch("agent_flow.Api") as api_type, contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            api = api_type.return_value
+            api.workflow.return_value = actual
+            path = Path(directory) / "plan.json"
+            with patch.object(sys, "argv", ["agent_flow", "run", "--report-file", str(path)]):
+                self.assertEqual(main(), 0)
+            api.request.assert_not_called()
+            approved = json.loads(path.read_text())["expectedHash"]
+            with patch.object(sys, "argv", ["agent_flow", "run", "--apply", "--expected-hash", "stale", "--report-file", str(Path(directory) / "stale.json")]):
+                self.assertEqual(main(), 1)
+            api.request.assert_not_called()
+            result = Path(directory) / "run.json"
+            with patch.object(sys, "argv", ["agent_flow", "run", "--apply", "--expected-hash", approved, "--report-file", str(result)]):
+                self.assertEqual(main(), 0)
+            api.request.assert_called_once_with("POST", identifier + "/triggers/manual/run", {}, flow=True)
+            self.assertEqual(json.loads(result.read_text())["status"], "run-accepted")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add independent agent-flows skill, catalog entry and GeekPowerCode registration.
- Include auth_helper-based create/publish/run/inspect CLI with reviewed hashes, graph/runtime parity, modernflowtype readback and sanitized output checks.
- Add Code Apps request/result integration guidance; existing v2 bot invocation remains a separate unverified contract.

## Validation
- 6 Python tests passed; validate_skill passed locally and in publication clone.
- Generic CLI live create: created-verified; publish: published-verified; run: run-accepted; history retrieved.
- Runtime fixed JSON acceptance remains pending ACP propagation (442). User approved continuing implementation and skill publication; no policy broadening.
- New UI network capture is incomplete. Flow RP run/history API is unsupported per Microsoft Learn; Dataverse create/state updates are documented.

## Merge Order
- Prefer existing admin PR #435 first, then this independent skill PR; rebase if needed.
- No app files, tenant-specific evidence or credentials included. Do not merge automatically.