### PR TITLE
feat(ai-teammate): sync local image workflow

### DIFF
--- a/.github/skills/ai-teammate/SKILL.md
+++ b/.github/skills/ai-teammate/SKILL.md
@@ -40,9 +40,10 @@ Teams アプリパッケージを通じて、Teams / Microsoft 365 Copilot の
 
 | 参照 | 用途 |
 |---|---|
-| [digital-colleague-design.md](references/digital-colleague-design.md) | **何を作るかを決める**（役割カタログ R1〜R6 / 機能ブロック B1〜B16 / 提案条件 / 制約 / 段階導入）。**Step 0 で読む** |
+| [digital-colleague-design.md](references/digital-colleague-design.md) | **何を作るかを決める**（役割カタログ R1〜R6 / 機能ブロック B1〜B17 / 提案条件 / 制約 / 段階導入）。**Step 0 で読む** |
 | [self-hosted-agent.md](references/self-hosted-agent.md) | 自己ホストの完全手順（Azure Bot / App Service / `appsettings.json` / ログの読み方） |
-| [feature-blocks.md](references/feature-blocks.md) | **機能ブロックの実装レシピ**（B2/B6/B9〜B16 のコピー・アプリ設定・DI 登録）。**Step 8 で読む** |
+| [feature-blocks.md](references/feature-blocks.md) | **機能ブロックの実装レシピ**（B2/B6/B9〜B17 のコピー・アプリ設定・DI 登録）。**Step 8 で読む** |
+| [image-generation.md](references/image-generation.md) | **画像生成（B17）**。モデル可用性の事前検証、UAMI 認証、OneDrive 保存、台帳連携。**Step 8 で読む** |
 | [agent-brain.md](references/agent-brain.md) | 中身の作り込み（Azure OpenAI / 会話履歴 / プロンプト外部化 / Dataverse MCP / Work IQ / 再デプロイ） |
 | [prompt-injection.md](references/prompt-injection.md) | **外部データを読むなら必須**。フェンス / 許可リスト / 検知 / 同意の強制の 4 層。**Step 8 で読む** |
 | [usage-accounting.md](references/usage-accounting.md) | **誰が・何に・いくら使ったか**の計測（B15）。Azure ポータルでは出せない内訳。**Step 8 で読む** |
@@ -135,6 +136,7 @@ python scripts/scaffold_ai_teammate.py --decisions decisions.json --env .env --t
 | [provision_selfhost.py](scripts/provision_selfhost.py) | UAMI + Azure Bot（Teams チャネル）+ App Service を冪等に作成し `.env` へ書き戻す。`--check` でプラン・Always On のドリフト検出 | 6 |
 | [deploy_agent_webapp.py](scripts/deploy_agent_webapp.py) | ブループリント作成/シークレット ローテーション（App Service 設定へのみ注入・ログ非出力）・`dotnet publish`・`az webapp deploy`/`restart`・`a365 setup blueprint --endpoint-only` を実行する | 4・6 |
 | [provision_code_sandbox.py](scripts/provision_code_sandbox.py) | コード実行サンドボックス（Container Apps 動的セッション プール）を冪等に作成しロールを付与（B12 のときのみ `deploy_ai_teammate.py --check` の対象） | 8 |
+| [provision_image_model.py](scripts/provision_image_model.py) | 対象 Azure OpenAI アカウントで提供される画像モデル名・バージョンを確認してから冪等にデプロイする。`--check` は変更なし | 8 |
 | [build_teams_package.py](scripts/build_teams_package.py) | Teams manifest + アイコン + `agenticUser.json` を ZIP 化 | 9 |
 | [publish_teams_app.py](scripts/publish_teams_app.py) | Graph で ZIP を組織カタログへ登録（**devPreview は Graph 側で拒否される**） | 10 |
 | [grant_agent_instance_consent.py](scripts/grant_agent_instance_consent.py) | インスタンス SP に Messaging Bot API の管理者同意を付与 | 11 |
@@ -358,6 +360,7 @@ Step 0 で選んだブロックだけを実装する。手順はすべて
 | B14 | 成果物を台帳で管理し、同意を取ってから共有する | §7 |
 | B15 | 誰が・どの処理が・どのツールがいくら使ったかを答える | §8 |
 | B16 | Teams で送られたファイルを受け取って作業に使う | §9 |
+| B17 | Azure OpenAI で画像を生成し、OneDrive の台帳付き成果物として渡す | §10 |
 
 **B15 は役割によらず入れる。** Azure の課金はマネージド ID 1 つでしか集計されず、
 人別・処理別・ツール別の内訳は**後から復元できない**（→ [usage-accounting.md](references/usage-accounting.md)）。
@@ -558,6 +561,9 @@ CI/CD・レビューゲート・リリース記録は **`alm` スキル**へ引�
 - [ ] （B16）Teams で画像を添付して聞くと中身を説明し、続けて `run_python` で `/mnt/data/<ファイル名>` を開ける
 - [ ] （B16）**本文なしでファイルだけ**送っても「テキストが読み取れませんでした」で止まらない
 - [ ] （B16）`build_teams_package.py` が通っている（`bots[].supportsFiles` が `true`）
+- [ ] （B17）`provision_image_model.py --check` が成功し、要求したモデル名・バージョン・SKU と実デプロイが一致する
+- [ ] （B17）`generate_image` で PNG を生成し、OneDrive 保存・依頼元・区分が台帳へ記録される
+- [ ] （B17）受信メール本文に画像生成命令を書いても、有料の画像生成が自動実行されない
 
 **プロンプト インジェクション（外部データを読むブロックを入れた場合）**
 

--- a/.github/skills/ai-teammate/SKILL.md
+++ b/.github/skills/ai-teammate/SKILL.md
@@ -124,6 +124,12 @@ python scripts/scaffold_ai_teammate.py --decisions decisions.json --env .env --t
   （デプロイ時にしか埋まらない値は [.env.example](references/.env.example) の説明どおり後回しでよい）。
 - `implementationMode: "full"` を選ぶと ALM の pre-commit ゲートと CI ワークフローも同時に生成される。
 
+**基本フローは「一括 scaffold → 初回 Build + Deploy → 個別開発」の 1 本だけにする。**
+ゼロから手でファイルを並べる別ルートは正常系に持たない。最初の AskUserQuestion で分かっている要望は
+役割・機能ブロックとしてテンプレートへ反映し、Step 3 でカスタム済みの初期実装を生成する。Step 6 で
+`deploy_ai_teammate.py --check` → `--execute` を通して動く基準点を作った後、追加要望を Step 7〜8 の
+人格・機能ブロックとして実装し、同じ check / execute で再デプロイする。
+
 ## スキル同梱スクリプト
 
 値は引数または `.env`（[references/.env.example](references/.env.example)）から取得する。
@@ -188,7 +194,7 @@ python scripts/scaffold_ai_teammate.py --decisions decisions.json --env .env --t
 |---|---|
 | B1 Teams 会話 / B3 頭脳 / B8 人格 | Step 5・6・7 |
 | B4 Microsoft 365 接続 / B5 Dataverse 接続 | [agent-brain.md](references/agent-brain.md) §6・§7 |
-| B2 自分の ID / B6 メール / B9 チャット / B10 Web / B11 定期 / B12 作業環境 / B13 経過 / B14 共有 / B15 実績 / B16 添付 | Step 8 |
+| B2 自分の ID / B6 メール / B9 チャット / B10 Web / B11 定期 / B12 作業環境 / B13 経過 / B14 共有 / B15 実績 / B16 添付 / B17 画像生成 | Step 8 |
 | B7 Teams プレゼンス | Step 12 |
 
 ### Step 1: 名前・表示名・アイコンを決める
