### PR TITLE
fix(code-apps): route MCP access through Copilot Studio

### DIFF
--- a/.github/skills/code-apps/SKILL.md
+++ b/.github/skills/code-apps/SKILL.md
@@ -93,9 +93,6 @@ triggers:
 Power Apps Code Apps（コードファースト）を **TypeScript + React + Tailwind CSS** で開発する。
 UI 設計・CSP 構成・メール送信パターンまで Code Apps 開発の全領域をカバーする統合スキル。
 
-> **選択対象付き設計チャット**: [コンテキスト・クイック返信・待機表示](references/contextual-design-chat.md) を参照。
-> 対象IDと設計版の固定、対象外変更の拒否、実状態だけの進捗表示、検証済み下書きと明示保存の分離を扱う。
-
 > **プラント・設備の JSON 駆動設計**: [モジュール設計パターン](references/modular-plant-design.md) と
 > [追加テンプレート](templates/modular-plant/README.md) を参照。敷地・ユニット・ポート接続、CSP 対応検証器、
 > Python 候補生成、Dataverse 改訂・提案レビューを再利用できる。既存アプリへのアドオンであり scaffold 元ではない。
@@ -104,7 +101,7 @@ UI 設計・CSP 構成・メール送信パターンまで Code Apps 開発の�
 > **設計と保守を統合する場合**: [Plant Design & Maintenance サンプル](samples/plant-design-maintenance/README.md) を参照。
 > 既存画面・合成3Dモデル・部位別の故障／修理・ヒートマップ・AI候補の変更前後比較を同梱。
 > `npm ci` → Python依存導入 → `npm run generate` → `npm run predeploy` で単体検証できる。
-> AI候補は確定まで下書きに適用せず、共有保存と分離する。外部接続は既定無効で、Dataverse／AI／MCP は導入先で生成したサービスへ交換する。
+> AI候補は確定まで下書きに適用せず、共有保存と分離する。外部接続は既定無効。Code App は Dataverse と Copilot Studio の生成サービスだけへ接続し、MCP Server は Copilot Studio のツールとして構成する。
 
 > [!NOTE]
 > 本スキルは React + Vite の **Web Code Apps** 用。Expo／React Native、camera／barcode／location 等の
@@ -391,6 +388,23 @@ python scripts/review_report.py --verdict-dir .gate --out .gate/review-report.md
 > - **実務上の判断**: 性能よりも、型安全性・再生成コスト・複数テーブル横断のしやすさで選ぶ
 
 ## 3. データソース接続
+
+### MCP Server は Copilot Studio 経由に統一する
+
+Code App に MCP カスタムコネクタを直接追加しない。会話・検索・原本取得は
+`Code App → Copilot Studio → MCP Server`、画面表示用の構造化データやページ画像は
+`取り込み処理 → Dataverse → Code App` と分離する。画像や大きなバイナリをエージェント応答へ載せない。
+
+同じ MCP 接続が Code App の同意一覧へ重複すると、接続更新ボタンが反応せずモーダルが閉じないことがある。
+誤って追加した場合は SDK 管理ファイルを手編集せず、CLI で削除する。
+
+```powershell
+npx pa app remove data-source --connector <shared_mcp_connector_id> --force --non-interactive
+```
+
+標準 `pre-deploy-check.mjs` は `.power` と `src/generated` の `/api/mcp` / `InvokeServer` を検出し、
+直接 MCP データソースが残ったデプロイを拒否する。詳しい切り分けは
+[トラブルシューティング](references/troubleshooting.md) を参照する。
 
 ### 正常系: コネクタ ID は聞かずに解決する（`add_data_source.py`）
 

