### PR TITLE
fix(agent-flows): verify completed results and distinguish execution evidence

### DIFF
--- a/.github/skills/agent-flows/SKILL.md
+++ b/.github/skills/agent-flows/SKILL.md
@@ -72,6 +72,8 @@ python .github/skills/agent-flows/scripts/agent_flow.py inspect --run-id <run-id
 
 実行受付は `run-accepted` として記録し、成功扱いにしない。履歴の開始時刻と対象 ID を照合して run を指定する。
 run / Agent の Succeeded と固定 JSON 一致で `output-verified` になる。
+出力の `body.message`、または `body.status=Completed` の `body.result` を検証する。
+実行成功と回答内容の検証は別に記録する。利用者から成功 run ID の報告を受けた場合は、再実行せずその履歴を照合する。
 履歴の最新1件を無条件に今回の run とみなさず、同時実行時は明示的に識別する。
 成功以外は [異常系](references/troubleshooting.md) に従う。自動リトライ・待機ループ・許可範囲拡大は行わない。
 

--- a/.github/skills/agent-flows/references/code-apps-integration.md
+++ b/.github/skills/agent-flows/references/code-apps-integration.md
@@ -11,9 +11,25 @@
 
 ## Required Existing V2 Bot Proof
 
-The new designer offers a separate Copilot node. Capture its selected-bot connector operation, bot schema name, inputs and output shape from a dedicated draft.
+The new designer offers an existing Agent node. Capture its selected-bot connector operation, bot schema name, inputs and output shape from a dedicated draft.
 Verify the exact existing bot with a fixed response and then its skill/MCP execution. Do not infer that `InvokeDefinition` calls that bot, or that classic `ExecuteCopilotAsyncV2` supports the new architecture.
 Until this contract is verified, implement and test the request/result adapter independently; do not substitute another model silently.
+
+## Conversational Wizard And Assistant
+
+Use one in-app conversation beside the preview. Persist a conversation ID, turn ID and monotonically increasing
+conditions version with each request; include bounded conversation context and confirmed structured conditions.
+The agent asks for missing conditions or returns a candidate, while code validates the response discriminant and payload.
+Keep confirmed conditions and the preview separate from the saved design. Never describe a local canned response as an Agent reply.
+
+New messages may be collected during generation, but supersede older conditions explicitly. A result must match the
+conversation, turn, conditions version, base revision/hash and selected object before it can update a preview or assistant answer.
+Show only persisted execution states, not guessed progress percentages. A timeout is indeterminate until reconciled;
+local cancellation does not authorize another billable call or guarantee remote cancellation.
+
+Reuse the request/result transport for the existing assistant only after its selected-object context and user authorization
+tests pass. Use distinct allowlisted operations for design proposals and read-only knowledge answers, with separate validators.
+Enable each path independently after real response tests. Preserve the existing assistant and manual fallback until then.
 
 ## Security And Acceptance
 

--- a/.github/skills/agent-flows/references/troubleshooting.md
+++ b/.github/skills/agent-flows/references/troubleshooting.md
@@ -28,6 +28,11 @@ Allow implementation to continue under explicit user approval while propagation 
 Do not add more connectors, disable DLP/ACP or reapply policies automatically. Retest once after propagation is confirmed or at an agreed checkpoint.
 Persistent divergence belongs in a support case. Setting save, new UI Review and runtime execution are three different checks.
 
+When a user reports a later successful run, read that exact workflow/run pair without submitting another run.
+Compare start/end timestamps, run status, Agent status and downloaded output. A later successful run supersedes
+the old block only for that tested path; keep the old 442 as history, not as proof that all current calls fail.
+Do not infer that an inline success proves ListAgents, an existing bot, MCP tools or public web chat authorization.
+
 ## Template Or Readback Rejected
 
 `validate_client` checks graph/runtime instruction, model, connection and mapping parity, empty tools, no web/human assistance and the input-free trigger.
@@ -46,3 +51,13 @@ The management endpoint may return an empty HTTP 200 body. Use run history and e
 `classify_output` requires successful run and action plus parsed JSON equality; boolean and number differences are rejected.
 Output mismatch is not repaired by stripping markdown or inventing missing fields.
 Code Apps inputs must not be sent using this input-free smoke transport.