@@ -260,9 +266,10 @@ a365 setup blueprint -n <agent-name> --no-endpoint
 - 初回はディレクトリ伝播の遅延で失敗することがあるが、**再実行すれば冪等に修復**される。
 - エンドポイント登録は Step 6 で行う（この時点ではまだ URL が存在しない）。
 
-### Step 5: Agents SDK アプリを実装する
+### Step 5: scaffold 済み Agents SDK アプリを初期要望に合わせる
 
-**ここで作るアプリが agentUser チャットの実体。**
+**Step 3 で生成したアプリが agentUser チャットの実体。** 選択した役割・機能ブロック、プロンプト、
+環境設定が初期要望と一致することを確認し、テンプレートでは表現できない業務固有部分だけを実装する。
 
 ```text
 src/<agent-name>-agent/
@@ -329,6 +336,9 @@ a365 setup blueprint -n <agent-name> --endpoint-only --messaging-endpoint $env:A
   `python scripts/provision_selfhost.py --check` を通す。
 
 ### Step 7: 人格と初期品質を入れる
+
+ここからは**初回 Build + Deploy 後の個別開発ループ**。追加要望を小さく実装し、変更ごとに
+`python scripts/deploy_ai_teammate.py --check` を通してから `--execute` で再デプロイする。
 
 公開前に [秘書プロンプト雛形](references/templates/assistant-system-prompt.template.md) を
 `prompts/system.md` へコピーし、`<表示名>` / `<役割>` / `<人格>` を業務に合わせて置き換える。

--- a/.github/skills/ai-teammate/references/.env.example
+++ b/.github/skills/ai-teammate/references/.env.example
@@ -97,6 +97,20 @@ WEB_SEARCH_ENABLED=false
 # 検索を別デプロイで回したいときだけ。未設定なら LLM と同じデプロイを使う
 # WEB_SEARCH_DEPLOYMENT=your-deployment
 
+# === 画像生成（B17・任意）===
+# scripts/provision_image_model.py --check で対象アカウントへの提供を確認してから有効化する
+IMAGE_GENERATION_ENABLED=false
+AZURE_OPENAI_RESOURCE_GROUP=rg-your-ai
+AZURE_OPENAI_ACCOUNT=your-ai-account
+# 取得元: scripts/provision_image_model.py --check。対象アカウントで提供される名前を指定する
+IMAGE_GENERATION_MODEL=gpt-image-1.5
+# deployment 名は任意。未指定時は IMAGE_GENERATION_MODEL と同じ名前を使う
+IMAGE_GENERATION_DEPLOYMENT=gpt-image-1.5
+# 対象アカウントで利用可能な SKU と capacity を指定する
+IMAGE_GENERATION_SKU=GlobalStandard
+IMAGE_GENERATION_CAPACITY=1
+IMAGE_GENERATION_TIMEOUT_SECONDS=300
+
 # === Web IQ MCP（任意・招待済みのテナントのみ）===
 # 画像・動画検索が業務要件のときだけ併用する。未設定なら接続を試みない
 # API キーは**秘匿値**。.env にのみ置き、App Service のアプリ設定へ注入する
@@ -229,7 +243,7 @@ TEAMS_APP_RESOURCE_URI=api://www.example.com
 | 区分 | 変数 | 扱い |
 |---|---|---|
 | 秘匿 | `AZURE_*`（`AZURE_KEYVAULT_NAME` を除く） / `FOUNDRY_PROJECT_ENDPOINT` / `*_PRINCIPAL_ID` / `*_CLIENT_ID` / `AGENT_GUID` / `A365_AGENT_BLUEPRINT_ID` / `A365_AGENT_USER_ID` / `AZURE_BOT_NAME` / `SANDBOX_ENDPOINT` / `SANDBOX_POOL_NAME` | `.env` と CI のシークレットストアのみ。テンプレートでは `${VAR}` |
-| 非秘匿 | `AGENT_NAME` / `BLUEPRINT_ID` / `TEAMS_APP_VERSION` / `AGENT_DISPLAY_NAME` / `AGENT_FULL_NAME` / `AGENT_ICON` / `AGENT_DESCRIPTION_*` / `DEVELOPER_*` / `TEAMS_APP_RESOURCE_URI` / `MAILBOX_*` / `MAIL_ENABLED` / `SCHEDULE_*` / `PROGRESS_*` / `DOCUMENTS_ENABLED` / `DOCUMENTS_FOLDER` / `USAGE_ENABLED` / `USAGE_STORE_PATH` / `USAGE_CURRENCY` / `USAGE_JPY_RATE` / `USAGE_ADMINS` / `SANDBOX_ENABLED` / `SANDBOX_LOCATION` / `SANDBOX_MAX_SESSIONS` / `SANDBOX_COOLDOWN_SECONDS` / `SANDBOX_EGRESS` | `alm.config.json` の `non_secret_vars`（および `sanitize.py` / `check_secrets.py` の `NON_SECRET_VARS`）に登録し、置換対象から除外する |
+| 非秘匿 | `AGENT_NAME` / `BLUEPRINT_ID` / `TEAMS_APP_VERSION` / `AGENT_DISPLAY_NAME` / `AGENT_FULL_NAME` / `AGENT_ICON` / `AGENT_DESCRIPTION_*` / `DEVELOPER_*` / `TEAMS_APP_RESOURCE_URI` / `MAILBOX_*` / `MAIL_ENABLED` / `SCHEDULE_*` / `PROGRESS_*` / `DOCUMENTS_ENABLED` / `DOCUMENTS_FOLDER` / `USAGE_ENABLED` / `USAGE_STORE_PATH` / `USAGE_CURRENCY` / `USAGE_JPY_RATE` / `USAGE_ADMINS` / `SANDBOX_ENABLED` / `SANDBOX_LOCATION` / `SANDBOX_MAX_SESSIONS` / `SANDBOX_COOLDOWN_SECONDS` / `SANDBOX_EGRESS` / `IMAGE_GENERATION_*` | `alm.config.json` の `non_secret_vars`（および `sanitize.py` / `check_secrets.py` の `NON_SECRET_VARS`）に登録し、置換対象から除外する |
 | ルーティング設定 | `IMPLEMENTATION_MODE` / `GIT_PROVIDER` / `SECRET_BACKEND` / `AZDO_*` / `AZURE_KEYVAULT_NAME` | 「秘匿値をどこへ送るか」を決める値。`BACKEND_CONFIG_VARS` に登録し、置換も同期もしない |
 
 非秘匿値を置換対象に含めると、`AGENT_NAME` のような短い文字列が

--- a/.github/skills/ai-teammate/references/digital-colleague-design.md
+++ b/.github/skills/ai-teammate/references/digital-colleague-design.md
@@ -123,6 +123,7 @@ Exchange の共有設定、Work IQ のポリシーで縛る。
 | **B14** | 成果物の共有と同意 | `DocumentLedger.cs` / `DocumentShareTools.cs` | 作ったファイルの依頼元と区分を覚えておき、別の人への共有は依頼元の許可を取ってから行う | B3 B12 ＋ Graph 委任同意（許可の受け付けに B9）|
 | **B15** | 利用実績とコスト | `UsageStore.cs` / `UsageTools.cs` | 誰が・どの処理が・どのツールがどれだけ使ったかを記録し、会話で内訳を返す | B3 |
 | **B16** | 添付の受け取り | `IncomingFiles.cs` | Teams で送られた画像・資料を見て理解し、作業環境で加工する | B1 B3 B12 ＋ マニフェスト `supportsFiles` |
+| **B17** | 画像生成 | `ImageGenerationTools.cs` | 新しい画像素材を生成し、OneDrive の台帳付き成果物として渡す | B3 B14 ＋ Azure OpenAI 画像モデル |
 
 雛形は [templates/](templates/) にある。`AgenticIdentity.template.cs` / `MailboxWorker.template.cs` /
 `PresenceWorker.template.cs` / `TeamsChatTools.template.cs` / `WebSearchTools.template.cs` /
@@ -130,7 +131,8 @@ Exchange の共有設定、Work IQ のポリシーで縛る。
 `CodeSandbox.template.cs` / `SandboxTools.template.cs` / `AgentProgress.template.cs` /
 `MessageHtml.template.cs` / `MailTools.template.cs` / `DocumentLedger.template.cs` /
 `DocumentShareTools.template.cs` / `UsageStore.template.cs` / `UsageTools.template.cs` /
-`IncomingFiles.template.cs`
+`IncomingFiles.template.cs`。一括 scaffold の原本は `templates/digital-colleague/` にあり、B17 の
+`ImageGenerationTools.cs` もそこから選択されたブロックに応じて生成される。
 をコピーし、名前空間だけ合わせる。
 
 > **B9 だけは Work IQ を通らない。** Work IQ のパス allowlist に `/chats` が無いため、
@@ -188,6 +190,7 @@ Exchange の共有設定、Work IQ のポリシーで縛る。
         B14 成果物の共有（B12 の出口に付く・許可の受け付けは B1 のターンでしかできない）
         B15 利用実績（B3 のツール ループ全体を 1 ターン単位で計測・全入口共通）
         B16 添付の受け取り（B1 のターンの入口に付く・画像は B3 に見せ、実体は B12 に置く）
+        B17 画像生成（B3 のローカル ツール・生成物は B14 の OneDrive と台帳へ渡す）
 ```
 
 **入口が増えても頭脳は 1 つ**にする。Teams とメールで判断が食い違うと、利用者は必ず気付く。