--- a/.github/skills/code-apps/references/troubleshooting.md
+++ b/.github/skills/code-apps/references/troubleshooting.md
@@ -2458,5 +2458,40 @@ useEffect(() => {
 
 > 実装一式は [使い方ガイドパターン](onboarding-guide-pattern.md) を参照。
 
+---
+
+## 51. MCP 接続の更新ボタンが反応せず、同意モーダルが閉じない（検証済 2026-09-11）
+
+### 症状
+
+Code App 起動時の接続モーダルに MCP カスタムコネクタが表示されるが、「接続の更新」を押しても
+何も起きず、モーダルが開いたままになる。ブラウザコンソールには同一 connection ID の
+`Encountered two children with the same key`、`useMemo changed size`、`React.createElement: type is invalid`
+が繰り返し出る。
+
+### 原因
+
+MCPカスタムコネクタを Code App のデータソースへ直接追加し、同じ接続が同意一覧へ重複して渡されている。
+これは接続資格情報の更新失敗ではなく、Power Apps の同意UIが重複行を処理できない状態。
+
+### 対処
+
+MCP Server は Copilot Studio のツールとして接続し、Code App は Copilot Studio と Dataverse のみにする。
+ページ画像のような画面表示データは投入時に検証して Dataverse の索引へ保存し、Code App はそこから読む。
+SDK管理ファイルを手編集せず、CLIで直接MCPデータソースを削除して再デプロイする。
+
+```powershell
+npx pa app remove data-source --connector <shared_mcp_connector_id> --force --non-interactive
+npm run predeploy
+npm run deploy
+```
+
+最新版へ更新後、接続モーダルにMCP接続が無いことを確認する。古い版のバナーが出た場合は
+[デプロイ後の旧バンドル](#37-power-apps-push-後もブラウザが古いバンドルを表示する検証済-2026-08-10)の手順で更新する。
+
+**恒久対策済み**: `scripts/pre-deploy-check.mjs` が `.power` と `src/generated` の `/api/mcp` / `InvokeServer`
+を検出し、直接MCPデータソースが残るデプロイを拒否する。Plant Design & Maintenanceサンプルの
+`check:sample` も直接MCPサービス参照を拒否し、Dataverse画像キャッシュ経由を検査する。
+
 
 

--- a/.github/skills/code-apps/samples/plant-design-maintenance/README.md
+++ b/.github/skills/code-apps/samples/plant-design-maintenance/README.md
@@ -11,7 +11,7 @@ JSON 正本のプラント設計と設備起点の保守履歴を統合した Re
 - AI 候補の変更前／変更後の同縮尺2カラム比較、確定による下書き反映、取り消し。小画面は縦並び。
 - 3種類の合成プラント、設備・部位選択、期間／未解決フィルター、故障件数ヒートマップ、故障と修理の相互参照。
 - 50 MB 以下の自己完結した静的 GLB をローカルで閲覧。実資料への名前一致による自動紐付けはしません。
-- Dataverse の共有改訂・提案、非同期 AI 要求と結果照合、出典検査、索引 ID ベースの図面画像取得の接続コード。
+- Dataverse の共有改訂・提案、非同期 AI 要求と結果照合、出典検査、検証済み索引に保存した図面ページ画像の表示。
 
 ## 起動
 
@@ -60,11 +60,11 @@ npm run dev
 
 1. 対象環境・ソリューション・公開範囲を設計し、admin の環境・DLP/ACP チェックを通します。
 2. code-apps の標準テンプレートで Code App を初期化し、共通 `.env` と本サンプルの `.env.example` を設定します。
-3. スキルリポジトリ側の [add_data_source.py](../../scripts/add_data_source.py) で Dataverse、必要なら Copilot Studio と図面ページ API のデータソースを生成します。既存プロジェクトの `power.config.json` や `src/generated/` をコピーしません。
+3. スキルリポジトリ側の [add_data_source.py](../../scripts/add_data_source.py) で Dataverse と Copilot Studio のデータソースを生成します。MCP Server は Code App に追加せず、Copilot Studio のツールとして接続します。既存プロジェクトの `power.config.json` や `src/generated/` をコピーしません。
 4. `src/integrations/connectors.ts` の未接続アダプターを、自分の環境で生成されたサービスの import / export に置き換えます。メソッド契約はコンパイルで検査してください。
 5. 標準テンプレートの Power Apps Vite plugin、CSP、プレデプロイゲートを保持して画面・データ・ロジックを導入します。本サンプルの Vite はローカル用です。
 6. 非同期 Worker は agent-flows の要求／結果パターンを使用します。認証済み作成者・所有者・相関・対象をサーバーでも検査し、管理者1名の成功を全利用者への公開許可にしません。
-7. File / DB 接続は mcp-server の [認可・ページ画像契約](../../../mcp-server/references/indexed-file-db-access.md) を適用します。
+7. File / DB 接続は mcp-server の [認可・ページ画像契約](../../../mcp-server/references/indexed-file-db-access.md) を適用します。取り込み処理でページ画像を生成し、検証済み索引の `{prefix}_pageimagejson` に保存します。
 8. 標準の `npm run predeploy` 成功後に `npm run deploy`。公開ホストで本人認可・実応答・改訂保存を別途確認します。本サンプル自身に push コマンドはありません。
 
 ## カスタマイズ
@@ -93,6 +93,7 @@ npm run dev
 `npm test` は形状・端点・敷地・出典・モデル改訂・対象・非同期相関・遅延応答・共有保存競合を検証します。
 `npm run generate` は CSP 対応の事前コンパイル検証器、JSON、GLB を再生成します。
 `npm run check:sample` は実 ID・固定 publisher・組織 URL・環境ファイルの混入を拒否します。
+同時に Code App からの直接 MCP 呼び出しを拒否し、図面画像が Dataverse キャッシュ経由であることを検査します。
 CI の `check-sample.mjs --tracked` は lockfile・設定例・Python生成器の Git 追跡も検査します。
 親リポジトリの `package-lock.json` 除外により初回CIで `npm ci` が失敗したため、サンプルの `.gitignore` で例外化し、存在確認だけでなく追跡確認も必須にしました。
 これはソース配布ゲートです。自分の `.env` を置いた本番作業フォルダーでは code-apps の環境対応プレデプロイを使ってください。

--- a/.github/skills/code-apps/samples/plant-design-maintenance/scripts/check-sample.mjs
+++ b/.github/skills/code-apps/samples/plant-design-maintenance/scripts/check-sample.mjs
@@ -31,4 +31,15 @@ if (process.argv.includes("--tracked")) {
 }
 const config = await readFile(path.join(root, "src/lib/plant-agent-config.ts"), "utf8")
 assert.ok(!/RETRIEVAL_READY\s*=\s*true/.test(config), "Retrieval must default off")
+const sourceFiles = [
+  "src/components/plant-agent-images.tsx",
+  "src/lib/plant-page-image-loader.ts",
+  "src/integrations/connectors.ts",
+]
+for (const filename of sourceFiles) {
+  const source = await readFile(path.join(root, filename), "utf8")
+  assert.ok(!/Drawing_files_mcpService|GetIndexedDrawingPageImage|InvokeServer/.test(source), `Direct MCP connector usage: ${filename}`)
+}
+const imageLoader = await readFile(path.join(root, "src/lib/plant-page-image-loader.ts"), "utf8")
+assert.match(imageLoader, /pageimagejson/, "Drawing images must be read from the verified Dataverse cache")
 console.log("Sample publication checks passed")

--- a/.github/skills/code-apps/samples/plant-design-maintenance/src/components/plant-agent-images.tsx
+++ b/.github/skills/code-apps/samples/plant-design-maintenance/src/components/plant-agent-images.tsx
@@ -4,35 +4,33 @@ import { Loader2, ZoomIn } from "lucide-react"
 import { listAll } from "@/data/dataverse-client"
 import type { PlantPageImage } from "@/lib/plant-page-images"
 import { loadPlantPageImages } from "@/lib/plant-page-image-loader"
-import { Drawing_files_mcpService } from "@/integrations/connectors"
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog"
 import "./plant-agent-images.css"
 
 const P = import.meta.env.VITE_PUBLISHER_PREFIX?.trim() || ""
 const TP = import.meta.env.VITE_TABLE_PREFIX?.trim() || `${P}_kb`
 
-async function fetchIndexedImage(sourceId: string) {
-  const result = await Drawing_files_mcpService.GetIndexedDrawingPageImage({ sourceId })
-  if (!result.success || !result.data) throw new Error("図面ページの取得に失敗しました。")
-  return result.data
-}
-
 export function PlantAgentImages({ sourceIds, reply, principalKey, direct = false }: { sourceIds: string[]; reply: string; principalKey: string; direct?: boolean }) {
   const [expanded, setExpanded] = useState<PlantPageImage | null>(null)
-  const images = useQuery({ queryKey: ["plant-page-images", principalKey, sourceIds, reply, direct], queryFn: () => loadPlantPageImages(listAll, sourceIds, reply, direct, P, TP, fetchIndexedImage), retry: false, gcTime: 0, staleTime: 0 })
+  const images = useQuery({ queryKey: ["plant-page-images", principalKey, sourceIds, reply, direct], queryFn: () => loadPlantPageImages(listAll, sourceIds, reply, direct, P, TP), retry: false, gcTime: 0, staleTime: 0 })
   if (images.isPending) return <p role="status" className="flex items-center gap-2 text-xs"><Loader2 size={14} className="animate-spin" aria-hidden="true" />図面画像を確認中</p>
-  if (images.isError) return <p role="status">図面画像を取得できません。接続と資料のアクセス権を確認してください。</p>
-  if (!images.data?.length) return direct ? <p role="status">選択した設備で参照できる検証済み図面ページの索引がありません。別設備の図面では代用しません。</p> : null
+  if (images.isError) return <p role="status">図面画像を取得できません。資料のアクセス権を確認してください。</p>
+  const unavailable = images.data?.unavailable ?? 0
+  if (!images.data?.images.length) {
+    if (unavailable) return <p role="status">図面ページ画像がまだ用意されていません（{unavailable} 件）。図面 PDF の取り込み後に表示されます。別図面では代用しません。</p>
+    return direct ? <p role="status">選択した設備で参照できる検証済み図面ページの索引がありません。別設備の図面では代用しません。</p> : null
+  }
   return <div className="agent-page-images">
     <p>関連図面</p>
-    <div className="agent-page-image-grid">{images.data.map(image => <button type="button" key={`${image.sha256}-${image.page}`} onClick={() => setExpanded(image)} title={`図面を拡大: ${image.drawingNumber} ${image.revision} p.${image.page}`}>
+    <div className="agent-page-image-grid">{images.data.images.map(image => <button type="button" key={`${image.sha256}-${image.page}`} onClick={() => setExpanded(image)} title={`図面を拡大: ${image.drawingNumber} ${image.revision} p.${image.page}`}>
       <img src={image.src} alt={`${image.drawingNumber} ${image.revision} p.${image.page}`} width={image.width} height={image.height} loading="lazy" />
       <span><ZoomIn size={14} aria-hidden="true" />{image.drawingNumber} {image.revision} p.{image.page}</span>
     </button>)}</div>
+    {unavailable > 0 && <p role="status">図面ページ画像が未用意の索引が {unavailable} 件あります。</p>}
     <Dialog open={!!expanded} onOpenChange={open => { if (!open) setExpanded(null) }}>
       <DialogContent className="agent-page-image-dialog">
         <DialogTitle>{expanded?.drawingNumber} {expanded?.revision} p.{expanded?.page}</DialogTitle>
-        <DialogDescription>Azure FilesのPDFから取得した図面ページ</DialogDescription>
+        <DialogDescription>Azure FilesのPDFから取り込んだ図面ページ</DialogDescription>
         {expanded && <div className="agent-page-image-scroll"><img src={expanded.src} alt={`${expanded.drawingNumber} p.${expanded.page}`} width={expanded.width} height={expanded.height} /></div>}
       </DialogContent>
     </Dialog>

--- a/.github/skills/code-apps/samples/plant-design-maintenance/src/integrations/connectors.ts
+++ b/.github/skills/code-apps/samples/plant-design-maintenance/src/integrations/connectors.ts
@@ -9,4 +9,3 @@ function disconnected(name: string): Connector {
 
 export const MicrosoftDataverseService = disconnected("Dataverse")
 export const MicrosoftCopilotStudioService = disconnected("Copilot Studio")
-export const Drawing_files_mcpService = disconnected("Drawing page API")

--- a/.github/skills/code-apps/samples/plant-design-maintenance/src/lib/plant-agent-wait-plan.ts
+++ b/.github/skills/code-apps/samples/plant-design-maintenance/src/lib/plant-agent-wait-plan.ts
@@ -13,7 +13,7 @@ const answer: PlantWaitStep = { title: "根拠と回答の整理", service: "AI 
 const plans: Record<string, PlantWaitPlan> = {
   image: { title: "図面画像", steps: [
     { title: "設備・資料の対応確認", service: "Dataverse", tool: "ListRecordsWithOrganization" },
-    { title: "PDFの指定ページを画像化", service: "Azure Files / Functions", tool: "GetIndexedDrawingPageImage" },
+    { title: "取り込み済みページ画像の取得", service: "Dataverse", tool: "ListRecordsWithOrganization" },
     { title: "図面番号・改訂・ページの確認", service: "画像ビューアー", tool: "" },
   ] },
   overview: { title: "設備の調査", steps: [index, drawing, document, answer] },

--- a/.github/skills/code-apps/samples/plant-design-maintenance/src/lib/plant-page-image-loader.ts
+++ b/.github/skills/code-apps/samples/plant-design-maintenance/src/lib/plant-page-image-loader.ts
@@ -3,13 +3,16 @@ import { parsePlantPageImage, type PlantPageImage } from "./plant-page-images.ts
 type ReadRows = (table: string, options: { select: string[]; filter: string; top: number }) => Promise<Record<string, unknown>[]>
 const guid = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i
 
-export async function loadPlantPageImages(read: ReadRows, sourceIds: string[], reply: string, direct: boolean, publisher: string, tables: string, fetchImage: (sourceId: string) => Promise<Record<string, unknown>>) {
-  if (!sourceIds.length || sourceIds.length > 8 || sourceIds.some(id => !guid.test(id))) return []
+export type PlantPageImageResult = { images: PlantPageImage[]; unavailable: number }
+
+export async function loadPlantPageImages(read: ReadRows, sourceIds: string[], reply: string, direct: boolean, publisher: string, tables: string): Promise<PlantPageImageResult> {
+  if (!sourceIds.length || sourceIds.length > 8 || sourceIds.some(id => !guid.test(id))) return { images: [], unavailable: 0 }
   const rows = await read(`${tables}sourceindexes`, {
-    select: [`${tables}sourceindexid`, `${publisher}_pagenumber`, `_${publisher}_drawingrevisionid_value`],
+    select: [`${tables}sourceindexid`, `${publisher}_pagenumber`, `_${publisher}_drawingrevisionid_value`, `${publisher}_pageimagejson`],
     filter: `(${sourceIds.map(id => `${tables}sourceindexid eq ${id}`).join(" or ")}) and statecode eq 0 and ${publisher}_verified eq true and ${publisher}_sourcekind eq 100000000`, top: 8,
   })
   const images: PlantPageImage[] = []
+  let unavailable = 0
   for (const row of rows) {
     const sourceId = row[`${tables}sourceindexid`]
     if (typeof sourceId !== "string" || !sourceIds.includes(sourceId)) continue
@@ -29,11 +32,15 @@ export async function loadPlantPageImages(read: ReadRows, sourceIds: string[], r
     const page = row[`${publisher}_pagenumber`]
     if (typeof drawingNumber !== "string" || typeof revisionName !== "string" || typeof path !== "string" || typeof page !== "number") continue
     if (!direct && (!reply.includes(drawingNumber) || !reply.includes(revisionName))) continue
-    const result = await fetchImage(sourceId)
-    if (result.sourceId !== sourceId) throw new Error("画像の索引IDが一致しません。")
-    const image = await parsePlantPageImage(JSON.stringify(result), { drawingNumber, revision: revisionName, path, page })
+    // 取り込み時に描画された画像がまだ無い索引が混ざっていても、揃っているページは表示する
+    const cached = row[`${publisher}_pageimagejson`]
+    if (typeof cached !== "string" || !cached) {
+      unavailable++
+      continue
+    }
+    const image = await parsePlantPageImage(cached, { drawingNumber, revision: revisionName, path, page })
     if (!image) throw new Error("画像の図面・改訂・ページを検証できません。")
     images.push(image)
   }
-  return images.sort((first, second) => first.page - second.page)
+  return { images: images.sort((first, second) => first.page - second.page), unavailable }
 }

--- a/.github/skills/code-apps/samples/plant-design-maintenance/tests/plant-agent-wait-plan.test.mjs
+++ b/.github/skills/code-apps/samples/plant-design-maintenance/tests/plant-agent-wait-plan.test.mjs
@@ -5,11 +5,11 @@ import { plantWaitPlan, waitPlanStep } from '../src/lib/plant-agent-wait-plan.ts
 
 const selection = { modelId: 'plant', modelRevision: 1, nodeId: 'tk101', label: 'Tank' }
 
-test('image quick reply describes indexed PDF rendering without agent invocation', () => {
+test('image quick reply describes Dataverse cache retrieval without agent invocation', () => {
   const question = plantAgentQuickReplies(selection).groups.find(group => group.id === 'drawings').replies[0].text
   const plan = plantWaitPlan(selection, question)
   assert.equal(plan.title, '図面画像')
-  assert.deepEqual(plan.steps.map(step => step.tool), ['ListRecordsWithOrganization', 'GetIndexedDrawingPageImage', ''])
+  assert.deepEqual(plan.steps.map(step => step.tool), ['ListRecordsWithOrganization', 'ListRecordsWithOrganization', ''])
 })
 
 test('every quick reply selects its group while free text and design remain generic', () => {

--- a/.github/skills/code-apps/samples/plant-design-maintenance/tests/plant-page-image-loader.test.mjs
+++ b/.github/skills/code-apps/samples/plant-design-maintenance/tests/plant-page-image-loader.test.mjs
@@ -13,7 +13,7 @@ const row = { sample_kbsourceindexid: source, sample_pagenumber: 1, sample_pagei
 const fixture = (cache = row, revisionRows = [{ sample_name: 'Rev.B', sample_fileurl: path, _sample_drawingid_value: drawing }]) => async (table, options) => {
   assert.match(options.filter, /statecode eq 0/)
   if (table === 'sample_kbsourceindexes') {
-    assert.ok(!options.select.includes('sample_pageimagejson'))
+    assert.ok(options.select.includes('sample_pageimagejson'))
     assert.ok(options.filter.includes(source))
     assert.match(options.filter, /sample_verified eq true/)
     return [cache]
@@ -27,20 +27,22 @@ const fixture = (cache = row, revisionRows = [{ sample_name: 'Rev.B', sample_fil
   assert.ok(options.filter.includes(drawing))
   return [{ sample_name: 'DWG-TK101-1001' }]
 }
-const load = (reader, direct = true, ids = [source], fetchImage = async id => ({ ...image, sourceId: id })) => loadPlantPageImages(reader, ids, '', direct, 'sample', 'sample_kb', fetchImage)
+const load = (reader, direct = true, ids = [source]) => loadPlantPageImages(reader, ids, '', direct, 'sample', 'sample_kb')
 
 test('explicit image request validates a synthetic PNG without AI reply text', async () => {
-  assert.equal((await load(fixture()))[0].src, 'data:image/png;base64,' + image.data)
-  assert.deepEqual(await load(fixture(), false), [])
+  assert.equal((await load(fixture())).images[0].src, 'data:image/png;base64,' + image.data)
+  assert.deepEqual(await load(fixture(), false), { images: [], unavailable: 0 })
 })
 test('missing image and inaccessible revision do not substitute another image', async () => {
-  assert.equal((await load(fixture({ ...row, sample_pageimagejson: null })))[0].src, 'data:image/png;base64,' + image.data)
-  assert.deepEqual(await load(fixture(row, [])), [])
+  assert.deepEqual(await load(fixture({ ...row, sample_pageimagejson: null })), { images: [], unavailable: 1 })
+  assert.deepEqual(await load(fixture(row, [])), { images: [], unavailable: 0 })
   await assert.rejects(load(fixture({ ...row, sample_pagenumber: 2 })), /検証できません/)
-  await assert.rejects(load(fixture(), true, [source], async () => ({ ...image, sourceId: revision })), /索引ID/)
-  await assert.rejects(load(fixture(), true, [source], async () => { throw new Error('renderer unavailable') }), /renderer unavailable/)
+  await assert.rejects(load(fixture({ ...row, sample_pageimagejson: JSON.stringify({ ...image, drawingNumber: 'DWG-OTHER-9999' }) })), /検証できません/)
+})
+test('drawings without a cached page image are reported without failing the whole request', async () => {
+  assert.deepEqual(await load(fixture({ ...row, sample_pageimagejson: '' })), { images: [], unavailable: 1 })
 })
 test('permission errors propagate and invalid IDs do not query', async () => {
   await assert.rejects(load(async () => { throw new Error('403') }), /403/)
-  assert.deepEqual(await load(async () => assert.fail('invalid ID must not query'), true, ['invalid']), [])
+  assert.deepEqual(await load(async () => assert.fail('invalid ID must not query'), true, ['invalid']), { images: [], unavailable: 0 })
 })

--- a/.github/skills/code-apps/scripts/detect-direct-mcp-data-sources.mjs
+++ b/.github/skills/code-apps/scripts/detect-direct-mcp-data-sources.mjs
@@ -14,7 +14,7 @@ export function findDirectMcpDataSources(root) {
       for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
         const entryPath = path.join(currentPath, entry.name)
         if (entry.isDirectory()) { pending.push(entryPath); continue }
-        if (!entry.isFile() || !/\.(json|tsx?)$/i.test(entry.name)) continue
+        if (!entry.isFile() || !/\.(json|[cm]?[jt]sx?)$/i.test(entry.name)) continue
         const content = fs.readFileSync(entryPath, "utf-8")
         if (markers.some(marker => marker.test(content))) matches.push(path.relative(root, entryPath))
       }

--- a/.github/skills/code-apps/scripts/detect-direct-mcp-data-sources.mjs
+++ b/.github/skills/code-apps/scripts/detect-direct-mcp-data-sources.mjs
@@ -1,0 +1,24 @@
+import fs from "node:fs"
+import path from "node:path"
+
+const markers = [/\/api\/mcp\b/i, /operationName\s*:\s*["']InvokeServer["']/i]
+
+export function findDirectMcpDataSources(root) {
+  const matches = []
+  const candidates = [path.join(root, ".power"), path.join(root, "src", "generated")]
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) continue
+    const pending = [candidate]
+    while (pending.length > 0) {
+      const currentPath = pending.pop()
+      for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
+        const entryPath = path.join(currentPath, entry.name)
+        if (entry.isDirectory()) { pending.push(entryPath); continue }
+        if (!entry.isFile() || !/\.(json|tsx?)$/i.test(entry.name)) continue
+        const content = fs.readFileSync(entryPath, "utf-8")
+        if (markers.some(marker => marker.test(content))) matches.push(path.relative(root, entryPath))
+      }
+    }
+  }
+  return matches.sort()
+}

--- a/.github/skills/code-apps/scripts/pre-deploy-check.mjs
+++ b/.github/skills/code-apps/scripts/pre-deploy-check.mjs
@@ -11,6 +11,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { findDirectMcpDataSources } from "./detect-direct-mcp-data-sources.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 // scripts/ の一つ上がプロジェクトルート
@@ -41,6 +42,16 @@ if (!fs.existsSync(envPath)) {
 const configPath = path.join(root, "power.config.json");
 if (!fs.existsSync(configPath)) {
   errors.push("power.config.json が存在しません。npx pa app init を先に実行してください。");
+}
+
+// 2a. MCP Server は Copilot Studio のツールとして接続し、Code App へ直接追加しない
+const directMcpFiles = findDirectMcpDataSources(root);
+if (directMcpFiles.length > 0) {
+  errors.push(
+    `Code App に MCP Server の直接データソースが含まれています: ${directMcpFiles.join(", ")}\n` +
+    `     → MCP は Copilot Studio のツールとして接続してください。Code App は Copilot Studio と Dataverse のみを使い、` +
+    `"npx pa app remove data-source --connector <shared_xxx> --force --non-interactive" で直接接続を削除してください。`
+  );
 }
 
 // 3. config.ts のアプリ名がデフォルトのままでないか

--- a/.github/skills/code-apps/scripts/test_detect_direct_mcp_data_sources.mjs
+++ b/.github/skills/code-apps/scripts/test_detect_direct_mcp_data_sources.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { findDirectMcpDataSources } from "./detect-direct-mcp-data-sources.mjs"
+
+test("allows Dataverse and Copilot Studio generated services", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codeapp-connections-"))
+  try {
+    await mkdir(path.join(root, "src", "generated"), { recursive: true })
+    await writeFile(path.join(root, "src", "generated", "MicrosoftCopilotStudioService.ts"), "operationName: 'ExecuteCopilotAsyncV2'")
+    assert.deepEqual(findDirectMcpDataSources(root), [])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("detects MCP schema and generated InvokeServer service", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codeapp-connections-"))
+  try {
+    const schema = path.join(root, ".power", "schemas", "drawing-mcp")
+    const generated = path.join(root, "src", "generated", "services")
+    await mkdir(schema, { recursive: true })
+    await mkdir(generated, { recursive: true })
+    await writeFile(path.join(schema, "drawing.Schema.json"), JSON.stringify({ path: "/{connectionId}/api/mcp" }))
+    await writeFile(path.join(generated, "DrawingMcpService.ts"), "operationName: 'InvokeServer'")
+    assert.deepEqual(findDirectMcpDataSources(root), [
+      path.join(".power", "schemas", "drawing-mcp", "drawing.Schema.json"),
+      path.join("src", "generated", "services", "DrawingMcpService.ts"),
+    ])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/.github/skills/code-apps/scripts/test_detect_direct_mcp_data_sources.mjs
+++ b/.github/skills/code-apps/scripts/test_detect_direct_mcp_data_sources.mjs
@@ -16,7 +16,7 @@ test("allows Dataverse and Copilot Studio generated services", async () => {
   }
 })
 
-test("detects MCP schema and generated InvokeServer service", async () => {
+test("detects MCP schema and generated TypeScript or JavaScript InvokeServer services", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "codeapp-connections-"))
   try {
     const schema = path.join(root, ".power", "schemas", "drawing-mcp")
@@ -25,8 +25,10 @@ test("detects MCP schema and generated InvokeServer service", async () => {
     await mkdir(generated, { recursive: true })
     await writeFile(path.join(schema, "drawing.Schema.json"), JSON.stringify({ path: "/{connectionId}/api/mcp" }))
     await writeFile(path.join(generated, "DrawingMcpService.ts"), "operationName: 'InvokeServer'")
+    await writeFile(path.join(generated, "CompiledMcpService.mjs"), "operationName: 'InvokeServer'")
     assert.deepEqual(findDirectMcpDataSources(root), [
       path.join(".power", "schemas", "drawing-mcp", "drawing.Schema.json"),
+      path.join("src", "generated", "services", "CompiledMcpService.mjs"),
       path.join("src", "generated", "services", "DrawingMcpService.ts"),
     ])
   } finally {

--- a/.github/skills/code-apps/templates/generic-base/scripts/detect-direct-mcp-data-sources.mjs
+++ b/.github/skills/code-apps/templates/generic-base/scripts/detect-direct-mcp-data-sources.mjs
@@ -14,7 +14,7 @@ export function findDirectMcpDataSources(root) {
       for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
         const entryPath = path.join(currentPath, entry.name)
         if (entry.isDirectory()) { pending.push(entryPath); continue }
-        if (!entry.isFile() || !/\.(json|tsx?)$/i.test(entry.name)) continue
+        if (!entry.isFile() || !/\.(json|[cm]?[jt]sx?)$/i.test(entry.name)) continue
         const content = fs.readFileSync(entryPath, "utf-8")
         if (markers.some(marker => marker.test(content))) matches.push(path.relative(root, entryPath))
       }

--- a/.github/skills/code-apps/templates/generic-base/scripts/detect-direct-mcp-data-sources.mjs
+++ b/.github/skills/code-apps/templates/generic-base/scripts/detect-direct-mcp-data-sources.mjs
@@ -1,0 +1,24 @@
+import fs from "node:fs"
+import path from "node:path"
+
+const markers = [/\/api\/mcp\b/i, /operationName\s*:\s*["']InvokeServer["']/i]
+
+export function findDirectMcpDataSources(root) {
+  const matches = []
+  const candidates = [path.join(root, ".power"), path.join(root, "src", "generated")]
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) continue
+    const pending = [candidate]
+    while (pending.length > 0) {
+      const currentPath = pending.pop()
+      for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
+        const entryPath = path.join(currentPath, entry.name)
+        if (entry.isDirectory()) { pending.push(entryPath); continue }
+        if (!entry.isFile() || !/\.(json|tsx?)$/i.test(entry.name)) continue
+        const content = fs.readFileSync(entryPath, "utf-8")
+        if (markers.some(marker => marker.test(content))) matches.push(path.relative(root, entryPath))
+      }
+    }
+  }
+  return matches.sort()
+}

--- a/.github/skills/code-apps/templates/generic-base/scripts/pre-deploy-check.mjs
+++ b/.github/skills/code-apps/templates/generic-base/scripts/pre-deploy-check.mjs
@@ -11,6 +11,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { findDirectMcpDataSources } from "./detect-direct-mcp-data-sources.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 // scripts/ の一つ上がプロジェクトルート
@@ -41,6 +42,16 @@ if (!fs.existsSync(envPath)) {
 const configPath = path.join(root, "power.config.json");
 if (!fs.existsSync(configPath)) {
   errors.push("power.config.json が存在しません。npx pa app init を先に実行してください。");
+}
+
+// 2a. MCP Server は Copilot Studio のツールとして接続し、Code App へ直接追加しない
+const directMcpFiles = findDirectMcpDataSources(root);
+if (directMcpFiles.length > 0) {
+  errors.push(
+    `Code App に MCP Server の直接データソースが含まれています: ${directMcpFiles.join(", ")}\n` +
+    `     → MCP は Copilot Studio のツールとして接続してください。Code App は Copilot Studio と Dataverse のみを使い、` +
+    `"npx pa app remove data-source --connector <shared_xxx> --force --non-interactive" で直接接続を削除してください。`
+  );
 }
 
 // 3. config.ts のアプリ名がデフォルトのままでないか


### PR DESCRIPTION
## Summary
- prohibit direct MCP custom connector data sources in Code Apps predeploy
- route agent tool access through Copilot Studio and page images through verified Dataverse cache
- update the Plant Design & Maintenance sample and troubleshooting guidance

## Validation
- sample publication check passed
- sample tests: 101 passed
- TypeScript typecheck and Vite production build passed
- direct MCP guard tests: 2 passed
- validate_skill.py and scan_sample.py passed

## Merge order
1. This Code Apps PR
2. Follow-up MCP Server contract PR