+
+## Completed Agent With Empty Result
+
+A successful inline run was observed with HTTP 200 and `body` containing `conversationId`, `status: Completed`
+and an empty string `result`. This proves execution completion, not the requested answer or skill execution.
+The run/action may both be Succeeded while output verification remains incomplete. Do not fabricate a fallback answer.
+Permanent guard: `classify_output` accepts exactly one of legacy `message` or completed `result`, parses exact JSON,
+and rejects empty text, unknown/non-completed status, ambiguous fields and unexpected HTTP status.
+`test_completed_result_requires_nonempty_exact_json` covers these cases. This is an observed runtime shape,
+not a guarantee that all Agent operations share this response contract.

--- a/.github/skills/agent-flows/scripts/agent_flow.py
+++ b/.github/skills/agent-flows/scripts/agent_flow.py
@@ -114,8 +114,17 @@ def classify_output(run_status, action_status, output, expected):
         return {"status": "runtime-policy-blocked", "httpStatus": 442}
     if run_status != "Succeeded" or action_status != "Succeeded":
         return {"status": "run-not-succeeded"}
+    if "statusCode" in output and output["statusCode"] not in (200, 201):
+        return {"status": "output-mismatch"}
     body = output.get("body", {})
-    message = body.get("message") if isinstance(body, dict) else None
+    if not isinstance(body, dict):
+        return {"status": "output-mismatch"}
+    if "status" in body and body["status"] != "Completed":
+        return {"status": "output-mismatch"}
+    fields = [key for key in ("message", "result") if key in body]
+    if len(fields) != 1 or (fields[0] == "result" and body.get("status") != "Completed"):
+        return {"status": "output-mismatch"}
+    message = body[fields[0]]
     try:
         actual = json.loads(message) if isinstance(message, str) else None
     except ValueError:

--- a/.github/skills/agent-flows/tests/test_agent_flow.py
+++ b/.github/skills/agent-flows/tests/test_agent_flow.py
@@ -91,6 +91,19 @@ class AgentFlowTests(unittest.TestCase):
             with self.subTest(url=bad), self.assertRaises(ValueError):
                 safe_output_url(bad, environment)
 
+    def test_completed_result_requires_nonempty_exact_json(self):
+        expected = {"ok": True}
+        body = {"status": "Completed", "result": '{"ok":true}'}
+        self.assertEqual(classify_output("Succeeded", "Succeeded", {"statusCode": 200, "body": body}, expected)["status"], "output-verified")
+        invalid = [dict(body, result=""), dict(body, result="   "), dict(body, result={"ok": True}),
+                   dict(body, status="Running"), dict(body, status="Failed"),
+                   {"result": '{"ok":true}'}, dict(body, message='{"ok":true}'),
+                   dict(body, result='{"ok":1}'), [], None]
+        for value in invalid:
+            with self.subTest(body=value):
+                self.assertEqual(classify_output("Succeeded", "Succeeded", {"statusCode": 200, "body": value}, expected)["status"], "output-mismatch")
+        self.assertEqual(classify_output("Succeeded", "Succeeded", {"statusCode": 500, "body": body}, expected)["status"], "output-mismatch")
+
     def test_run_cli_requires_approval_and_reports_acceptance_only(self):
         identifier = "00000000-0000-0000-0000-000000000000"
         settings = {"ENV_ID": identifier, "AGENT_FLOW_ID": identifier, "AGENT_FLOW_NAME": "sample",


### PR DESCRIPTION
## Summary
- Validate observed Completed/result responses alongside legacy message responses; reject empty, incomplete, ambiguous and nonmatching outputs.
- Record exact successful run evidence without treating historical 442 failures as current failures or execution success as a business answer.
- Document versioned conversational wizard/assistant requests and separate authorization, existing-agent, MCP and adoption gates.

## Validation
- 14 unittest cases passed locally and in the publication clone.
- validate_skill.py passed locally and in the publication clone; no tenant-specific artifacts included.
- Microsoft Learn call-agents documentation rechecked via web retrieval (Learn MCP unavailable).

## Merge order
Independent agent-flows-only change. No overlap or dependency on admin PR #435; do not modify or merge that PR as part of this work.

## Limits
The observed successful inline execution had an empty result. Existing-bot, MCP and Code Apps end-to-end acceptance remain separate gates.