@@ -202,14 +205,14 @@ Exchange の共有設定、Work IQ のポリシーで縛る。
 
 ## 4. 役割 × ブロックの対応表
 
-| 役割 | B1 Teams | B2 ID | B3 頭脳 | B4 M365 | B5 Dataverse | B6 メール | B7 在席 | B8 人格 | B9 チャット | B10 Web | B11 定期 | B12 作業環境 | B13 経過 | B14 共有 | B15 実績 | B16 添付 |
-|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
-| R1 予定調整の秘書 | ● | ● | ● | ● | ○ | ● | ● | ● | ○ | ○ | ○ | ○ | ○ | ○ | ● | ○ |
-| R2 一次受付 | ○ | ● | ● | ● | ● | ● | ○ | ● | ○ | ● | ○ | ○ | ○ | ○ | ● | ○ |
-| R3 ウォッチャー | ● | ● | ● | ○ | ● | ○ | ● | ● | ● | ● | ● | ○ | ● | ○ | ● | ○ |
-| R4 まとめ役 | ○ | ● | ● | ● | ● | ○ | ○ | ● | ○ | ○ | ● | ● | ● | ● | ● | ● |
-| R5 起票・下書き係 | ● | ● | ● | ○ | ● | ● | ● | ● | — | ○ | ○ | ● | ● | ● | ● | ● |
-| R6 チーム | 各体に依存 | ● | ● | — | ● | — | ● | ● | ○ | ● | ○ | ○ | ● | ○ | ● | ○ |
+| 役割 | B1 Teams | B2 ID | B3 頭脳 | B4 M365 | B5 Dataverse | B6 メール | B7 在席 | B8 人格 | B9 チャット | B10 Web | B11 定期 | B12 作業環境 | B13 経過 | B14 共有 | B15 実績 | B16 添付 | B17 画像 |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| R1 予定調整の秘書 | ● | ● | ● | ● | ○ | ● | ● | ● | ○ | ○ | ○ | ○ | ○ | ○ | ● | ○ | ○ |
+| R2 一次受付 | ○ | ● | ● | ● | ● | ● | ○ | ● | ○ | ● | ○ | ○ | ○ | ○ | ● | ○ | ○ |
+| R3 ウォッチャー | ● | ● | ● | ○ | ● | ○ | ● | ● | ● | ● | ● | ○ | ● | ○ | ● | ○ | ○ |
+| R4 まとめ役 | ○ | ● | ● | ● | ● | ○ | ○ | ● | ○ | ○ | ● | ● | ● | ● | ● | ● | ○ |
+| R5 起票・下書き係 | ● | ● | ● | ○ | ● | ● | ● | ● | — | ○ | ○ | ● | ● | ● | ● | ● | ○ |
+| R6 チーム | 各体に依存 | ● | ● | — | ● | — | ● | ● | ○ | ● | ○ | ○ | ● | ○ | ● | ○ | ○ |
 
 ● 必須 ／ ○ 業務次第 ／ — 不要
 

--- a/.github/skills/ai-teammate/references/feature-blocks.md
+++ b/.github/skills/ai-teammate/references/feature-blocks.md
@@ -1,4 +1,4 @@
-# 機能ブロックの実装レシピ（B2/B6/B9〜B16）
+# 機能ブロックの実装レシピ（B2/B6/B9〜B17）
 
 [SKILL.md](../SKILL.md) の **Step 8** で足す機能ブロックの実装手順。
 どのブロックも **「テンプレートをコピー → アプリ設定 → DI 登録 → 再デプロイ」** の 4 手で入る。
@@ -22,6 +22,7 @@
 | B14 成果物の共有 | `DocumentLedger.cs` / `DocumentShareTools.cs` | `Documents__*` | §7 |
 | B15 利用実績 | `UsageStore.cs` / `UsageTools.cs` | `Usage__*` | §8 |
 | B16 添付の受け取り | `IncomingFiles.cs` | なし（マニフェストの `supportsFiles`） | §9 |
+| B17 画像生成 | `ImageGenerationTools.cs` | `ImageGeneration__*` | §10 |
 
 **インスタンス単位の同意・委任スコープ付与は Step 11 でまとめて行う。**
 B6 は `Mail.Send`、B9 は `Chat.Create` / `Chat.Read` / `ChatMessage.Send`、
@@ -425,3 +426,40 @@ return new UserChatMessage(parts);
 > GCC High / DoD / 21Vianet ではファイルの送受信自体が未対応。
 
 経路ごとの取得方法・落とし穴・検証手順は [incoming-files.md](incoming-files.md)。
