### PR TITLE
feat(agent-flows): preserve API Hub and existing-agent lessons

### DIFF
--- a/.github/skills/agent-flows/SKILL.md
+++ b/.github/skills/agent-flows/SKILL.md
@@ -79,6 +79,15 @@ run / Agent の Succeeded と固定 JSON 一致で `output-verified` になる�
 
 [非同期連携の契約](references/code-apps-integration.md) に従い、Code Apps からの要求・結果と既存 v2 bot 呼び出しを別段階で実装する。
 inline `InvokeDefinition` の成功を既存 v2 bot / MCP / スキルの実行成功と同一視しない。
+既存エージェントを利用する場合は [Agent ノードの診断](references/existing-agent-node.md) に従い、
+`.env` に対象 bot と接続参照を指定して読み取り専用の確認を行う。
+
+```powershell
+python .github/skills/agent-flows/scripts/inspect_agent_node.py --report-file .local/agent-flow/agent-discovery.json
+```
+
+`target-verified` は一覧上の対象照合のみで、エージェントは実行しない。
+Workflow の既存 Agent ノードは公式に案内されているが、ここで観測した直接 API は実験的経路として扱う。
 ACP 反映待ちでもユーザーの承認に基づき実装・モックテストを進められるが、実応答・本人認可・本番受入のゲートは保持する。
 
 ## Step 6: 検証と結果報告

--- a/.github/skills/agent-flows/references/.env.example
+++ b/.github/skills/agent-flows/references/.env.example
@@ -13,5 +13,10 @@ AGENT_FLOW_EXPECTED_JSON={"ok":true,"message":"agent-flow-ready"}
 # Set only after create returned created-verified.
 AGENT_FLOW_ID=<created-workflow-id>
 
+# Optional read-only existing-agent discovery; obtain from Dataverse bot and connection reference.
+AGENT_FLOW_BOT_ID=<existing-bot-id>
+AGENT_FLOW_BOT_NAME=<exact-existing-bot-display-name>
+AGENT_FLOW_CONNECTION_REFERENCE=<connection-reference-logical-name>
+
 # Local evidence contains environment/connection IDs; exclude from Git.
 # Add .local/agent-flow/ to the project's .gitignore.

--- a/.github/skills/agent-flows/references/api-contract.md
+++ b/.github/skills/agent-flows/references/api-contract.md
@@ -62,3 +62,9 @@ Server resource IDs are not cloned. Node IDs are scoped to each separate flow an
 - Output links may contain SAS credentials. Restrict to the observed environment-specific `environment.api.powerplatformusercontent.com` host, omit bearer and redirects, never log the URL or output body.
 - `body.message` is the expected response shape, still awaiting a successful live Agent response. A different successful output schema must be inspected and tested, not silently accepted.
 - Model availability, license/credits, connection ownership, new UI rollout and runtime ACP propagation remain environmental prerequisites.
+
+## Existing-Agent Discovery
+
+[Existing Agent node evidence](existing-agent-node.md) records the separate `InvokeAgent` contract and a read-only diagnostic.
+The API Hub runtime uses a different audience from connector metadata. Its successful list response, invocation and designer graph
+are not yet verified. The diagnostic deliberately does not extend the inline create/publish/run CLI to accept guessed existing-agent definitions.

