### PR TITLE
feat(skills): contextual design chat and verified conversation workers

### DIFF
--- a/.github/skills/agent-flows/SKILL.md
+++ b/.github/skills/agent-flows/SKILL.md
@@ -92,6 +92,18 @@ python .github/skills/agent-flows/scripts/inspect_agent_node.py --report-file .l
 Workflow の既存 Agent ノードは公式に案内されているが、ここで観測した直接 API は実験的経路として扱う。
 ACP 反映待ちでもユーザーの承認に基づき実装・モックテストを進められるが、実応答・本人認可・本番受入のゲートは保持する。
 
+既存 bot を呼ぶ要求/結果ワーカーは [構築・更新・受入パターン](references/conversation-worker.md) を使う。
+`conversation_contract.py` の定義・要求者・相関・結果検証を実装に組み込み、
+テーブル/列/許可対象を `.env` で指定して既存要求を読み取り検証する。
+
+```powershell
+python .github/skills/agent-flows/scripts/inspect_conversation.py --request-id <accepted-request-id>
+```
+
+このコマンドは GET のみ。`reply-envelope-verified` は相関/所有者/応答形式の成功であり、
+設計の幾何検証や回答の正しさは別ゲート。単一ユーザー限定なら対象変更を明示承認し、
+サーバーの CreatedBy を許可 ID と照合する。クライアント表示制限だけを認可にしない。
+
 ## Step 6: 検証と結果報告
 
 ```powershell

--- a/.github/skills/agent-flows/references/.env.example
+++ b/.github/skills/agent-flows/references/.env.example
@@ -20,3 +20,14 @@ AGENT_FLOW_CONNECTION_REFERENCE=<connection-reference-logical-name>
 
 # Local evidence contains environment/connection IDs; exclude from Git.
 # Add .local/agent-flow/ to the project's .gitignore.
+
+# Optional GET-only conversation inspection. Obtain logical names and entity sets from metadata.
+CONVERSATION_REQUEST_TABLE=<request-table-logical-name>
+CONVERSATION_REQUEST_SET=<request-entity-set-name>
+CONVERSATION_RESULT_SET=<result-entity-set-name>
+CONVERSATION_REQUEST_JSON_COLUMN=<request-json-column>
+CONVERSATION_RESULT_JSON_COLUMN=<result-json-column>
+CONVERSATION_RESULT_LOOKUP=<result-to-request-lookup-column>
+# Server-owned systemuserid of the explicitly approved single user, not an email or Entra object ID.
+CONVERSATION_ALLOWED_USER_ID=<allowed-dataverse-user-id>
+CONVERSATION_ALLOWED_OPERATION=<allowed-design-operation>

--- a/.github/skills/agent-flows/references/code-apps-integration.md
+++ b/.github/skills/agent-flows/references/code-apps-integration.md
@@ -4,10 +4,10 @@
 
 1. Keep the existing app and v1 channel available. Develop the new path behind a disabled-by-default feature setting.
 2. Code Apps creates a user-owned Dataverse request with a server-generated ID, client correlation key, base design revision/hash, operation, bounded input JSON and Pending status.
-3. A Dataverse-triggered flow claims the request using a conditional update. Duplicate events must not start duplicate billable Agent calls or overwrite a completed result.
+3. A Dataverse-triggered flow claims the request using an atomic conditional update or insert-only result row with a unique request lookup. Invocation depends on successful claim creation. Trigger concurrency alone is not deduplication. Duplicate events must not start duplicate billable Agent calls or overwrite a completed result.
 4. Invoke the chosen engine and persist a terminal result through a separate result table or a server-validated transition. An inline Agent is not an existing v2 bot.
 5. The app reads only authorized results, supports bounded polling/cancellation/timeouts and ignores stale responses after navigation or base design changes.
-6. Parse the response through the app's existing design schema and domain validators. AI output is a proposal; adoption remains an explicit user action.
+6. Parse the response through the app's existing design schema and domain validators. AI output is a proposal. With explicit product approval, validated candidates may update an unsaved editing draft with Undo; shared saving or publishing always remains an explicit user action.
 
 ## Required Existing V2 Bot Proof
 
@@ -33,12 +33,12 @@ Enable each path independently after real response tests. Preserve the existing 
 
 ## Security And Acceptance
 
-- Request CreatedBy comes from Dataverse, never a client-supplied identity. Client correlation keys require an alternate key including requester scope.
+- Request CreatedBy comes from Dataverse, never a client-supplied identity. Use a globally unique turn UUID key or a supported requester-scoped key; verify actual key activation and duplicate rejection. A system-managed CreatedBy lookup may not be eligible for the desired alternate key. Uniqueness does not replace authorization.
 - Restrict request payload operations and sizes server-side. Ordinary users must not set Completed/result/engine identity fields.
 - A maker-owned connector runs with maker permissions, not requester permissions. Filter/authorize data retrieval for the requester or restrict the operation to the submitted design payload. This must be proven before enabling real knowledge retrieval.
 - Results need explicit sharing/ownership matching the requesting user. Test with a second ordinary user that cross-user reads and writes fail.
 - Conditional state transitions, retries, cancellation, timeouts and late completion must have deterministic behavior. UI cancellation alone does not cancel remote processing.
-- Design results must preserve locked modules, specified boundary/exclusions, base revision and output limits. No automatic adoption, saving, email or resource changes by the AI.
+- Design results must preserve locked modules, specified boundary/exclusions, base revision and output limits. Selected-object requests must additionally preserve unrelated units and connections. Only an explicitly approved unsaved-draft auto-apply mode may change the preview; never automatically save, email or change external resources.
 - Acceptance gates: Dataverse round-trip, duplicate delivery, failure/timeout, stale response, ordinary-user authorization, exact existing bot/skill invocation, desktop/mobile workflow, explicit adoption.
 
-The bundled CLI currently automates only the manual inline smoke lifecycle. Dataverse trigger generation, request tables, existing-bot invocation and app deployment are not claimed as implemented by this skill.
+The lifecycle CLI automates the manual inline smoke flow. The GET-only conversation inspection CLI also verifies existing request/result envelopes; it does not generate tables or triggers, invoke a bot, deploy an app, or validate domain geometry. See [conversation-worker.md](conversation-worker.md) for the independently tested implementation pattern and its remaining boundaries.

--- a/.github/skills/agent-flows/references/conversation-worker.md
+++ b/.github/skills/agent-flows/references/conversation-worker.md
@@ -1,0 +1,92 @@
+# User-Owned Conversation Worker
+
+## Architecture And Consent
+
+Keep the existing knowledge assistant and tools unchanged. Add an independently enabled design operation:
+Code Apps authenticated request creation -> Dataverse insert trigger -> unique result claim -> existing bot
+InvokeAgent -> persisted result -> bounded client reads -> independent domain validation -> editing draft.
+Obtain approval for the chosen bot, connectors, request payload, permitted users and draft auto-apply behavior.
+Changing to a tool-free draft bot is an architectural choice, not a silent model fallback.
+
+Design-only execution can be limited to supplied JSON. A maker-owned tool connection must never be presented as
+requester-scoped knowledge access. Enable knowledge and design separately after their own acceptance tests.
+Run environment, classic DLP and inherited ACP checks before implementation. Do not broaden policy after an
+indeterminate runtime failure merely because configuration checks passed.
+
+## Worker Contract
+
+1. Create user-owned request and result tables with active alternate keys. A globally unique turn UUID avoids
+   reliance on an unsupported system CreatedBy key. Give callers request Create/Read and result Read only.
+   Inspect actual role privileges after role creation and after any broad role generator runs.
+2. Persist immutable conversationId, turnId, integer version, allowlisted operation, exact basis and selection.
+   Fence untrusted business JSON, cap serialized UTF-8 payloads, and bound history independently.
+3. Read the request from Dataverse. Before claiming, compare server CreatedBy with owner and any approved
+   allowlist. Resolve an exact enabled account once, record its systemuserid, and distinguish it from Entra objectId.
+   Never read requester identity from prompt JSON. Single-user acceptance does not prove multi-user isolation.
+4. Insert the result with a unique request lookup (and optionally the same UUID primary key) and caller ownership.
+   Invoke only on Claim Succeeded; retain the claim on ambiguous failure. Concurrency=1 alone is insufficient.
+   Use a fixed bot schema and connection reference. Do not let request data select the engine or enable HITL.
+5. Disable connector auto-retries for a billable invocation. Persist running receipt before invoking, and persist
+   agent conversation ID/diagnostic on incomplete or timed-out output. A transport timeout is not a terminal failure.
+   Local wait cancellation stops reads, not remote execution. Resume the same receipt; never create a replacement
+   request merely because the response was lost. Reconciliation is a separate GET-only path, not an automatic retry.
+6. Accept only Completed plus a nonempty bounded result. Persist caller ownership and exact scope into the result.
+   The app checks request ID, full scope, identity and editing version again after every asynchronous boundary.
+   A successful connector action without a verified reply is not successful generation.
+
+`conversation_contract.py` supplies pure validation functions and is used by the normal lifecycle CLI and
+`inspect_conversation.py`. These are application/diagnostic guards, not a Dataverse server plugin or an authorization
+enforcement layer. Implement equivalent pre-claim checks in the worker; prove row permissions separately.
+
+## Updating And Publishing
+
+- Keep the worker stopped while changing its known definition. Bind the plan to environment, solution, full
+  definition, connection references, bot identity, state and ETag. Re-read immediately before a narrow PATCH.
+- Require top-level `clientdata.schemaVersion=1.0.0.0` (guarded by `validate_envelope`), category=5, type=1 and the
+  target new-UI discriminator. Runtime definitions and designer graph metadata are distinct acceptance gates.
+- ParseJson keyword support is narrower than arbitrary JSON Schema implementations. If `pattern` is rejected,
+  use supported length/type fields plus explicit UUID shape checks before Claim; do not simply remove validation.
+- Exact If-Match is the default concurrency guard. A 412 requires re-reading and a new decision, never blind retry.
+  An explicitly approved stopped-workflow snapshot mode can use If-Match:* only to prevent accidental creation.
+  It does NOT provide atomic version conflict protection; a read/write race remains. Do not describe it as CAS.
+- Verify actual `solutioncomponents` membership for both flow and bot. A solution header or local `.env` value
+  alone is not proof. If missing, plan an explicit AddSolutionComponent for only the intended component and
+  verify membership, preserving other solution membership and existing bots/tools.
+- Validate expected stopped definition before publish, then verify Active/Started and an identified run.
+  A blank new-UI graph cannot be reported as a verified designer canvas even if the runtime succeeds.
+
+## Diagnostics And Test Matrix
+
+Configure logical names, entity sets, approved systemuserid and operation in the local `.env` using the skill example.
+Run `inspect_conversation.py --request-id <accepted-request-id>` from the project with its configured auth_helper.
+Use the cached common authentication; do not print tokens or full prompts/results. The command only reads, emits
+sanitized status/byte count, exits 2 when no result exists and 1 when unverified. It does not retry or reconcile a
+remote conversation. Domain schema, geometry and requested-change correctness remain separate checks.
+
+Test duplicate create/claim, every scope mismatch, changed identity, changed base and selection, extra fields,
+oversized UTF-8, empty replies, multiple JSON blocks, late completion, request submission ambiguity, stopped reads,
+receipt resumption and result ownership. Verify exact preserved structures and unchanged unrelated objects.
+Test successful replies against the request's actual basis, not a bundled sample that may differ from the UI draft.
+
+Public acceptance uses normal visible-browser clicks and the latest deployed asset hash. Record request/run identity,
+selected object, baseline coordinates, changed coordinates, Undo/Redo and unsaved state. Scripted event dispatch is
+useful for local inspection but is not equivalent to visible-user acceptance. Test desktop/mobile layout and canvas
+pixels separately. Keep tenant-specific reports, emails, IDs and `.env` outside the public PR.
+
+## Evidence Boundaries
+
+This pattern has been exercised with a user-owned Dataverse round trip, a separately approved tool-free existing
+bot, domain-validated complete design JSON, public-host draft auto-apply and Undo/Redo. The published CLI's pure
+guards and GET-only inspection also ran against an existing successful request. This does not establish every
+tenant's connector contract, remote Python execution trace, all mobile workflows, ordinary-user isolation,
+knowledge retrieval authorization, automatic reconciliation or shared-save acceptance.
+
+## Official References
+
+- [Cloud flows using code](https://learn.microsoft.com/en-us/power-automate/manage-flows-with-code): workflow
+  table lifecycle, clientdata example, and explicit unsupported status of api.flow.microsoft.com.
+- [Conditional operations](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/perform-conditional-operations-using-web-api): exact ETag concurrency versus existing-only If-Match:*.
+- [AddSolutionComponent](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/reference/addsolutioncomponent): explicit solution inclusion.
+
+These pages were checked through Web retrieval because Learn MCP was unavailable. Observed Agent node runtime
+paths and new designer metadata are implementation observations, not a promise of supported public APIs.

--- a/.github/skills/agent-flows/scripts/agent_flow.py
+++ b/.github/skills/agent-flows/scripts/agent_flow.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 from urllib.parse import urlsplit
 from uuid import UUID, uuid4
+from conversation_contract import canonical_uuid, validate_envelope
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard/scripts"))
 
@@ -22,6 +23,7 @@ def digest(value):
 
 
 def validate_client(client):
+    validate_envelope(client)
     properties = client["properties"]
     definition = properties["definition"]
     if set(definition["triggers"]) != {"manual"} or set(definition["actions"]) != {"Agent"}:
@@ -150,12 +152,13 @@ class Api:
         self.dv_session = get_session()
         self.flow_session = get_session(FLOW_SCOPE)
 
-    def request(self, method, path, body=None, flow=False, solution=None):
+    def request(self, method, path, body=None, flow=False, solution=None, extra_headers=None):
         session = self.flow_session if flow else self.dv_session
         url = (self.flow if flow else self.dataverse) + path
         if flow:
             url += ("&" if "?" in url else "?") + "api-version=2016-11-01"
         headers = {"MSCRM.SolutionUniqueName": solution} if solution else {}
+        headers.update(extra_headers or {})
         response = session.request(method, url, json=body, headers=headers, timeout=120, allow_redirects=False)
         if not 200 <= response.status_code < 300:
             raise ValueError("API request failed: HTTP " + str(response.status_code))
@@ -163,6 +166,24 @@ class Api:
 
     def workflow(self, flow_id):
         return self.request("GET", f"workflows({flow_id})?$select={SELECT}")
+
+    def require_solution_component(self, component_id, component_type, solution):
+        component_id = canonical_uuid(component_id)
+        if type(component_type) is not int or component_type not in (29, 10185):
+            raise ValueError("Expected workflow or bot component")
+        if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_]*", solution):
+            raise ValueError("Invalid solution unique name")
+        rows = self.request("GET", f"solutions?$select=solutionid&$filter=uniquename eq '{solution}'&$top=2").get("value", [])
+        if len(rows) != 1:
+            raise ValueError("Unique target solution required")
+        solution_id = canonical_uuid(rows[0]["solutionid"])
+        components = self.request("GET", "solutioncomponents?$select=objectid,componenttype,_solutionid_value"
+                                  f"&$filter=objectid eq {component_id} and componenttype eq {component_type}"
+                                  f" and _solutionid_value eq {solution_id}&$top=2").get("value", [])
+        if (len(components) != 1 or canonical_uuid(components[0]["objectid"]) != component_id
+                or components[0]["componenttype"] != component_type
+                or canonical_uuid(components[0]["_solutionid_value"]) != solution_id):
+            raise ValueError("Actual solution membership not verified; plan explicit inclusion separately")
 
 
 def main():
@@ -257,12 +278,17 @@ def main():
                 flow_id = report["flowId"]
                 api.request("POST", "workflows", workflow_body(flow_id, name, plan["clientdata"]), solution=solution)
                 validate_workflow(api.workflow(flow_id), name, plan["clientdata"], 0)
+                api.require_solution_component(flow_id, 29, solution)
                 if digest(api.workflow(plan["sourceId"])) != plan["sourceHash"]:
                     raise ValueError("Source changed during create")
                 report["status"] = "created-verified"
             elif args.command == "publish":
+                api.require_solution_component(plan["flowId"], 29, solution)
                 before = api.workflow(plan["flowId"])
-                api.request("PATCH", "workflows(" + plan["flowId"] + ")", {"statecode": 1, "statuscode": 2})
+                if digest(before) != plan["workflowHash"] or not before.get("@odata.etag"):
+                    raise ValueError("Workflow changed or ETag missing before publish")
+                api.request("PATCH", "workflows(" + plan["flowId"] + ")", {"statecode": 1, "statuscode": 2},
+                            extra_headers={"If-Match": before["@odata.etag"]})
                 validate_workflow(api.workflow(plan["flowId"]), name, json.loads(before["clientdata"]), 1)
                 state = api.request("GET", plan["flowId"], flow=True)["properties"]["state"]
                 if state != "Started":

--- a/.github/skills/agent-flows/scripts/conversation_contract.py
+++ b/.github/skills/agent-flows/scripts/conversation_contract.py
@@ -1,0 +1,74 @@
+"""Pure guards for a user-owned asynchronous request/result integration."""
+
+import json
+import re
+from uuid import UUID
+
+SCOPE_FIELDS = ("conversationId", "turnId", "version", "operation", "basis", "selection")
+MAX_BYTES = 500000
+
+
+def canonical_uuid(value):
+    if not isinstance(value, str) or not re.fullmatch(
+            r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", value):
+        raise ValueError("Canonical UUID required")
+    identifier = UUID(value)
+    if identifier.int == 0:
+        raise ValueError("Nonzero UUID required")
+    return str(identifier)
+
+
+def require_requester(created_by, owner_id, allowed_user_id):
+    if canonical_uuid(created_by) != canonical_uuid(owner_id):
+        raise ValueError("Request ownership differs from server CreatedBy")
+    if canonical_uuid(created_by) != canonical_uuid(allowed_user_id):
+        raise ValueError("Requester is not allowlisted")
+
+
+def validate_envelope(client):
+    if client.get("schemaVersion") != "1.0.0.0":
+        raise ValueError("clientdata.schemaVersion must be 1.0.0.0")
+    properties = client["properties"]
+    if not isinstance(properties.get("connectionReferences"), dict):
+        raise ValueError("Connection references required")
+    definition = properties["definition"]
+    if not isinstance(definition.get("triggers"), dict) or not definition["triggers"]:
+        raise ValueError("Trigger definition required")
+    if not isinstance(definition.get("actions"), dict) or not definition["actions"]:
+        raise ValueError("Action definition required")
+
+
+def validate_request(request, allowed_operations):
+    if set(request) != {*SCOPE_FIELDS, "prompt"}:
+        raise ValueError("Unexpected request fields")
+    for field in ("conversationId", "turnId"):
+        canonical_uuid(request[field])
+    if type(request["version"]) is not int or not 1 <= request["version"] <= 2147483647:
+        raise ValueError("Positive bounded integer version required")
+    if request["operation"] not in allowed_operations:
+        raise ValueError("Operation not allowlisted")
+    for field in ("basis", "prompt", "selection"):
+        value = request[field]
+        if not isinstance(value, str) or (field != "selection" and not value.strip()):
+            raise ValueError("Invalid request text")
+    if len(request["selection"].encode("utf-8")) > 10000:
+        raise ValueError("Selection too large")
+    if len(json.dumps(request, ensure_ascii=False).encode("utf-8")) > MAX_BYTES:
+        raise ValueError("Request too large")
+
+
+def verified_reply(request, result, request_id, created_by, result_owner, allowed_operations):
+    validate_request(request, allowed_operations)
+    if canonical_uuid(result["requestId"]) != canonical_uuid(request_id):
+        raise ValueError("Request ID mismatch")
+    if canonical_uuid(created_by) != canonical_uuid(result_owner):
+        raise ValueError("Result owner mismatch")
+    for field in SCOPE_FIELDS:
+        if type(result.get(field)) is not type(request[field]) or result[field] != request[field]:
+            raise ValueError("Result scope mismatch: " + field)
+    if result.get("status") != "succeeded":
+        raise ValueError("Result is not a verified success; retain receipt without resubmitting")
+    reply = result.get("reply")
+    if not isinstance(reply, str) or not reply.strip() or len(reply.encode("utf-8")) > MAX_BYTES:
+        raise ValueError("Empty, invalid or oversized reply")
+    return reply

--- a/.github/skills/agent-flows/scripts/inspect_conversation.py
+++ b/.github/skills/agent-flows/scripts/inspect_conversation.py
@@ -1,0 +1,71 @@
+"""Read and verify one existing request/result; never invoke an agent or write data."""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from conversation_contract import canonical_uuid, require_requester, validate_request, verified_reply
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "standard/scripts"))
+
+
+def identifier(value):
+    if not isinstance(value, str) or not re.fullmatch(r"[a-z][a-z0-9_]*", value):
+        raise ValueError("Dataverse logical name required")
+    return value
+
+
+def inspect(get, request_id, request_table, request_set, result_set, request_json, result_json,
+            result_lookup, allowed_user_id, allowed_operation):
+    request_id = canonical_uuid(request_id)
+    for value in (request_table, request_set, result_set, request_json, result_json, result_lookup):
+        identifier(value)
+    row = get(f"{request_set}({request_id})?$select={request_table}id,{request_json},_createdby_value,_ownerid_value")
+    if canonical_uuid(row[request_table + "id"]) != request_id:
+        raise ValueError("Request row mismatch")
+    require_requester(row["_createdby_value"], row["_ownerid_value"], allowed_user_id)
+    request = json.loads(row[request_json])
+    validate_request(request, {allowed_operation})
+    rows = get(f"{result_set}?$select={result_json},_ownerid_value,_{result_lookup}_value"
+               f"&$filter=_{result_lookup}_value eq {request_id}&$top=2").get("value", [])
+    if not rows:
+        return {"status": "pending", "verified": False}
+    if len(rows) != 1 or canonical_uuid(rows[0][f"_{result_lookup}_value"]) != request_id:
+        raise ValueError("Result lookup or uniqueness mismatch")
+    result = json.loads(rows[0][result_json])
+    reply = verified_reply(request, result, request_id, row["_createdby_value"],
+                           rows[0]["_ownerid_value"], {allowed_operation})
+    return {"status": "reply-envelope-verified", "verified": True,
+            "replyBytes": len(reply.encode("utf-8")), "domainValidation": "required-separately"}
+
+
+def main():
+    from auth_helper import api_get
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--request-id", required=True)
+    parser.add_argument("--request-table", default=os.getenv("CONVERSATION_REQUEST_TABLE"))
+    parser.add_argument("--request-set", default=os.getenv("CONVERSATION_REQUEST_SET"))
+    parser.add_argument("--result-set", default=os.getenv("CONVERSATION_RESULT_SET"))
+    parser.add_argument("--request-json", default=os.getenv("CONVERSATION_REQUEST_JSON_COLUMN"))
+    parser.add_argument("--result-json", default=os.getenv("CONVERSATION_RESULT_JSON_COLUMN"))
+    parser.add_argument("--result-lookup", default=os.getenv("CONVERSATION_RESULT_LOOKUP"))
+    parser.add_argument("--allowed-user-id", default=os.getenv("CONVERSATION_ALLOWED_USER_ID"))
+    parser.add_argument("--operation", default=os.getenv("CONVERSATION_ALLOWED_OPERATION"))
+    args = parser.parse_args()
+    try:
+        if not args.operation:
+            raise ValueError("Allowed operation required")
+        report = inspect(api_get, args.request_id, args.request_table, args.request_set, args.result_set,
+                         args.request_json, args.result_json, args.result_lookup, args.allowed_user_id, args.operation)
+        print(json.dumps(report))
+        return 0 if report["verified"] else 2
+    except Exception as error:
+        print(json.dumps({"status": "unverified", "errorType": type(error).__name__}))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/agent-flows/tests/test_agent_flow.py
+++ b/.github/skills/agent-flows/tests/test_agent_flow.py
@@ -8,10 +8,11 @@ import tempfile
 import types
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
+from uuid import uuid4
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
-from agent_flow import build_client, classify_output, digest, main, require_approval, safe_output_url, validate_client, validate_workflow, workflow_body
+from agent_flow import Api, build_client, classify_output, digest, main, require_approval, safe_output_url, validate_client, validate_workflow, workflow_body
 
 
 def fixture():
@@ -23,7 +24,7 @@ def fixture():
         {"id": "start", "type": "start", "data": {"config": {"triggerType": "manual"}}},
         {"id": "agent", "type": "agent", "data": {"config": config}}],
         "edges": [{"source": "start", "target": "agent"}], "connectionReferences": refs}
-    return {"properties": {"connectionReferences": refs, "definition": {
+    return {"schemaVersion": "1.0.0.0", "properties": {"connectionReferences": refs, "definition": {
         "triggers": {"manual": {"type": "Request", "kind": "Button", "inputs": {
             "schema": {"type": "object", "properties": {}, "required": []}}, "metadata": {
                 "associatedData": {"graph": graph, "nodeActionMapping": {"agent": ["Agent"]}}}}},
@@ -33,6 +34,18 @@ def fixture():
 
 
 class AgentFlowTests(unittest.TestCase):
+    def test_actual_solution_membership_is_required(self):
+        api = object.__new__(Api)
+        component_id, solution_id = str(uuid4()), str(uuid4())
+        solution = {"value": [{"solutionid": solution_id}]}
+        component = {"objectid": component_id, "componenttype": 29, "_solutionid_value": solution_id}
+        api.request = Mock(side_effect=[solution, {"value": [component]}])
+        api.require_solution_component(component_id, 29, "Sample")
+        for rows in ([], [component, component], [{**component, "_solutionid_value": str(uuid4())}]):
+            api.request = Mock(side_effect=[solution, {"value": rows}])
+            with self.subTest(count=len(rows)), self.assertRaises(ValueError):
+                api.require_solution_component(component_id, 29, "Sample")
+
     def test_clone_and_readback(self):
         source = fixture()
         before = copy.deepcopy(source)
@@ -43,6 +56,28 @@ class AgentFlowTests(unittest.TestCase):
         for key, value in [("modernflowtype", 0), ("statecode", 1), ("category", 0), ("name", "other")]:
             with self.subTest(key=key), self.assertRaises(ValueError):
                 validate_workflow(dict(actual, **{key: value}), "new", client, 0)
+
+    def test_publish_requires_etag_and_never_retries_failure(self):
+        identifier = str(uuid4())
+        settings = {"ENV_ID": identifier, "AGENT_FLOW_ID": identifier, "AGENT_FLOW_NAME": "sample",
+                    "SOLUTION_NAME": "Sample", "AGENT_FLOW_EXPECTED_JSON": '{"ok":true}'}
+        message = 'Return only this exact JSON without markdown: {"ok": true}. Do not use tools, knowledge, web search, email, or human assistance.'
+        actual = dict(workflow_body(identifier, "sample", build_client(fixture(), "sample", message)), statecode=0)
+        actual["@odata.etag"] = 'W/"version"'
+        auth = types.ModuleType("auth_helper")
+        auth.DATAVERSE_URL = "https://example.com"
+        with tempfile.TemporaryDirectory() as directory, patch.dict(os.environ, settings), patch.dict(sys.modules, {"auth_helper": auth}), patch("agent_flow.Api") as api_type, contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            api = api_type.return_value
+            api.workflow.return_value = actual
+            path = Path(directory) / "plan.json"
+            with patch.object(sys, "argv", ["agent_flow", "publish", "--report-file", str(path)]):
+                self.assertEqual(main(), 0)
+            approved = json.loads(path.read_text())["expectedHash"]
+            api.request.side_effect = ValueError("HTTP 412")
+            with patch.object(sys, "argv", ["agent_flow", "publish", "--apply", "--expected-hash", approved, "--report-file", str(Path(directory) / "result.json")]):
+                self.assertEqual(main(), 1)
+            api.request.assert_called_once_with("PATCH", f"workflows({identifier})", {"statecode": 1, "statuscode": 2}, extra_headers={"If-Match": actual["@odata.etag"]})
+            api.require_solution_component.assert_called_once_with(identifier, 29, "Sample")
 
     def test_graph_runtime_mismatch_rejected(self):
         for mutation in ["model", "mapping", "tools", "edge", "web", "extra-action", "reference"]:

--- a/.github/skills/agent-flows/tests/test_conversation_contract.py
+++ b/.github/skills/agent-flows/tests/test_conversation_contract.py
@@ -1,0 +1,76 @@
+import copy
+import sys
+import unittest
+from pathlib import Path
+from uuid import uuid4
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from conversation_contract import canonical_uuid, require_requester, validate_envelope, validate_request, verified_reply
+
+
+class ConversationContractTests(unittest.TestCase):
+    def setUp(self):
+        self.owner = str(uuid4())
+        self.request_id = str(uuid4())
+        self.request = {"conversationId": str(uuid4()), "turnId": str(uuid4()), "version": 1,
+                        "operation": "design", "basis": "{}", "selection": "", "prompt": "Arrange"}
+        self.result = {**self.request, "requestId": self.request_id, "status": "succeeded", "reply": "{}"}
+        del self.result["prompt"]
+
+    def verify(self, result):
+        return verified_reply(self.request, result, self.request_id, self.owner, self.owner, {"design"})
+
+    def test_valid_round_trip(self):
+        self.assertEqual(self.verify(self.result), "{}")
+
+    def test_identity_is_server_owned_and_fail_closed(self):
+        require_requester(self.owner.upper(), self.owner, self.owner)
+        for identity in (str(uuid4()), "", "user@example.com", None):
+            with self.subTest(identity=identity), self.assertRaises(ValueError):
+                require_requester(identity, self.owner, self.owner)
+        with self.assertRaises(ValueError):
+            require_requester(self.owner, str(uuid4()), self.owner)
+
+    def test_canonical_uuid(self):
+        for identifier in (self.owner.replace("-", ""), "{" + self.owner + "}", str(uuid4()) + "x", "0" * 36):
+            with self.subTest(identifier=identifier), self.assertRaises(ValueError):
+                canonical_uuid(identifier)
+
+    def test_every_scope_field_is_required(self):
+        for field in ("conversationId", "turnId", "version", "operation", "basis", "selection", "requestId"):
+            result = copy.deepcopy(self.result)
+            result[field] = str(uuid4()) if field != "version" else 2
+            with self.subTest(field=field), self.assertRaises(ValueError):
+                self.verify(result)
+        with self.assertRaises(ValueError):
+            self.verify({**self.result, "version": True})
+
+    def test_pending_failure_and_empty_output_are_not_success(self):
+        for state in ("pending", "running", "failed", "cancelled", "Completed", None):
+            with self.subTest(state=state), self.assertRaises(ValueError):
+                self.verify({**self.result, "status": state})
+        for reply in (None, {}, "", "  ", "x" * 500001):
+            with self.subTest(reply_type=type(reply)), self.assertRaises(ValueError):
+                self.verify({**self.result, "reply": reply})
+
+    def test_payload_operations_sizes_and_extra_fields(self):
+        for changes in ({"version": True}, {"version": 0}, {"operation": "knowledge"}, {"prompt": ""},
+                        {"createdBy": self.owner}, {"selection": "x" * 10001}, {"prompt": "x" * 500000}):
+            with self.subTest(keys=list(changes)), self.assertRaises(ValueError):
+                validate_request({**self.request, **changes}, {"design"})
+
+    def test_result_ownership(self):
+        with self.assertRaises(ValueError):
+            verified_reply(self.request, self.result, self.request_id, self.owner, str(uuid4()), {"design"})
+
+    def test_envelope_requires_schema_version(self):
+        client = {"schemaVersion": "1.0.0.0", "properties": {"connectionReferences": {},
+                  "definition": {"triggers": {"request": {}}, "actions": {"agent": {}}}}}
+        validate_envelope(client)
+        for version in (None, "1", "2.0.0.0"):
+            with self.subTest(version=version), self.assertRaises(ValueError):
+                validate_envelope({**client, "schemaVersion": version})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/skills/agent-flows/tests/test_inspect_conversation.py
+++ b/.github/skills/agent-flows/tests/test_inspect_conversation.py
@@ -1,0 +1,52 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+from uuid import uuid4
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from inspect_conversation import inspect
+
+
+class InspectConversationTests(unittest.TestCase):
+    def setUp(self):
+        self.request_id, self.owner = str(uuid4()), str(uuid4())
+        self.request = {"conversationId": str(uuid4()), "turnId": str(uuid4()), "version": 1,
+                        "operation": "design", "basis": "{}", "selection": "", "prompt": "Arrange"}
+        self.row = {"sample_requestid": self.request_id, "sample_requestjson": json.dumps(self.request),
+                    "_createdby_value": self.owner, "_ownerid_value": self.owner}
+        result = {**self.request, "requestId": self.request_id, "status": "succeeded", "reply": "{}"}
+        del result["prompt"]
+        self.result = {"sample_resultjson": json.dumps(result), "_ownerid_value": self.owner,
+                       "_sample_requestid_value": self.request_id}
+
+    def run_inspection(self, get):
+        return inspect(get, self.request_id, "sample_request", "sample_requests", "sample_results",
+                       "sample_requestjson", "sample_resultjson", "sample_requestid", self.owner, "design")
+
+    def test_reads_only_bound_request_and_unique_result(self):
+        get = Mock(side_effect=[self.row, {"value": [self.result]}])
+        self.assertTrue(self.run_inspection(get)["verified"])
+        self.assertEqual(get.call_count, 2)
+        self.assertIn(self.request_id, get.call_args_list[1].args[0])
+
+    def test_no_result_is_pending_without_resubmission(self):
+        get = Mock(side_effect=[self.row, {"value": []}])
+        self.assertEqual(self.run_inspection(get)["status"], "pending")
+        self.assertEqual(get.call_count, 2)
+
+    def test_wrong_owner_stops_before_result_read(self):
+        get = Mock(return_value={**self.row, "_ownerid_value": str(uuid4())})
+        with self.assertRaises(ValueError):
+            self.run_inspection(get)
+        self.assertEqual(get.call_count, 1)
+
+    def test_duplicate_and_wrong_lookup_results_are_rejected(self):
+        for rows in ([self.result, self.result], [{**self.result, "_sample_requestid_value": str(uuid4())}]):
+            with self.subTest(count=len(rows)), self.assertRaises(ValueError):
+                self.run_inspection(Mock(side_effect=[self.row, {"value": rows}]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -93,6 +93,9 @@ triggers:
 Power Apps Code Apps（コードファースト）を **TypeScript + React + Tailwind CSS** で開発する。
 UI 設計・CSP 構成・メール送信パターンまで Code Apps 開発の全領域をカバーする統合スキル。
 
+> **選択対象付き設計チャット**: [コンテキスト・クイック返信・待機表示](references/contextual-design-chat.md) を参照。
+> 対象IDと設計版の固定、対象外変更の拒否、実状態だけの進捗表示、検証済み下書きと明示保存の分離を扱う。
+
 > **プラント・設備の JSON 駆動設計**: [モジュール設計パターン](references/modular-plant-design.md) と
 > [追加テンプレート](templates/modular-plant/README.md) を参照。敷地・ユニット・ポート接続、CSP 対応検証器、
 > Python 候補生成、Dataverse 改訂・提案レビューを再利用できる。既存アプリへのアドオンであり scaffold 元ではない。

--- a/.github/skills/code-apps/references/contextual-design-chat.md
+++ b/.github/skills/code-apps/references/contextual-design-chat.md
@@ -1,0 +1,53 @@
+# Contextual Design Chat
+
+## Interaction Contract
+
+Use the existing design system and keep the live preview beside a compact conversation. Offer a small initial set
+of starter commands, then grouped quick replies for layout, connections, maintenance and the selected object.
+Categories prevent a large button wall. Use icons for selection/send/stop/Undo and names for natural-language commands.
+Preserve an editable textarea for custom requests; do not replace the actual tool with a marketing or instruction page.
+
+Selected-object mode must show the canonical unit and node names. Resolve labels from the current design, not
+from a client-supplied description. Persist unitId and nodeId separately, including the unit prefix for same-named
+equipment in different modules. Clearing selection disables targeted commands. Whole-design commands explicitly
+clear the request selection, even if old history refers to another object.
+
+Freeze the target, full basis and editing version before awaiting identity or submission. Compare again before
+submission and application. A selection change invalidates a targeted response, including text-only explanations.
+Validate that unrelated units and connections remain byte-equivalent in the parsed domain representation.
+If the existing validator locks module internals, offer unit movement/rotation and explanation, not impossible
+equipment-internal edits, deletion or unapproved topology changes.
+
+## Honest Waiting Experience
+
+Display real send/accepted/running/validation states, elapsed time and the frozen request target. An indeterminate
+activity line or spinner is appropriate. Never simulate hidden chain-of-thought, invent analysis claims, advance
+stages based on a timer, show guessed percentages or claim a tool is running without telemetry.
+After a longer wait, state only what is known: awaiting output, no draft change, no resubmission.
+
+Use fixed stage grid tracks, tabular elapsed digits, bounded history/reply panels and wrapping labels. Respect
+prefers-reduced-motion. Elapsed updates must not cause a screen reader announcement every second. Clear timers
+on idle/unmount. Preserve the request receipt when stopping reads, and distinguish local waiting from remote cancellation.
+Users may prepare the next input while busy; do not send another billable request while one is unresolved.
+
+## Draft And Save Separation
+
+With explicit approval, a schema/domain-valid candidate may update the editing draft automatically and create
+one Undo entry. Shared save and publishing remain explicit commands. On failure retain the original design,
+explain the failure, and do not silently apply a partial candidate. Keep knowledge routing independent.
+
+## Verification
+
+- Pure tests: every quick reply is nonempty, bounded and uniquely labeled; target ID resolves; forged labels are
+  ignored; wrong-unit/same-node selections fail; changed base/selection rejects; unrelated changes fail.
+- Transport tests: immutable scope, identity change after await, duplicate submission locks, GET-only resume,
+  terminal versus indeterminate results, abort/unmount and bounded reads.
+- Visible public browser: record baseline -> selected command -> real waiting states -> expected coordinate change
+  -> Undo -> Redo -> still unsaved. Validate responses against the actual submitted basis.
+- Responsive checks: desktop/mobile screenshots, settled layout widths, long names, category controls, send button,
+  reduced motion, and nonblank canvas pixels. A resized nonvisible tab can leave layout/animation stale; distinguish
+  that from an actual narrow-screen defect and verify on a visible page before claiming acceptance.
+- Use the same confirmed Edge profile in VS Code integrated browser. Do not install standalone Playwright or
+  Playwright MCP. Preserve existing user drafts and do not reload a pending request merely to update assets.
+
+See [worker integration](../../agent-flows/references/conversation-worker.md) for server ownership, claims and receipts.

--- a/.github/skills/copilot-studio-v2/SKILL.md
+++ b/.github/skills/copilot-studio-v2/SKILL.md
@@ -37,6 +37,10 @@ triggers:
 Copilot Studio の **「全く新しいアーキテクチャ」（`cliagent` テンプレート）** エージェントを
 **Dataverse Web API だけで完全自動構築** する。
 
+> **間接連携の補足**: [下書き専用botと非同期ワーカー](references/draft-only-worker-agent.md) は、
+> Workflow経由で既存botを呼び、Dataverse結果をCode Appsが読む実験的パターン。
+> 以下の「v2不可」は従来の直接SDK呼び出し・Web埋め込みの制約であり、この間接経路と区別する。
+
 ## v1（旧）スキルとの最大の違い
 
 | 観点 | v1（`copilot-studio` スキル / 旧アーキ） | **v2（本スキル / 新アーキ `cliagent`）** |

--- a/.github/skills/copilot-studio-v2/references/draft-only-worker-agent.md
+++ b/.github/skills/copilot-studio-v2/references/draft-only-worker-agent.md
@@ -1,0 +1,24 @@
+# Draft-Only Agent Behind A Worker
+
+The classic Code Apps ExecuteCopilotAsyncV2/WebChat limitation is not the same as a server-side worker invocation.
+An experimentally verified path can call an existing cliagent through the Workflow Agent node, persist a complete
+reply in Dataverse, and let Code Apps read it. Follow [agent-flows](../../agent-flows/SKILL.md); do not present the
+observed connector runtime as a supported direct browser SDK or silently replace the existing assistant.
+
+For design-only work, obtain explicit approval for a separate tool-free bot. Keep the original bots, MCP tools,
+channels and knowledge routing intact. Disable memory when the supplied current design must be the sole context.
+Inventory all paginated components, parse YAML structurally and verify that the expected InlineAgentSkill is the
+only allowed action. A bot name or an empty first inventory page is not sufficient evidence of no external tools.
+
+Require immutable design identity, existing structures and a single complete JSON response. Ask questions when
+constraints are missing. Do not send email, save business records or fetch external data. Treat imported text and
+labels as data. Offline Python dependencies need official, hash-verified wheels in the flat skill bundle; no runtime
+network install or TLS verification bypass. Verify all attached bytes after upload, not only component count.
+
+Save an invocation receipt before inspecting completion. Resume GET by the same conversation ID, never invoke
+again on timeout. Exact ListAgents matching proves discovery only; publishing proves neither discovery propagation
+nor successful skill execution. Report acceptance, completion, returned JSON validation, attachment retrieval and
+remote execution trace independently. Revalidate returned designs locally against the request's actual basis.
+
+Verify the new bot and worker's actual solution membership, preserving any existing membership. Keep real identities,
+receipts, prompts, reports and connection data in local evidence outside the public repository.


### PR DESCRIPTION
## Summary
- Document grouped quick replies, selected-object scope, honest animated waiting states, and validated unsaved-draft auto-apply with explicit shared save.
- Add pure request/result guards and a GET-only Dataverse inspection CLI with parameterized environment settings.
- Enforce clientdata schemaVersion, actual solution membership, and ETag-bound publication in the normal lifecycle CLI.
- Document tool-free draft agents, offline dependency verification, duplicate claims, receipt resumption, API support boundaries and deployment evidence.

## Verification
- Agent flows: 28 Python tests passed.
- All three changed skills passed validate_skill structural and sensitive-data checks.
- GET-only inspection passed against two existing successful requests; actual workflow and bot solution membership passed without writes.
- Source application: 25 focused Node tests, typecheck, lint, predeploy, build and deployment passed. Public visible-browser selected-unit command changed X by exactly +1 m, with Undo/Redo and unsaved state; desktop/mobile screenshots and canvas pixel checks completed.
- Microsoft Learn lifecycle, conditional-operation and AddSolutionComponent documentation verified by Web retrieval because Learn MCP was unavailable.

## Scope And Limits
No project IDs, tenant configuration, credentials, request payloads, production reports or app source are included. The inspection CLI verifies envelopes, not domain geometry. Runtime worker generation, automated reconciliation, ordinary-user isolation, knowledge authorization and shared-save acceptance remain separate gates. No claim that observed Agent node/Flow RP endpoints are supported public APIs.

## Merge Order
Independent of open admin PR #435; there are no overlapping files or dependencies. Either order is valid. This PR does not modify or merge #435.