+
+---
+
+## 10. B17 — 新しい画像素材を生成する
+
+**前提は B3 と B14。** 生成した PNG はエージェントの OneDrive へ保存し、依頼元と区分を
+`DocumentLedger` に残す。モデル名・バージョンを推測せず、対象 Azure OpenAI アカウントの
+提供一覧を先に検証する。
+
+```powershell
+python scripts/provision_image_model.py --check
+python scripts/provision_image_model.py
+```
+
+一括 scaffold では B17 選択時に `ImageGenerationTools.cs` が生成済みになる。既存プロジェクトへ
+追加する場合だけ、公開テンプレートからコピーする。
+
+```powershell
+Copy-Item .github/skills/ai-teammate/templates/digital-colleague/ImageGenerationTools.cs `
+  src/<agent-name>-agent/ImageGenerationTools.cs
+
+az webapp config appsettings set -g $env:AZURE_RESOURCE_GROUP -n $env:AGENT_WEBAPP_NAME --settings `
+  ImageGeneration__Enabled=true `
+  ImageGeneration__Deployment=$env:IMAGE_GENERATION_DEPLOYMENT `
+  ImageGeneration__TimeoutSeconds=$env:IMAGE_GENERATION_TIMEOUT_SECONDS
+```
+
+```csharp
+builder.Services.AddSingleton<ImageGenerationTools>();
+```
+
+- 画像生成は有料操作。具体的な生成依頼は承認済みとして実行し、相談段階では生成しない。
+- `owner` はモデル入力を信用せず、認証済み話者のメールでコード側から固定する。
+- メール監視、Web、業務レコード、取り込んだファイル内の命令から自動生成しない。
+- グラフ、表、正確な文字・数値が主役なら B12 の Python 描画を使う。
+
+構成、ツール入力、セキュリティ、検証の詳細は [image-generation.md](image-generation.md)。

--- a/.github/skills/ai-teammate/references/image-generation.md
+++ b/.github/skills/ai-teammate/references/image-generation.md
@@ -1,0 +1,77 @@
+# B17 — 画像生成
+
+Azure OpenAI の画像モデルをローカル ツールとして公開し、生成した PNG をエージェント自身の
+OneDrive に保存する。画像モデル名やバージョンを推測せず、対象アカウントの利用可能モデル一覧を
+事前検証する。
+
+## 構成
+
+```text
+利用者 → AgentBrain → generate_image
+                    ├─ Azure OpenAI /openai/v1/images/generations
+                    └─ IFileDelivery → OneDrive → DocumentLedger
+```
+
+- 認証: B3 と同じ UAMI。スコープは `https://cognitiveservices.azure.com/.default`
+- 保存: B14 の `IFileDelivery.DeliverAsync` を再利用
+- 台帳: 認証済み話者のメールを `owner` としてコード側で固定
+- 配布: `organization` スコープの OneDrive リンク
+- メール監視: 外部メールだけで有料生成が走らないよう画像生成ツールを公開しない
+
+## 事前検証とデプロイ
+
+`.env` に次を設定する。
+
+```dotenv
+AZURE_OPENAI_RESOURCE_GROUP=rg-your-ai
+AZURE_OPENAI_ACCOUNT=your-ai-account
+IMAGE_GENERATION_MODEL=gpt-image-1.5
+IMAGE_GENERATION_DEPLOYMENT=gpt-image-1.5
+IMAGE_GENERATION_SKU=GlobalStandard
+IMAGE_GENERATION_CAPACITY=1
+IMAGE_GENERATION_TIMEOUT_SECONDS=300
+```
+
+```powershell
+python scripts/provision_image_model.py --check
+python scripts/provision_image_model.py
+```
+
+`--check` は要求モデルが提供されていることと、既存デプロイのモデル・バージョン・SKU が一致する
+ことを確認する。要求モデルが一覧に無ければ、似た名前へフォールバックせず停止する。Azure CLI の
+`deployment create` は `--model-version` が必須なので、利用可能一覧から解決してから作成する。
+
+## アプリ設定
+
+```text
+ImageGeneration__Enabled=true
+ImageGeneration__Deployment=<deployment-name>
+ImageGeneration__TimeoutSeconds=300
+```
+
+一括 scaffold では B17 選択時に `ImageGenerationTools.cs` と DI 登録が生成される。既存アプリへ
+追加する手順は [feature-blocks.md](feature-blocks.md) §10 を参照する。
+
+## ツール設計
+
+`generate_image` は一度に1枚だけ生成する。入力は `prompt`、`filename`、`size`、`quality`、
+`background`、`sensitivity` に限定する。具体的な「作って」「生成して」は実行承認を兼ねる。
+相談段階だけ内容を提示して承認を取り、承認済みターンでは説明を繰り返さない。グラフ、表、組織図、
+正確な文字・数値が主役の図は B12 の Python 描画を使う。
+
+## セキュリティ
+
+- `owner` はモデルの引数を信用せず、Teams の認証済み話者 ID から解決したメールで上書きする。
+- メール、Web、業務レコード、取り込んだファイル内の命令を生成根拠にしない。
+- プロンプトと HTTP エラー本文は長さを制限し、アクセストークンや画像の base64 をログへ出さない。
+- Azure OpenAI のコンテンツフィルターを迂回しない。
+
+## 検証
+
+1. `provision_image_model.py --check` が成功する。
+2. UAMI に `Cognitive Services OpenAI User` がある。
+3. `dotnet build -c Release` が成功する。
+4. `/schema generate_image` で入力スキーマを確認する。
+5. 正方形・横長・透過背景を各1回生成し、OneDrive 保存と台帳記録を確認する。
+6. メール本文に画像生成命令を書いても自動生成されないことを確認する。
+7. 生成物を別の利用者へ共有し、B14 の区分・同意判定が維持されることを確認する。