--- a/.github/skills/agent-flows/references/existing-agent-node.md
+++ b/.github/skills/agent-flows/references/existing-agent-node.md
@@ -1,0 +1,87 @@
+# Existing Agent Node: Discovery And Evidence
+
+## Choose The Correct Route
+
+Microsoft Learn distinguishes these supported product experiences:
+
+- Standard harness: the Microsoft Copilot Studio connector in a Power Automate cloud flow.
+- GitHub Copilot harness: an existing Agent node in a Copilot Studio Workflow.
+- Web app iframe embedding is available for GitHub Copilot harness agents. That does not establish programmatic message delivery, user authorization or Code Apps CSP compatibility.
+
+Sources verified on 2026-09-09 using web retrieval because Learn MCP was unavailable:
+[Call agents](https://learn.microsoft.com/en-us/power-automate/call-copilot-studio-agent),
+[Available channels](https://learn.microsoft.com/en-us/microsoft-copilot-studio/agents-experience/publication-channels-overview).
+Do not turn one connector's harness rejection into a blanket claim that all automation or embedding is unsupported.
+
+## Observed API Contract
+
+These details came from authenticated connector metadata, not from a published authoring SDK.
+The documented Workflow experience does not guarantee support for direct API Hub calls.
+
+| Concern | Observed contract |
+|---|---|
+| Metadata | GET `https://api.powerapps.com/providers/Microsoft.PowerApps/apis/shared_agentnode` |
+| Metadata parameters | `api-version=2016-11-01`, `$filter=environment eq '<environment-id>'` |
+| Metadata authentication | `https://service.powerapps.com/.default` |
+| Runtime base | `properties.primaryRuntimeUrl`; environment-specific HTTPS API Hub host |
+| Runtime authentication | `https://apihub.azure.com/.default` |
+| ListAgents | GET `/{connectionId}/powerautomate/agentnodes/agents` relative to runtime base |
+| InvokeAgent | POST `/{connectionId}/powerautomate/agentnodes/conversations` relative to runtime base |
+| InvokeAgent input | `agentId`, `prompt`; optional `isHitlEscalationEnabled` and `outputSchema` |
+| InvokeAgent output schema | HTTP 201 with `result`, `structuredOutput`, `files` |
+| Inline alternative | `InvokeDefinition`, with `body/botDefinition` and `body/message`; not the existing bot |
+
+The ListAgents dynamic-values metadata names `agents/agentId/agentName`, while its referenced response type names `entities`.
+An actual successful list response remains unverified. Do not invent mappings for unknown entity shapes.
+
+## Read-Only Diagnostic
+
+Configure `ENV_ID`, `DATAVERSE_URL`, `AGENT_FLOW_BOT_ID`, `AGENT_FLOW_BOT_NAME` and
+`AGENT_FLOW_CONNECTION_REFERENCE` using `.env` and the standard auth helper. Do not reuse the shared bot-ID file for a newly created agent.
+
+```powershell
+python .github/skills/agent-flows/scripts/inspect_agent_node.py --report-file .local/agent-flow/discovery.json
+```
+
+The script verifies the exact Dataverse bot ID, display name and cliagent template; resolves one Agent node connection reference;
+checks the observed Swagger operations; validates the environment-bound runtime host; then performs ListAgents with the API Hub audience.
+It sends only GET requests, never invokes an agent, modifies policies, publishes a flow or changes credentials.
+
+| Result | Meaning |
+|---|---|
+| `target-verified` (exit 0) | Exactly one list entry matches the expected bot ID or schema name and display name |
+| `runtime-policy-blocked` (exit 2) | HTTP 442 at the recorded stage; no automatic retry or policy modification |
+| `contract-mismatch` (exit 2) | Identity, host, metadata or list shape differs; stop rather than guess |
+| `http-error` / `request-failed` (exit 2) | HTTP or transport failure; sanitized report without response body |
+
+Every result retains `agentInvoked: false` and `runtimeValidated: false`.
+Reports omit names, IDs, tokens, response text and signed file URLs. Existing report files are not overwritten.
+`resolve_agent()` rejects duplicate matches, multiple collection shapes, pagination and unknown response formats.
+`validate_runtime_url()` rejects other environments, credentials, query strings, fragments and unobserved hosts.
+
+## Verification Boundary
+
+The corrected API Hub audience reached HTTP 442 at ListAgents in the development environment.
+That confirms progress beyond the earlier audience rejection, not successful target enumeration or agent execution.
+Policy configuration readback, runtime policy evaluation, publish acceptance and business output are separate gates.
+If another session owns governance, report the stage and status without changing or repeatedly rechecking its settings.
+
+Before adding an invocation path:
+
+1. Verify a real ListAgents response and identify the intended bot without guessing its ID.
+2. Verify the existing-agent designer graph independently of inline graph settings.
+3. Review the exact prompt, intended side effects and connection owner. Disable human escalation when email notification is not authorized.
+4. Treat HTTP 200/201 as transport evidence only. Inspect run completion, actual response and generated artifacts separately.
+5. Validate downloaded candidate bytes with the domain validator. A file count, attachment hash, success-shaped message or local mock test is not evidence of cloud execution.
+6. Keep timeouts indeterminate and reconcile before retrying. Do not substitute an inline agent silently.
+
+## Reproducible Agent Delivery
+
+Keep each agent's desired configuration and resulting bot ID separate. Verify uploaded skill bytes by download and SHA-256,
+preserve unrelated MCP components and confirm a repeated application is a no-op before calling it reproducible.
+One agent's no-op does not prove the process works for a second agent. A second existing-agent check must remain non-destructive.
+
+Agent instructions must make validation claims conditional on executing the actual candidate validator successfully.
+Distinguish validation not run, validation failed, and validation passed. Preserve baseline identifiers and locked structure;
+do not fabricate output logs or claim persistence without successful writes and readback. These instructions require domain tests,
+not just string-matching tests. Keep human adoption separate from candidate generation.

--- a/.github/skills/agent-flows/references/troubleshooting.md
+++ b/.github/skills/agent-flows/references/troubleshooting.md
@@ -1,3 +1,17 @@
+# Agent Node Audience And Response Boundaries
+
+- Direct API Hub requests with the metadata audience can fail token exchange before reaching the connector.
+	Use the observed API Hub audience only for a validated environment-bound runtime URL. Permanent guards:
+	`inspect_agent_node.validate_runtime_url()` and separate `METADATA_SCOPE` / `RUNTIME_SCOPE` sessions.
+- Connector metadata requires the observed `$filter=environment eq '<environment-id>'`; a plain `environment` parameter returned HTTP 400.
+	`inspect_agent_node.inspect_agent()` supplies the filter on every metadata request.
+- ListAgents response declarations disagree between `agents` and `entities`. `resolve_agent()` requires a complete, unambiguous
+	ID/name match and rejects unknown formats. Add a fixture from sanitized successful evidence before accepting another shape.
+- A 442 after correcting the audience is still a policy block, not an invocation success. The diagnostic returns a sanitized
+	`runtime-policy-blocked` report and performs no policy changes or automatic retry.
+- HTTP 201, `result` text or attached file count alone do not prove the requested skill ran. Keep invocation, artifact retrieval,
+	domain validation and user approval as separate checks. See [existing-agent evidence](existing-agent-node.md).
+
 # Troubleshooting
 
 ## Classic Experience Instead Of New Workflow

--- a/.github/skills/agent-flows/scripts/inspect_agent_node.py
+++ b/.github/skills/agent-flows/scripts/inspect_agent_node.py
@@ -1,0 +1,137 @@
+"""Read-only, experimental existing-agent discovery. Never invokes an agent."""
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlsplit
+from uuid import UUID
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard" / "scripts"))
+
+CONNECTOR = "/providers/Microsoft.PowerApps/apis/shared_agentnode"
+METADATA_SCOPE = "https://service.powerapps.com/.default"
+RUNTIME_SCOPE = "https://apihub.azure.com/.default"
+LIST_PATH = "/{connectionId}/powerautomate/agentnodes/agents"
+INVOKE_PATH = "/{connectionId}/powerautomate/agentnodes/conversations"
+
+
+class ApiFailure(Exception):
+    def __init__(self, status):
+        self.status = status
+        super().__init__(f"HTTP {status}")
+
+
+def get_json(session, url, **kwargs):
+    response = session.get(url, timeout=90, allow_redirects=False, **kwargs)
+    if response.status_code != 200:
+        raise ApiFailure(response.status_code)
+    value = response.json()
+    if not isinstance(value, dict):
+        raise ValueError("Expected a JSON object")
+    return value
+
+
+def validate_runtime_url(value, environment):
+    environment = str(UUID(environment))
+    parsed = urlsplit(value)
+    host_pattern = re.escape(environment) + r"\.[a-z0-9-]+\.common\.[a-z0-9-]+\.azure-apihub\.net"
+    if (parsed.scheme != "https" or parsed.username or parsed.password or parsed.query
+            or parsed.fragment or parsed.port not in (None, 443)
+            or not re.fullmatch(host_pattern, parsed.hostname or "")
+            or parsed.path != "/apim/agentnode"):
+        raise ValueError("Runtime URL is outside the observed environment-bound contract")
+    return value.rstrip("/")
+
+
+def validate_operations(swagger):
+    paths = swagger["paths"]
+    if paths[LIST_PATH]["get"]["operationId"] != "ListAgents":
+        raise ValueError("ListAgents contract changed")
+    operation = paths[INVOKE_PATH]["post"]
+    bodies = [parameter for parameter in operation["parameters"] if parameter.get("in") == "body"]
+    if (operation["operationId"] != "InvokeAgent" or len(bodies) != 1
+            or not {"agentId", "prompt"}.issubset(bodies[0]["schema"].get("required", []))):
+        raise ValueError("InvokeAgent contract changed")
+
+
+def resolve_agent(payload, bot):
+    collections = [payload[key] for key in ("agents", "entities") if key in payload]
+    if len(collections) != 1 or not isinstance(collections[0], list) or payload.get("moreRecords"):
+        raise ValueError("Ambiguous, incomplete or unknown ListAgents response")
+    entries = collections[0]
+    matches = [entry for entry in entries if isinstance(entry, dict)
+               and entry.get("agentName") == bot["name"]
+               and entry.get("agentId") in (bot["botid"], bot["schemaname"])]
+    if len(matches) != 1:
+        raise ValueError("Expected exactly one matching agent ID and name")
+    return matches[0]["agentId"]
+
+
+def inspect_agent(environment, bot_id, bot_name, reference_name, dataverse_url, session_factory):
+    report = {"status": "started", "stage": "input", "runtimeValidated": False, "agentInvoked": False}
+    try:
+        environment, bot_id = str(UUID(environment)), str(UUID(bot_id))
+        if not bot_name or not reference_name:
+            raise ValueError("Expected bot name and connection reference")
+        api = dataverse_url.rstrip("/") + "/api/data/v9.2/"
+        dataverse = session_factory()
+        report["stage"] = "bot-identity"
+        bot = get_json(dataverse, api + f"bots({bot_id})", params={
+            "$select": "botid,name,schemaname,template"})
+        if bot["botid"] != bot_id or bot["name"] != bot_name or bot["template"] != "cliagent-1.0.0":
+            raise ValueError("Bot identity mismatch")
+        report["stage"] = "connection-reference"
+        references = get_json(dataverse, api + "connectionreferences", params={
+            "$select": "connectionid,connectorid",
+            "$filter": "connectionreferencelogicalname eq '" + reference_name.replace("'", "''") + "'"})
+        if len(references.get("value", [])) != 1 or references.get("@odata.nextLink"):
+            raise ValueError("Expected one complete connection reference result")
+        reference = references["value"][0]
+        if reference["connectorid"] != CONNECTOR:
+            raise ValueError("Wrong connector")
+        connection = reference["connectionid"].rsplit("/", 1)[-1]
+        if not re.fullmatch(r"[a-zA-Z0-9-]+", connection):
+            raise ValueError("Invalid connection ID")
+        report["stage"] = "connector-metadata"
+        connector = get_json(session_factory(METADATA_SCOPE), "https://api.powerapps.com" + CONNECTOR,
+                             params={"api-version": "2016-11-01", "$filter": f"environment eq '{environment}'"})
+        properties = connector["properties"]
+        validate_operations(properties["swagger"])
+        base = validate_runtime_url(properties["primaryRuntimeUrl"], environment)
+        report["stage"] = "list-agents"
+        payload = get_json(session_factory(RUNTIME_SCOPE), base + LIST_PATH.replace("{connectionId}", connection))
+        resolve_agent(payload, bot)
+        report["status"] = "target-verified"
+    except ApiFailure as error:
+        report.update(status="runtime-policy-blocked" if error.status == 442 else "http-error", httpStatus=error.status)
+    except (ValueError, KeyError, TypeError, AttributeError):
+        report["status"] = "contract-mismatch"
+    except Exception:
+        report["status"] = "request-failed"
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report-file", type=Path, required=True)
+    args = parser.parse_args()
+    if args.report_file.exists():
+        parser.error("Report exists; use a new path")
+    from auth_helper import DATAVERSE_URL, get_session
+    report = inspect_agent(os.environ.get("ENV_ID", ""), os.environ.get("AGENT_FLOW_BOT_ID", ""),
+                           os.environ.get("AGENT_FLOW_BOT_NAME", ""),
+                           os.environ.get("AGENT_FLOW_CONNECTION_REFERENCE", ""), DATAVERSE_URL, get_session)
+    report["checkedAt"] = datetime.now(timezone.utc).isoformat()
+    args.report_file.parent.mkdir(parents=True, exist_ok=True)
+    with args.report_file.open("x", encoding="utf-8") as output:
+        json.dump(report, output, indent=2)
+    print(json.dumps(report, indent=2))
+    return 0 if report["status"] == "target-verified" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/agent-flows/tests/test_inspect_agent_node.py
+++ b/.github/skills/agent-flows/tests/test_inspect_agent_node.py
@@ -1,0 +1,107 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+from uuid import UUID
+
+SPEC = importlib.util.spec_from_file_location("inspect_agent_node", Path(__file__).resolve().parents[1] / "scripts/inspect_agent_node.py")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+ENVIRONMENT = str(UUID(int=1))
+BOT_ID = str(UUID(int=2))
+BASE = f"https://{ENVIRONMENT}.09.common.usa002.azure-apihub.net/apim/agentnode"
+BOT = {"botid": BOT_ID, "name": "Sample Agent", "schemaname": "sample_agent", "template": "cliagent-1.0.0"}
+
+
+def response(payload, status=200):
+    result = Mock(status_code=status)
+    result.json.return_value = payload
+    return result
+
+
+def sessions(runtime_status=200):
+    dataverse, metadata, runtime = Mock(), Mock(), Mock()
+    dataverse.get.side_effect = [response(BOT), response({"value": [{"connectorid": MODULE.CONNECTOR, "connectionid": "sample-connection"}]})]
+    swagger = {"paths": {
+        MODULE.LIST_PATH: {"get": {"operationId": "ListAgents"}},
+        MODULE.INVOKE_PATH: {"post": {"operationId": "InvokeAgent", "parameters": [
+            {"in": "body", "schema": {"required": ["agentId", "prompt"]}}]}},
+    }}
+    metadata.get.return_value = response({"properties": {"primaryRuntimeUrl": BASE, "swagger": swagger}})
+    runtime.get.return_value = response({"agents": [{"agentId": BOT_ID, "agentName": BOT["name"]}]}, runtime_status)
+    factory = Mock(side_effect=[dataverse, metadata, runtime])
+    return factory, dataverse, metadata, runtime
+
+
+class AgentNodeInspectionTests(unittest.TestCase):
+    def inspect(self, factory):
+        return MODULE.inspect_agent(ENVIRONMENT, BOT_ID, BOT["name"], "sample_reference", "https://example.invalid", factory)
+
+    def test_success_is_discovery_only_and_uses_separate_audiences(self):
+        factory, dataverse, metadata, runtime = sessions()
+        report = self.inspect(factory)
+        self.assertEqual(report["status"], "target-verified")
+        self.assertFalse(report["runtimeValidated"])
+        self.assertFalse(report["agentInvoked"])
+        self.assertEqual([call.args for call in factory.call_args_list], [(), (MODULE.METADATA_SCOPE,), (MODULE.RUNTIME_SCOPE,)])
+        self.assertEqual(metadata.get.call_args.kwargs["params"]["$filter"], f"environment eq '{ENVIRONMENT}'")
+        for session in (dataverse, metadata, runtime):
+            session.post.assert_not_called()
+            session.patch.assert_not_called()
+            session.delete.assert_not_called()
+            for call in session.get.call_args_list:
+                self.assertFalse(call.kwargs["allow_redirects"])
+
+    def test_policy_block_is_sanitized_without_retry(self):
+        factory, _, _, runtime = sessions(442)
+        runtime.get.return_value.json.return_value = {"message": "secret-output-url"}
+        report = self.inspect(factory)
+        self.assertEqual(report["status"], "runtime-policy-blocked")
+        self.assertEqual(report["stage"], "list-agents")
+        self.assertNotIn("secret", json.dumps(report))
+        runtime.get.assert_called_once()
+        runtime.get.return_value.json.assert_not_called()
+
+    def test_host_guard_rejects_other_environments_and_credentials(self):
+        self.assertEqual(MODULE.validate_runtime_url(BASE, ENVIRONMENT), BASE)
+        for value in (BASE.replace(ENVIRONMENT, BOT_ID), BASE + "?sig=secret", BASE + "#fragment",
+                      BASE.replace("https:", "http:"), BASE.replace("https://", "https://user:secret@"),
+                      BASE.replace(".net/", ".net.evil/"), BASE.replace(".net/", ".net:444/")):
+            with self.assertRaises(ValueError):
+                MODULE.validate_runtime_url(value, ENVIRONMENT)
+
+    def test_identity_and_schema_ambiguity_fail_closed(self):
+        entry = {"agentId": BOT_ID, "agentName": BOT["name"]}
+        self.assertEqual(MODULE.resolve_agent({"entities": [entry]}, BOT), BOT_ID)
+        for payload in ({"agents": []}, {"agents": [entry, entry]}, {"agents": [entry], "entities": [entry]},
+                        {"agents": [entry], "moreRecords": True}, {"entities": [{"id": BOT_ID}]},
+                        {"agents": [{**entry, "agentId": "other"}]}):
+            with self.assertRaises(ValueError):
+                MODULE.resolve_agent(payload, BOT)
+
+    def test_wrong_connector_stops_before_runtime_auth(self):
+        factory, dataverse, _, _ = sessions()
+        dataverse.get.side_effect = [response(BOT), response({"value": [{"connectorid": "other"}]})]
+        self.assertEqual(self.inspect(factory)["status"], "contract-mismatch")
+        factory.assert_called_once_with()
+
+    def test_swagger_change_stops_before_runtime_auth(self):
+        factory, _, metadata, _ = sessions()
+        metadata.get.return_value.json.return_value["properties"]["swagger"]["paths"][MODULE.INVOKE_PATH]["post"]["operationId"] = "InvokeDefinition"
+        self.assertEqual(self.inspect(factory)["status"], "contract-mismatch")
+        self.assertEqual(factory.call_count, 2)
+
+    def test_http_and_transport_errors_do_not_expose_details(self):
+        for status in (201, 302, 400, 401, 403, 500):
+            factory, _, _, _ = sessions(status)
+            self.assertEqual(self.inspect(factory)["status"], "http-error")
+        factory, _, _, runtime = sessions()
+        runtime.get.side_effect = RuntimeError("Authorization: secret")
+        report = self.inspect(factory)
+        self.assertEqual(report["status"], "request-failed")
+        self.assertNotIn("secret", json.dumps(report))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Follow up after merged PR #436; only seven files under agent-flows change.
- Add a read-only existing-agent diagnostic with distinct metadata/API Hub audiences, strict environment host checks, exact bot/reference identity and fail-closed Swagger/list validation.
- Record InvokeAgent versus inline InvokeDefinition, documented Workflow/iframe capabilities, evidence limits, reproducible delivery and conditional domain-validation claims.
- No policy changes, agent invocation, tenant-specific artifacts, application files or unrelated skill changes.

## Validation
- 13 Python tests pass locally and in the publication clone.
- validate_skill passes locally and in the publication clone; git diff --check passes.
- Read-only live diagnostic reproduces list-agents HTTP 442 with agentInvoked=false and runtimeValidated=false. Successful enumeration and invocation remain unverified.
- Microsoft Learn was rechecked by web retrieval because Learn MCP is unavailable. Direct API Hub operations remain experimental.

## Merge Order
- PR #436 was merged first, as requested. This PR is based on the resulting main.
- Admin PR #435 belongs to a separate session and is not changed or required by this diff.
- The user explicitly requested creating and merging this follow-up after validation.