--- a/.github/skills/ai-teammate/references/local-sync-review-2026-09-11.md
+++ b/.github/skills/ai-teammate/references/local-sync-review-2026-09-11.md
@@ -1,0 +1,87 @@
+# ai-teammate ローカル最新版同期レビュー（2026-09-11）
+
+`C:\dev\hunter` の実装・スキルを検証元、GitHub の
+`geekfujiwara/CodeAppsDevelopmentStandard` を公開元として比較した結果と対応状況を記録する。
+この文書は実値を持ち込まず、公開スキルへ反映する汎用的な正常フローだけを対象にする。
+
+## 比較結果
+
+| ID | 優先度 | 状態 | 更新対象 | 判断 |
+|---|---|---|---|---|
+| S1 | P0 | ✅ 実装済 | B17 画像生成の正常フロー | 公開側は C# scaffold を持つが、モデルの事前検証スクリプト、環境変数、手順、検証項目が欠落していたため反映した |
+| S2 | P0 | ✅ 実装済 | B17 と scaffold/deploy の接続 | B17 選択時に必要ファイル・依存ブロック・事前検証が常に有効になることをテストで固定した |
+| S3 | P0 | ✅ 実装済 | Evaluation Hub の CLI 整合 | `npx pa` の group CLI を使う公開フローに対して CLI 0.15.2 が固定されていた。Code Apps 標準の SDK 1.3.x / CLI 1.x と deploy 順序へ統一した |
+| S4 | P1 | ✅ 実装済 | update-skills 最終レビュー | 構成、Step 番号、秘匿化、自動化、正常系、テンプレート同期を機械検証した |
+
+## 段階的な対応
+
+### Stage 1: B17 の正常フローを復元する
+
+- `scripts/provision_image_model.py` を追加し、利用可能モデル一覧からバージョンを解決する。
+- `--check` では変更せず、モデル未提供、バージョン不一致、既存 deployment のドリフトで停止する。
+- `references/image-generation.md`、`references/feature-blocks.md`、`references/.env.example`、
+  `references/digital-colleague-design.md`、`SKILL.md` を更新する。
+- `ImageGenerationTools.cs` は既存の汎用 scaffold テンプレートを正とし、重複テンプレートを増やさない。
+
+受け入れ条件:
+
+- B17 の選定からモデル事前検証、構成、デプロイ後検証まで正常フローだけで辿れる。
+- Azure OpenAI のモデル名・バージョンを推測せず、未提供時に作成処理へ進まない。
+- 画像生成をメールなどの未信頼コンテンツから自動実行しない制約が明記される。
+
+### Stage 2: scaffold と事前検証を固定する
+
+- `scaffold_ai_teammate.py` の B17 依存関係（B3、B14、B12）とファイル出力をテストする。
+- B17 有効時だけ画像モデルの preflight を deployment plan に含める。
+- `provision_image_model.py` のモデル選択、`--check`、ドリフト拒否を単体テストする。
+
+受け入れ条件:
+
+- B17 を選ぶと `ImageGenerationTools.cs` と依存ブロックが生成される。
+- B17 を選ばない構成では画像モデルの Azure 操作を計画しない。
+- Windows でも shell 文字列実行や対話入力に依存しない。
+
+### Stage 3: Evaluation Hub の deploy を正常化する
+
+- Evaluation App の SDK、CLI、`deploy` を Code Apps の generic-base と同じバージョン範囲・順序へ統一する。
+- scaffold テストで package script の回帰を検出する。
+
+受け入れ条件:
+
+- `npm run build`、`npm run predeploy`、`npx pa app push` の順で実行される。
+- `@microsoft/power-apps-cli` 1.x の `pa` bin を明示的な devDependency として持つ。
+- 実デプロイは行わず、lint、build、predeploy の非破壊検証まで実施する。
+
+### Stage 4: update-skills による最終レビュー
+
+- `manage_skill_pr.py` で関連 PR がないことを確認し、本更新を単一 PR にする。
+- `validate_skill.py`、単体テスト、生成 .NET build、Evaluation App lint/build、`git diff --check` を実行する。
+- 実 GUID、テナント URL、メール、シークレット、生成物をスキャンする。
+- 公開側だけにある scaffold、deployment orchestration、Evaluation Hub、ALM 連携は維持する。
+
+受け入れ条件:
+
+- すべての検証が成功し、既知の固有値ヒットが 0 件になる。
+- `.env`、`a365.generated.config.json`、`bin`、`obj`、`dist`、`node_modules`、`__pycache__` を含めない。
+
+## 反映しない差分
+
+- `hunter3-agent` の namespace、エージェント名、固定 publisher prefix、Azure リソース名。
+- `.env`、`a365.config.json`、`a365.generated.config.json`、認証情報、実 GUID、実 URL、実メール。
+- ローカルの手動コピー中心の scaffold。公開側の AskUserQuestion decision JSON による一括 scaffold を維持する。
+- 公開側にのみ存在する Evaluation Hub、deployment orchestration、単体テスト、ALM scaffold の削除。
+- コメントやブランド文言だけの差分で、公開テンプレートの方が汎用的なもの。
+
+## レビュー記録
+
+- `manage_skill_pr.py --skill ai-teammate --repo geekfujiwara/CodeAppsDevelopmentStandard`: 関連オープン PR 0 件。
+- `npx pa app push --help`: CLI 0.15.2 ではローカル `pa` bin がなく、無関係な `pa@0.1.1` のインストール要求を確認して中止。Code Apps 標準の CLI 1.x へ同期する判断材料とした。
+- `EvaluationDataverse.cs` と `EvaluationRunner.cs`: 環境依存値を除く機能差分なし。
+- `AspNetExtensions.cs`: ローカル側は XML コメントが詳細だが、動作差分ではないため本更新の対象外。
+- `validate_skill.py`: `✅ ai-teammate`。
+- 単体テスト: 68 件成功（image deployment create argv テストを含む）。
+- B1〜B17 full scaffold: 任意 prefix で生成し、.NET 8 Release build が警告 0 / エラー 0。
+- Evaluation App: `@microsoft/power-apps-cli` 1.0.1、`npx pa --version`、ESLint が成功。
+- 既知のテナント固有値スキャン: 0 件。
+- 独立差分レビュー: 実行阻害、秘匿化違反、正常フローの欠落なし。モデル/SKU の取得元コメントと
+  image deployment create argv の回帰テストを追加した。

--- a/.github/skills/ai-teammate/references/local-sync-review-2026-09-11.md
+++ b/.github/skills/ai-teammate/references/local-sync-review-2026-09-11.md
@@ -12,6 +12,7 @@
 | S2 | P0 | ✅ 実装済 | B17 と scaffold/deploy の接続 | B17 選択時に必要ファイル・依存ブロック・事前検証が常に有効になることをテストで固定した |
 | S3 | P0 | ✅ 実装済 | Evaluation Hub の CLI 整合 | `npx pa` の group CLI を使う公開フローに対して CLI 0.15.2 が固定されていた。Code Apps 標準の SDK 1.3.x / CLI 1.x と deploy 順序へ統一した |
 | S4 | P1 | ✅ 実装済 | update-skills 最終レビュー | 構成、Step 番号、秘匿化、自動化、正常系、テンプレート同期を機械検証した |
+| S5 | P0 | ✅ 実装済 | scaffold 後の個別開発フロー | 一括 scaffold を唯一の基本ルートとし、初回 Build + Deploy 後に追加要望を Step 7〜8 で実装して同じ check / execute へ戻る流れを明文化した |
 
 ## 段階的な対応
 
@@ -71,6 +72,22 @@
 - ローカルの手動コピー中心の scaffold。公開側の AskUserQuestion decision JSON による一括 scaffold を維持する。
 - 公開側にのみ存在する Evaluation Hub、deployment orchestration、単体テスト、ALM scaffold の削除。
 - コメントやブランド文言だけの差分で、公開テンプレートの方が汎用的なもの。
+
+## 確定した正常フロー
+
+```text
+AskUserQuestion
+  → 要望を roles / blocks / personality として decisions.json へ記録
+  → テンプレートからカスタム scaffold（Agents SDK + Evaluation Hub + ALM）
+  → deploy_ai_teammate.py --check
+  → deploy_ai_teammate.py --execute（Build + Deploy）
+  → 稼働する基準点を確認
+  → 個別要望を人格・機能ブロック・業務ロジックとして追加
+  → 同じ --check / --execute で反復
+```
+
+ゼロからの手動 scaffold は別ルートとして持たない。手動手順は、既存プロジェクトへの個別機能追加と
+障害調査で自動処理の中身を確認する用途に限定する。
 
 ## レビュー記録
 

--- a/.github/skills/ai-teammate/references/troubleshooting.md
+++ b/.github/skills/ai-teammate/references/troubleshooting.md
@@ -1186,9 +1186,20 @@ Windows PowerShell 5.1 へフォールバックする場合、`Set-Content -Enco
   接続して初めて生成されるコードで、秘匿情報を含むため scaffold の対象外
   （`code-apps` スキルの標準と同じ）。
 - `deploy_ai_teammate.py --check` はこれを失敗として扱わない: `power.config.json` が無い段階では
-  `npm install` と `npx tsc -b --noEmit` までを検証範囲とし、`npm run build` は試さない。
+  `npm install` と `npm run lint` までを検証範囲とし、`npm run build` は試さない。
   `power.config.json` が存在する（`pa app init` まで進んだ）場合のみ `npm run build --if-present`
   を実行して本当のビルド健全性を見る。
 - 対処: `python scripts/deploy_ai_teammate.py --execute` が
   `pa app init` → `setup_connection_reference.py --write-env` → `add_data_source.py` →
   `npm run predeploy` の順に実行して初めて `src/generated/` が揃い、`npm run build` が成立する。
+
+## 57. `npx pa app push` が無関係な `pa@0.1.1` のインストールを要求する
+
+- 原因: `package.json` が旧 `@microsoft/power-apps-cli` 0.x を固定しているか、CLI を直接依存に持たず、
+  ローカルの `pa` bin を解決できていない。npm は同名の無関係な `pa` パッケージを取得しようとする。
+- 対処: `@microsoft/power-apps-cli` 1.x を `devDependencies` に明示し、`npx pa --version` と
+  `npx pa app --help` を確認する。`deploy` は
+  `npm run build && npm run predeploy && npx pa app push` に統一する。
+- 恒久対策済み: Evaluation App の `scripts/pre-deploy-check.mjs` が CLI の major version と deploy
+  script を毎回検証し、`test_deploy_ai_teammate.py::test_template_uses_current_pa_cli` がテンプレートの
+  回帰を検出する。

--- a/.github/skills/ai-teammate/scripts/deploy_ai_teammate.py
+++ b/.github/skills/ai-teammate/scripts/deploy_ai_teammate.py
@@ -214,6 +214,7 @@ def check_existing_scripts(skill_root: Path, env_path: Path, target: Path, env: 
     for script_name in script_names:
         script = skill_root / "scripts" / script_name
         if not script.is_file():
+            problems.append(f"required provisioning script not found: {script_name}")
             continue
         ok, output = run(
             [sys.executable, str(script), "--check", "--env", str(env_path)],
@@ -342,6 +343,7 @@ def build_pre_connection_steps(target: Path, env: dict[str, str], skill_root: Pa
     env_path = target / ".env"
     app_dir = target / "evaluation-app"
     code_apps_scripts = skill_root.parent / "code-apps" / "scripts"
+    blocks = _scaffold_blocks(target)
 
     steps = [
         Step(
@@ -349,6 +351,14 @@ def build_pre_connection_steps(target: Path, env: dict[str, str], skill_root: Pa
             (sys.executable, str(skill_root / "scripts" / "setup_evaluation_dataverse.py"), "--env", str(env_path)),
             target,
         ),
+    ]
+    if "B17" in blocks:
+        steps.append(Step(
+            "provision_image_model.py",
+            (sys.executable, str(skill_root / "scripts" / "provision_image_model.py"), "--env", str(env_path)),
+            target,
+        ))
+    steps += [
         Step(
             "provision_selfhost.py",
             (sys.executable, str(skill_root / "scripts" / "provision_selfhost.py"), "--write", str(env_path)),

--- a/.github/skills/ai-teammate/scripts/provision_image_model.py
+++ b/.github/skills/ai-teammate/scripts/provision_image_model.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Validate and provision an Azure OpenAI image deployment without guessing versions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def load_env(path: Path) -> None:
+    if not path.is_file():
+        return
+    for raw_line in path.read_text(encoding="utf-8-sig").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+def run_az(*arguments: str) -> object:
+    executable = shutil.which("az")
+    if executable is None:
+        raise RuntimeError("Azure CLI executable 'az' was not found on PATH.")
+    result = subprocess.run(
+        [executable, *arguments, "--output", "json"],
+        capture_output=True,
+        text=True,
+        shell=False,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+    return json.loads(result.stdout) if result.stdout.strip() else None
+
+
+def model_details(entry: dict[str, object]) -> tuple[str | None, str | None, str]:
+    value = entry.get("model")
+    model = value if isinstance(value, dict) else entry
+    return (
+        model.get("name") if isinstance(model.get("name"), str) else None,
+        model.get("version") if isinstance(model.get("version"), str) else None,
+        model.get("format") if isinstance(model.get("format"), str) else "OpenAI",
+    )
+
+
+def available_versions(resource_group: str, account: str, requested: str) -> list[tuple[str, str]]:
+    entries = run_az(
+        "cognitiveservices", "account", "list-models",
+        "--resource-group", resource_group,
+        "--name", account,
+    ) or []
+    found: set[tuple[str, str]] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name, version, model_format = model_details(entry)
+        if name == requested and version:
+            found.add((version, model_format))
+    return sorted(found, reverse=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env", default=".env")
+    parser.add_argument("--resource-group", help="Defaults to AZURE_OPENAI_RESOURCE_GROUP or AZURE_RESOURCE_GROUP.")
+    parser.add_argument("--account", help="Defaults to AZURE_OPENAI_ACCOUNT.")
+    parser.add_argument("--model", help="Defaults to IMAGE_GENERATION_MODEL.")
+    parser.add_argument("--model-version", help="Exact version. Defaults to the newest offered version.")
+    parser.add_argument("--deployment", help="Defaults to IMAGE_GENERATION_DEPLOYMENT or the model name.")
+    parser.add_argument("--sku", help="Defaults to IMAGE_GENERATION_SKU or GlobalStandard.")
+    parser.add_argument("--capacity", type=int, help="Defaults to IMAGE_GENERATION_CAPACITY or 1.")
+    parser.add_argument("--check", action="store_true", help="Verify only; never create or update a deployment.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    load_env(Path(args.env))
+    resource_group = (
+        args.resource_group
+        or os.environ.get("AZURE_OPENAI_RESOURCE_GROUP")
+        or os.environ.get("AZURE_RESOURCE_GROUP")
+    )
+    account = args.account or os.environ.get("AZURE_OPENAI_ACCOUNT")
+    model = args.model or os.environ.get("IMAGE_GENERATION_MODEL")
+    deployment = args.deployment or os.environ.get("IMAGE_GENERATION_DEPLOYMENT") or model
+    sku = args.sku or os.environ.get("IMAGE_GENERATION_SKU") or "GlobalStandard"
+    capacity = args.capacity or int(os.environ.get("IMAGE_GENERATION_CAPACITY", "1"))
+    if not all((resource_group, account, model, deployment)):
+        raise ValueError("resource group, account, model, and deployment are required (arguments or .env).")
+    if capacity < 1:
+        raise ValueError("capacity must be at least 1.")
+
+    versions = available_versions(resource_group, account, model)
+    if not versions:
+        print(f"Model '{model}' is not offered by account '{account}'. No deployment was changed.", file=sys.stderr)
+        return 2
+
+    selected_version = args.model_version or versions[0][0]
+    matches = [entry for entry in versions if entry[0] == selected_version]
+    if not matches:
+        offered = ", ".join(version for version, _ in versions)
+        print(
+            f"Model '{model}' version '{selected_version}' is unavailable. Offered versions: {offered}. "
+            "No deployment was changed.",
+            file=sys.stderr,
+        )
+        return 2
+    model_format = matches[0][1]
+
+    try:
+        existing = run_az(
+            "cognitiveservices", "account", "deployment", "show",
+            "--resource-group", resource_group,
+            "--name", account,
+            "--deployment-name", deployment,
+        )
+    except RuntimeError as error:
+        if "notfound" not in str(error).replace(" ", "").lower():
+            raise
+        existing = None
+
+    if isinstance(existing, dict):
+        properties = existing.get("properties") if isinstance(existing.get("properties"), dict) else {}
+        current = properties.get("model") if isinstance(properties.get("model"), dict) else {}
+        current_sku = existing.get("sku") if isinstance(existing.get("sku"), dict) else {}
+        actual = (current.get("name"), current.get("version"), current_sku.get("name"))
+        expected = (model, selected_version, sku)
+        if actual != expected:
+            print(
+                f"Deployment '{deployment}' exists as {actual}; expected {expected}. "
+                "Refusing an implicit model replacement.",
+                file=sys.stderr,
+            )
+            return 3
+        print(f"OK: {deployment} -> {model} {selected_version} ({sku})")
+        return 0
+
+    if args.check:
+        print(f"Deployment '{deployment}' does not exist. No deployment was changed.", file=sys.stderr)
+        return 4
+
+    created = run_az(
+        "cognitiveservices", "account", "deployment", "create",
+        "--resource-group", resource_group,
+        "--name", account,
+        "--deployment-name", deployment,
+        "--model-name", model,
+        "--model-version", selected_version,
+        "--model-format", model_format,
+        "--sku-name", sku,
+        "--sku-capacity", str(capacity),
+    )
+    created_value = created if isinstance(created, dict) else {}
+    properties = created_value.get("properties") if isinstance(created_value.get("properties"), dict) else {}
+    deployed_model = properties.get("model") if isinstance(properties.get("model"), dict) else {}
+    created_sku = created_value.get("sku") if isinstance(created_value.get("sku"), dict) else {}
+    print(
+        f"Created: {deployment} -> {deployed_model.get('name')} {deployed_model.get('version')} "
+        f"({created_sku.get('name')}, capacity {created_sku.get('capacity')})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, ValueError) as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/.github/skills/ai-teammate/scripts/tests/test_deploy_ai_teammate.py
+++ b/.github/skills/ai-teammate/scripts/tests/test_deploy_ai_teammate.py
@@ -10,6 +10,7 @@ Run with:
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import tempfile
 import unittest
@@ -41,14 +42,14 @@ class PreConnectionStepsTests(unittest.TestCase):
     def _steps(self, target: Path, env: dict[str, str] | None = None) -> list:
         return deploy_ai_teammate.build_pre_connection_steps(target, env or dict(FAKE_ENV), _skill_root())
 
-    def test_no_old_power_apps_cli_name_anywhere(self) -> None:
+    def test_uses_current_pa_group_cli(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp)
             (target / "evaluation-app").mkdir()
             steps = self._steps(target)
             for step in steps:
                 self.assertNotIn("power-apps", step.command,
-                                  f"{step.name}: must use the `pa` CLI, not the retired `power-apps` binary")
+                                  f"{step.name}: must use the `pa` group CLI")
 
     def test_pa_app_init_present_with_required_flags_when_not_yet_initialized(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -97,6 +98,27 @@ class PreConnectionStepsTests(unittest.TestCase):
             (target / "evaluation-app").mkdir()
             names = [s.name for s in self._steps(target)]
             self.assertIn("deploy_agent_webapp.py", names)
+
+    def test_image_model_is_provisioned_only_for_b17(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            (target / "evaluation-app").mkdir()
+            (target / "scaffold-plan.json").write_text(
+                json.dumps({"blocks": ["B3", "B12", "B14", "B17"]}), encoding="utf-8"
+            )
+            names = [s.name for s in self._steps(target)]
+            self.assertIn("provision_image_model.py", names)
+            self.assertLess(names.index("provision_image_model.py"), names.index("provision_selfhost.py"))
+
+    def test_image_model_is_not_provisioned_without_b17(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            (target / "evaluation-app").mkdir()
+            (target / "scaffold-plan.json").write_text(
+                json.dumps({"blocks": ["B1", "B3", "B15"]}), encoding="utf-8"
+            )
+            names = [s.name for s in self._steps(target)]
+            self.assertNotIn("provision_image_model.py", names)
 
 
 class PostConnectionStepsTests(unittest.TestCase):
@@ -159,11 +181,18 @@ class EvaluationAppEnvGenerationTests(unittest.TestCase):
 
 class CheckHelpersTests(unittest.TestCase):
     def test_template_uses_current_pa_cli(self) -> None:
-        package_json = (
-            SCRIPT_PATH.parent.parent / "templates" / "evaluation-app" / "package.json"
-        ).read_text(encoding="utf-8")
+        app_template = SCRIPT_PATH.parent.parent / "templates" / "evaluation-app"
+        package_json = (app_template / "package.json").read_text(encoding="utf-8")
+        predeploy = (app_template / "scripts" / "pre-deploy-check.mjs").read_text(encoding="utf-8")
         self.assertIn("npx pa app push", package_json)
         self.assertNotIn("npx power-apps", package_json)
+        self.assertIn('"@microsoft/power-apps-cli": "^1.0.1"', package_json)
+        self.assertIn(
+            '"deploy": "npm run build && npm run predeploy && npx pa app push"',
+            package_json,
+        )
+        self.assertIn("npx pa app init", predeploy)
+        self.assertNotIn("npx power-apps", predeploy)
 
     def test_scaffold_blocks_reads_plan(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/skills/ai-teammate/scripts/tests/test_provision_image_model.py
+++ b/.github/skills/ai-teammate/scripts/tests/test_provision_image_model.py
@@ -1,0 +1,83 @@
+"""Unit tests for provision_image_model.py without Azure calls."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "provision_image_model.py"
+
+_spec = importlib.util.spec_from_file_location("provision_image_model", SCRIPT_PATH)
+provision_image_model = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = provision_image_model
+assert _spec.loader is not None
+_spec.loader.exec_module(provision_image_model)
+
+
+class AzureCommandTests(unittest.TestCase):
+    @patch.object(provision_image_model.shutil, "which", return_value="C:/tools/az.cmd")
+    @patch.object(provision_image_model.subprocess, "run")
+    def test_run_az_uses_argv_without_shell(self, run_mock, _which_mock) -> None:
+        run_mock.return_value = subprocess.CompletedProcess([], 0, stdout="[]", stderr="")
+
+        provision_image_model.run_az("account", "show")
+
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command[0], "C:/tools/az.cmd")
+        self.assertEqual(command[-2:], ["--output", "json"])
+        self.assertFalse(run_mock.call_args.kwargs["shell"])
+
+    @patch.object(provision_image_model, "run_az")
+    def test_available_versions_filters_requested_model(self, run_az_mock) -> None:
+        run_az_mock.return_value = [
+            {"model": {"name": "gpt-image-1.5", "version": "2026-01-01", "format": "OpenAI"}},
+            {"model": {"name": "other-model", "version": "2026-08-01", "format": "OpenAI"}},
+            {"model": {"name": "gpt-image-1.5", "version": "2026-06-01", "format": "OpenAI"}},
+        ]
+
+        versions = provision_image_model.available_versions("rg-test", "ai-test", "gpt-image-1.5")
+
+        self.assertEqual(versions, [("2026-06-01", "OpenAI"), ("2026-01-01", "OpenAI")])
+
+    @patch.object(provision_image_model.shutil, "which", return_value=None)
+    def test_missing_azure_cli_fails_before_subprocess(self, _which_mock) -> None:
+        with self.assertRaisesRegex(RuntimeError, "not found"):
+            provision_image_model.run_az("account", "show")
+
+    @patch.object(provision_image_model, "run_az")
+    @patch.object(provision_image_model, "parse_args")
+    def test_create_uses_selected_version_and_numeric_capacity(self, parse_args_mock, run_az_mock) -> None:
+        parse_args_mock.return_value = type("Args", (), {
+            "env": "missing.env",
+            "resource_group": "rg-test",
+            "account": "ai-test",
+            "model": "gpt-image-1.5",
+            "model_version": None,
+            "deployment": "image-test",
+            "sku": "GlobalStandard",
+            "capacity": 2,
+            "check": False,
+        })()
+        run_az_mock.side_effect = [
+            [{"model": {"name": "gpt-image-1.5", "version": "2026-06-01", "format": "OpenAI"}}],
+            RuntimeError("ResourceNotFound"),
+            {
+                "properties": {"model": {"name": "gpt-image-1.5", "version": "2026-06-01"}},
+                "sku": {"name": "GlobalStandard", "capacity": 2},
+            },
+        ]
+
+        self.assertEqual(provision_image_model.main(), 0)
+
+        create_command = run_az_mock.call_args_list[-1].args
+        self.assertIn("--model-version", create_command)
+        self.assertEqual(create_command[create_command.index("--model-version") + 1], "2026-06-01")
+        self.assertEqual(create_command[create_command.index("--sku-capacity") + 1], "2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/skills/ai-teammate/scripts/tests/test_scaffold_ai_teammate.py
+++ b/.github/skills/ai-teammate/scripts/tests/test_scaffold_ai_teammate.py
@@ -93,6 +93,13 @@ class ResolveBlocksTests(unittest.TestCase):
         for expected in ("B3", "B12", "B13", "B14", "B16", "B15"):
             self.assertIn(expected, plan.blocks, f"{expected} should be pulled in by B12")
 
+    def test_b17_dependency_pulls_in_delivery_and_sandbox_blocks(self) -> None:
+        plan = scaffold_ai_teammate.build_plan(
+            base_decisions(preset="role", blocks=["B17"]), Path("unused")
+        )
+        for expected in ("B3", "B12", "B14", "B15", "B17"):
+            self.assertIn(expected, plan.blocks, f"{expected} should be pulled in by B17")
+
     def test_role_r1_resolves_documented_blocks(self) -> None:
         plan = scaffold_ai_teammate.build_plan(
             base_decisions(preset="role", roles=["R1"]), Path("unused")
@@ -177,6 +184,20 @@ class ScaffoldFileSystemTests(unittest.TestCase):
             # Base files are always present.
             self.assertTrue((target / "AgentBrain.cs").is_file())
             self.assertTrue((target / "UsageStore.cs").is_file())
+
+    def test_b17_scaffolds_image_generation_and_delivery_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "agent"
+            target.mkdir()
+            plan = scaffold_ai_teammate.build_plan(
+                base_decisions(preset="role", blocks=["B17"]), target
+            )
+            scaffold_ai_teammate.scaffold(plan, dict(FULL_ENV), force=False)
+
+            self.assertTrue((target / "ImageGenerationTools.cs").is_file())
+            self.assertTrue((target / "FileDelivery.cs").is_file())
+            self.assertTrue((target / "DocumentLedger.cs").is_file())
+            self.assertTrue((target / "SandboxTools.cs").is_file())
 
     def test_rendered_csharp_has_no_leftover_block_markers(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/skills/ai-teammate/templates/evaluation-app/package.json
+++ b/.github/skills/ai-teammate/templates/evaluation-app/package.json
@@ -9,13 +9,13 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "node scripts/pre-deploy-check.mjs",
-    "deploy": "npm run predeploy && npm run build && npx pa app push"
+    "deploy": "npm run build && npm run predeploy && npx pa app push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@microsoft/power-apps": "^1.0.17",
+    "@microsoft/power-apps": "^1.3.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
-    "@microsoft/power-apps-cli": "0.15.2",
+    "@microsoft/power-apps-cli": "^1.0.1",
     "@types/node": "^24.6.0",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",

--- a/.github/skills/ai-teammate/templates/evaluation-app/scripts/pre-deploy-check.mjs
+++ b/.github/skills/ai-teammate/templates/evaluation-app/scripts/pre-deploy-check.mjs
@@ -1,7 +1,7 @@
 /**
  * pre-deploy-check.mjs — テンプレートそのままのデプロイを防止する
  *
- * npx power-apps push の前に実行し、
+ * npx pa app push の前に実行し、
  * テーマ固有のカスタマイズが行われていることを確認する。
  *
  * このファイルはプロジェクト直下の scripts/ にコピーして使う。
@@ -40,7 +40,23 @@ if (!fs.existsSync(envPath)) {
 // 2. power.config.json が存在するか
 const configPath = path.join(root, "power.config.json");
 if (!fs.existsSync(configPath)) {
-  errors.push("power.config.json が存在しません。npx power-apps init を先に実行してください。");
+  errors.push("power.config.json が存在しません。npx pa app init を先に実行してください。");
+}
+
+// 2a. package.json と CLI bin が Code Apps 標準に揃っているか
+const packagePath = path.join(root, "package.json");
+if (!fs.existsSync(packagePath)) {
+  errors.push("package.json が存在しません。");
+} else {
+  const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf-8"));
+  const expectedDeploy = "npm run build && npm run predeploy && npx pa app push";
+  if (packageJson.scripts?.deploy !== expectedDeploy) {
+    errors.push(`package.json の deploy を '${expectedDeploy}' に統一してください。`);
+  }
+  const cliVersion = packageJson.devDependencies?.["@microsoft/power-apps-cli"] ?? "";
+  if (!/^[~^]?1\./.test(cliVersion)) {
+    errors.push("@microsoft/power-apps-cli 1.x を devDependencies に明示してください。");
+  }
 }
 
 // 3. config.ts のアプリ名がデフォルトのままでないか


### PR DESCRIPTION
## Summary

ローカル最新版 `C:\dev\hunter` と公開 `ai-teammate` スキルを比較し、反映要否を `.github/skills/ai-teammate/references/local-sync-review-2026-09-11.md` に整理したうえで、同じ PR 内で段階的に対応しました。

## Confirmed normal flow

`AskUserQuestion -> requirements-based custom scaffold -> Build + Deploy -> working baseline -> incremental feature development -> check + redeploy`

- 一括 scaffold が唯一の基本ルート
- 既知の要望は roles / blocks / personality としてテンプレートへ反映して生成
- Agents SDK、Evaluation Hub、full 時の ALM assets を同時 scaffold
- 初回 `deploy_ai_teammate.py --check` / `--execute` で稼働基準点を作成
- 追加要望は Step 7-8 で人格・機能ブロック・業務ロジックとして実装し、同じ check / execute で反復
- ゼロからの手動 scaffold は別ルートにせず、手動手順は既存プロジェクトへの個別追加と障害調査に限定

### Stage 1: B17 normal flow
- add `provision_image_model.py` to validate Azure OpenAI model availability, version, and SKU before creation
- connect B17 design, environment variables, implementation recipe, security, and validation

### Stage 2: scaffold/deploy integration
- lock B17 dependencies and generated files with tests
- run image model check/execute only when B17 is selected
- fail when a required provisioning script is missing instead of silently skipping it

### Stage 3: Evaluation Hub CLI
- align the Evaluation App with Code Apps SDK 1.3.x / CLI 1.x
- standardize deploy as `build -> predeploy -> pa app push`
- validate CLI major and deploy script during predeploy

### Stage 4: update-skills review
- preserve the existing scaffold, deployment orchestration, Evaluation Hub, and ALM assets
- exclude tenant/project-specific values and the old manual-copy scaffold route
- fix the Step 0 B17 coverage entry

## Validation
- 68 unit tests passed
- `validate_skill.py .github/skills/ai-teammate`: passed
- generated B1-B17 .NET 8 project: Release build, 0 warnings / 0 errors
- Evaluation App: `@microsoft/power-apps-cli` 1.0.1, `npx pa --version`, ESLint passed
- known tenant-specific value scan: 0 hits
- `git diff --check`: passed
- independent diff review: no blocking runtime, security, or normal-flow findings

## Deployment

No Azure, Dataverse, Agent 365, or Code Apps deployment was performed.