### PR TITLE
skill(admin): スキルを追加/更新

### DIFF
--- a/.github/skills/admin/SKILL.md
+++ b/.github/skills/admin/SKILL.md
@@ -36,6 +36,12 @@ triggers:
   - "テナント分離"
   - "監査ログ"
   - "ライセンス"
+  - "ライセンス棚卸"
+  - "ユーザー追加"
+  - "非アクティブユーザー"
+  - "Microsoft 365 管理センター"
+  - "Frontier"
+  - "Copilot メニュー"
   - "セキュリティ ロール確認"
   - "管理者権限"
   - "admin"
@@ -93,10 +99,13 @@ triggers:
 | [scripts/create_environments.py](scripts/create_environments.py) | ブループリントに対して不足している環境を作成し、環境グループへ割り当て | `--apply` 時のみ |
 | [scripts/setup_pipeline.py](scripts/setup_pipeline.py) | Power Platform パイプライン（開発 → テスト → 本番）の構成 | `--apply` 時のみ |
 | [scripts/set_content_security_policy.py](scripts/set_content_security_policy.py) | 環境の CSP（Code Apps / モデル駆動 / キャンバス）の確認と設定 | `--apply` 時のみ |
+| [scripts/manage_m365_users.py](scripts/manage_m365_users.py) | Graph v1.0 で M365 ライセンス棚卸・付与/解除・ユーザー作成・有効/無効化 | 変更は承認ハッシュ + `--apply` 時のみ |
+| [scripts/manage_m365_portal_api.py](scripts/manage_m365_portal_api.py) | Frontier と Agent availability の管理センター private API plan を検証 | `READY_FOR_BROWSER_API` 後に統合ブラウザ session API で変更 |
 | [scripts/dlp_helper.py](scripts/dlp_helper.py) | DLP 管理 API の共通ロジック（他スクリプトから import） | なし |
 | [references/acp-profiles.json](references/acp-profiles.json) | ACP 推奨許可セットの定義（パターン / ブロック / 要確認） | なし |
 | [references/rule-catalog.md](references/rule-catalog.md) | 環境グループのルール ID と非公開 API の一覧 | なし |
 | [references/environment-strategy.json](references/environment-strategy.json) | 環境戦略のブループリント（グループ / 環境 / 共有上限 / テナント設定） | なし |
+| [references/m365-tenant-api.md](references/m365-tenant-api.md) | M365 ユーザー/ライセンス/エージェント/Frontier/Copilot の公開 API とポータル API 調査基準 | なし |
 
 ## ワークフロー（正常系）
 
@@ -569,6 +578,30 @@ python set_environment_group_rules.py --tenant-id <TENANT_ID> --environment-grou
   --welcome-markdown-file welcome.md --welcome-url <GUIDELINE_URL> --apply
 ```
 
+### Step 11: Microsoft 365 ユーザーとライセンスを管理する（オプション）
+
+Microsoft 365 管理センターのユーザー/ライセンス操作は、公開済みの Microsoft Graph v1.0 を正常系にする。
+詳細な API、権限、非アクティブ判定、ポータル通信の調査基準は
+[m365-tenant-api.md](references/m365-tenant-api.md)を参照する。
+
+```powershell
+# 棚卸（読み取り専用）
+python .github/skills/admin/scripts/manage_m365_users.py inventory `
+  --inactive-days 90 --report-file m365-inventory.json
+
+# 変更は dry-run -> PLAN_HASH の承認 -> 同じ hash で --apply
+python .github/skills/admin/scripts/manage_m365_users.py license `
+  --user user@example.com --add-sku <SKU_PART_NUMBER>
+```
+
+非アクティブ候補は自動無効化しない。`lastSuccessfulSignInDateTime`、M365 利用状況、アカウント種別、
+所有者確認を合わせて判断する。ユーザー作成時の一時パスワードは環境変数だけで渡し、ログへ出さない。
+
+Agent Registry、MCP コネクター、Frontier、Copilot 機能トグルに公開 API がない場合は、
+VS Code 統合ブラウザで通信を調査する。Bearer token、Cookie、CSRF token、secret、個人/テナントの
+実値は保存しない。捕捉した API は公開 API と混同せず `observed/unsupported`、確認日、portal build を
+記録し、Cookie/CSRF 依存なら CLI で再送せずブラウザ自動化を fallback にする。
+
 ## 他スキルからの呼び出し
 
 | 呼び出し元 | タイミング | 実行するもの |
@@ -580,6 +613,7 @@ python set_environment_group_rules.py --tenant-id <TENANT_ID> --environment-grou
 | `mcp-server` | カスタムコネクタ登録前後 | Step 2 → Step 5 → Step 6 |
 | ユーザー依頼 | DLP / ACP の推奨設定・移行 | Step 7（推奨プロファイル）/ Step 8（DLP → ACP 移行） |
 | ユーザー依頼 | 環境戦略の策定・環境の見直し | Step 10 |
+| ユーザー依頼 | M365 ユーザー・ライセンス・Frontier・Copilot 管理 | Step 11 |
 | `sharepoint` | 利用ガイドライン ページの作成依頼を受ける側 | Step 10-9 |
 
 ## 参考リンク

--- a/.github/skills/admin/SKILL.md
+++ b/.github/skills/admin/SKILL.md
@@ -100,7 +100,8 @@ triggers:
 | [scripts/setup_pipeline.py](scripts/setup_pipeline.py) | Power Platform パイプライン（開発 → テスト → 本番）の構成 | `--apply` 時のみ |
 | [scripts/set_content_security_policy.py](scripts/set_content_security_policy.py) | 環境の CSP（Code Apps / モデル駆動 / キャンバス）の確認と設定 | `--apply` 時のみ |
 | [scripts/manage_m365_users.py](scripts/manage_m365_users.py) | Graph v1.0 で M365 ライセンス棚卸・付与/解除・ユーザー作成・有効/無効化 | 変更は承認ハッシュ + `--apply` 時のみ |
-| [scripts/manage_m365_portal_api.py](scripts/manage_m365_portal_api.py) | Frontier と Agent availability の管理センター private API plan を検証 | `READY_FOR_BROWSER_API` 後に統合ブラウザ session API で変更 |
+| [scripts/manage_m365_portal_api.py](scripts/manage_m365_portal_api.py) | Frontier と Agent Registry の Install / Publish / Permission private API plan を検証 | `READY_FOR_BROWSER_API` 後に統合ブラウザ session API で変更 |
+| [scripts/m365_portal_browser_runner.mjs](scripts/m365_portal_browser_runner.mjs) | 承認済み plan のhash/allowlistを再検証し、session header継承、write、poll、read-backを実行 | 承認済み plan のみ変更 |
 | [scripts/dlp_helper.py](scripts/dlp_helper.py) | DLP 管理 API の共通ロジック（他スクリプトから import） | なし |
 | [references/acp-profiles.json](references/acp-profiles.json) | ACP 推奨許可セットの定義（パターン / ブロック / 要確認） | なし |
 | [references/rule-catalog.md](references/rule-catalog.md) | 環境グループのルール ID と非公開 API の一覧 | なし |

--- a/.github/skills/admin/references/.env.example
+++ b/.github/skills/admin/references/.env.example
@@ -17,3 +17,6 @@ ADMIN_ROUTING_TARGET_GROUP_ID=00000000-0000-0000-0000-000000000000
 # 削除が承認された空グループの ID と表示名。専用ポリシー整理も計画に含む
 ADMIN_DELETE_GROUP_ID=00000000-0000-0000-0000-000000000000
 ADMIN_DELETE_GROUP_NAME=<obsolete-group-name>
+
+# M365 クラウドユーザー作成時だけ、実行プロセスへ一時設定する。ファイルへ実値を保存しないこと
+M365_NEW_USER_PASSWORD=<temporary-password-do-not-commit>

--- a/.github/skills/admin/references/admin-roles.md
+++ b/.github/skills/admin/references/admin-roles.md
@@ -13,7 +13,12 @@
 | Dataverse のセキュリティ ロール割り当て | Power Platform 管理センター / Dataverse | Dataverse の **System Administrator** | [ユーザーへのロール割り当て](https://learn.microsoft.com/power-platform/admin/assign-security-roles) |
 | Dataverse の監査の有効化 | Dataverse（組織設定・テーブル設定） | Dataverse の **System Administrator** | [Dataverse の監査](https://learn.microsoft.com/power-platform/admin/manage-dataverse-auditing) |
 | テナント分離 / IP ファイアウォールなどのテナント設定 | Power Platform 管理センター | **Power Platform Administrator** | [テナント分離](https://learn.microsoft.com/power-platform/admin/cross-tenant-restrictions) |
-| ライセンス割り当て・容量の配分 | Microsoft 365 管理センター | **Global Administrator** または **License Administrator** | [ライセンスの割り当て](https://learn.microsoft.com/microsoft-365/admin/manage/assign-licenses-to-users) |
+| ライセンス棚卸 | Microsoft Graph / Microsoft 365 管理センター | **Directory Readers** または **Global Reader** + `LicenseAssignment.Read.All` | [subscribedSkus の一覧](https://learn.microsoft.com/graph/api/subscribedsku-list) |
+| ライセンス割り当て・解除 | Microsoft Graph / Microsoft 365 管理センター | **License Administrator** + `LicenseAssignment.ReadWrite.All` | [assignLicense](https://learn.microsoft.com/graph/api/user-assignlicense) |
+| クラウドユーザー作成 | Microsoft Graph / Microsoft 365 管理センター | **User Administrator** + `User.Create` | [ユーザー作成](https://learn.microsoft.com/graph/api/user-post-users) |
+| ユーザー有効化・無効化 | Microsoft Graph / Microsoft 365 管理センター | **User Administrator** + `User.EnableDisableAccount.All` + `User.Read.All` | [ユーザー更新](https://learn.microsoft.com/graph/api/user-update) |
+| 非アクティブ候補の棚卸 | Microsoft Graph | レポートを読める管理ロール + `AuditLog.Read.All`、Entra ID P1/P2 | [signInActivity](https://learn.microsoft.com/graph/api/resources/signinactivity) |
+| Copilot エージェントの公開・配布 | Microsoft 365 管理センター | **AI Administrator** | [エージェント管理](https://learn.microsoft.com/microsoft-365/admin/manage/manage-agents-integrated-apps) |
 
 ## 重要な制約
 

--- a/.github/skills/admin/references/m365-tenant-api.md
+++ b/.github/skills/admin/references/m365-tenant-api.md
@@ -18,7 +18,8 @@
 | M365 app package の登録・更新 | `POST /appCatalogs/teamsApps[/{id}/appDefinitions]` | `AppCatalog.ReadWrite.All` | 公開 Graph v1.0、委任のみ |
 | Agent Registry の Install/Uninstall | `POST /fd/addins/api/apps` | `AI Administrator` | private API、browser session |
 | Agent Registry の Publish/Finalize | `POST /fd/addins/api/v2/actionableApps` | `AI Administrator` | private API、browser session |
-| Agent request/permission の承認 | `POST /fd/addins/api/agentActions/approve` | `AI Administrator` | private API、browser session |
+| Agent 利用要求の承認 | `POST /fd/addins/api/agentActions/approve` | `AI Administrator` | private API、browser session |
+| Agent Entra permission の更新 | `POST /fd/addins/api/v2/AgentPermission/update` | `AI Administrator` | private API、browser session |
 | MCP コネクターの Registry 表示・公開対象 | M365 管理センター | `AI Administrator` | 読み取り通信のみ `observed/unsupported` |
 | Frontier 対象者の有効化 | `GET/POST /admin/api/settings/company/frontier/access` | 製品画面で確認 | private API、browser session |
 | Copilot メニューのプレビュー機能 | Copilot 管理画面 | 製品画面で確認 | 読み取り通信のみ `observed/unsupported` |
@@ -72,7 +73,8 @@ python .github/skills/admin/scripts/manage_m365_users.py account `
 |---|---|---|
 | Install / Uninstall | `POST /fd/addins/api/apps` | `WorkloadManagementList[].Command` は `DEPLOY` / `UNDEPLOY`。割り当ては `Members`, `DeployToEveryone`, `UserAssignmentCategory` |
 | Publish / Finalize | `POST /fd/addins/api/v2/actionableApps` | `Apps[].Command` は `APPROVE` / `FINALIZEPACKAGE`。`AppId`, `Workload`, version/etag を送る |
-| Request / permission approval | `POST /fd/addins/api/agentActions/approve?workload=SharedAgent` | `{ "requestIds": ["<request-id>"] }` |
+| Agent 利用要求の承認 | `POST /fd/addins/api/agentActions/approve?workload=SharedAgent` | `{ "requestIds": ["<request-id>"] }` |
+| Entra permission Grant / Revoke | `POST /fd/addins/api/v2/AgentPermission/update` | `ActiveDirectoryAppId`, `PermissionRequestData[]` |
 | Deployment status | `GET /fd/addins/api/deploymentRequestStatus/{requestId}` | `POST` が返す `appManagementRequestID` を完了まで poll |
 | Agent details read-back | `GET /fd/addins/api/availableAgents/details/{id}` | `assignedUsersAndGroups`, `isDeployed`, permissions/status を照合 |
 
@@ -83,11 +85,26 @@ python .github/skills/admin/scripts/manage_m365_portal_api.py frontier-access `
 
 python .github/skills/admin/scripts/manage_m365_portal_api.py agent-publish `
   --payload-file publish-plan.json
-python .github/skills/admin/scripts/manage_m365_portal_api.py agent-permission-approve `
-  --payload-file permission-plan.json --workload SharedAgent
+python .github/skills/admin/scripts/manage_m365_portal_api.py agent-request-approve `
+  --payload-file request-approval-plan.json --workload SharedAgent
+python .github/skills/admin/scripts/manage_m365_portal_api.py agent-permission-update `
+  --payload-file permission-update-plan.json
 ```
 
-`READY_FOR_BROWSER_API` の plan だけを `m365_portal_browser_runner.mjs` へ渡す。runner は VS Code 統合ブラウザの
+`PermissionRequestData[]` の各要素は portal bundle の request builder と同じ
+`Type` (`Scope` / `Role`)、`Action` (`Grant` / `Revoke`)、`ResourceId`、`Scope`、`AppId` を送る。
+このAPIはHTTP `200`（全件成功）または`207`（項目別結果）を返す。`agentActions/approve` は利用要求の
+承認であり、Entra permission のGrantではないため代用しない。
+
+実測状況は区別する。Install/Uninstallはwrite、poll、details read-backまで成功済み。Publish/Finalizeと
+Entra permission更新はportal bundleからendpoint/body/response contractを捕捉しplan/runner契約テストまで
+完了しているが、成功するmutationは未実測。検証専用packageのGraph登録はcached tokenに`AppCatalog.*`
+scopeがなくHTTP `403`でwrite前に停止した。既存agentを代用せず、disposable agentまたは管理者指定の
+検証専用agentを用意してから実測する。この条件を満たすまでは「完全なAPI-only」と判定しない。
+
+`READY_FOR_BROWSER_API` のplanだけを、VS Code統合ブラウザの`page`とともに
+`runApprovedPlan(page, planPath, expectedHash)`へ渡す。この一括入口はplan fileのhash検証後にだけ送信する。runnerは
+VS Code 統合ブラウザの
 同一 session GET から `ajaxsessionkey` と `x-admin*` / `x-ms-mac*` headers をメモリ内だけで継承する。
 値をログや戻り値へ出さずに direct `fetch` し、deployment poll と `readBack` を実行する。
 通常の `fetch` だけでは write が HTTP 400 になるため、session header 継承を省略しない。

--- a/.github/skills/admin/references/m365-tenant-api.md
+++ b/.github/skills/admin/references/m365-tenant-api.md
@@ -16,7 +16,9 @@
 | ライセンス付与・解除 | `POST /users/{id}/assignLicense` | `LicenseAssignment.ReadWrite.All` + License Administrator 等 | 公開 Graph v1.0 |
 | 組織アプリ/エージェント取得 | `GET /appCatalogs/teamsApps` | `AppCatalog.Read.All` | 公開 Graph v1.0 |
 | M365 app package の登録・更新 | `POST /appCatalogs/teamsApps[/{id}/appDefinitions]` | `AppCatalog.ReadWrite.All` | 公開 Graph v1.0、委任のみ |
-| Agent Registry の公開対象・Install 設定 | `POST /fd/addins/api/availableAgents` | `AI Administrator` | private API、browser session |
+| Agent Registry の Install/Uninstall | `POST /fd/addins/api/apps` | `AI Administrator` | private API、browser session |
+| Agent Registry の Publish/Finalize | `POST /fd/addins/api/v2/actionableApps` | `AI Administrator` | private API、browser session |
+| Agent request/permission の承認 | `POST /fd/addins/api/agentActions/approve` | `AI Administrator` | private API、browser session |
 | MCP コネクターの Registry 表示・公開対象 | M365 管理センター | `AI Administrator` | 読み取り通信のみ `observed/unsupported` |
 | Frontier 対象者の有効化 | `GET/POST /admin/api/settings/company/frontier/access` | 製品画面で確認 | private API、browser session |
 | Copilot メニューのプレビュー機能 | Copilot 管理画面 | 製品画面で確認 | 読み取り通信のみ `observed/unsupported` |
@@ -64,17 +66,32 @@ python .github/skills/admin/scripts/manage_m365_users.py account `
 | Tools pending requests | `GET /admin/api/agentssettings/titles/requests/pending` | なし | `200` |
 | Power Platform resource query | `POST https://<tenant-region>.tenant.api.powerplatform.com/resourcequery/resources/query` | `api-version` | `200` |
 
-書き込みは `POST /admin/api/settings/company/frontier/access` と
-`POST /fd/addins/api/availableAgents?botId=...&environmentId=...` を確認済み。後者は locale/market、
-`WorkloadManagementList`、`SendEmailToUsers` を受ける。ID は GET inventory から解決し、文書へ固定しない。
+書き込みは次を確認済み。ID は GET inventory から解決し、文書へ固定しない。
+
+| 操作 | Method / path | payload / query の契約 |
+|---|---|---|
+| Install / Uninstall | `POST /fd/addins/api/apps` | `WorkloadManagementList[].Command` は `DEPLOY` / `UNDEPLOY`。割り当ては `Members`, `DeployToEveryone`, `UserAssignmentCategory` |
+| Publish / Finalize | `POST /fd/addins/api/v2/actionableApps` | `Apps[].Command` は `APPROVE` / `FINALIZEPACKAGE`。`AppId`, `Workload`, version/etag を送る |
+| Request / permission approval | `POST /fd/addins/api/agentActions/approve?workload=SharedAgent` | `{ "requestIds": ["<request-id>"] }` |
+| Deployment status | `GET /fd/addins/api/deploymentRequestStatus/{requestId}` | `POST` が返す `appManagementRequestID` を完了まで poll |
+| Agent details read-back | `GET /fd/addins/api/availableAgents/details/{id}` | `assignedUsersAndGroups`, `isDeployed`, permissions/status を照合 |
 
 ```powershell
 python .github/skills/admin/scripts/manage_m365_portal_api.py frontier-access `
   --payload-file frontier-plan.json
 # 承認後、同じ入力に --expected-hash <APPROVED_HASH> --apply
+
+python .github/skills/admin/scripts/manage_m365_portal_api.py agent-publish `
+  --payload-file publish-plan.json
+python .github/skills/admin/scripts/manage_m365_portal_api.py agent-permission-approve `
+  --payload-file permission-plan.json --workload SharedAgent
 ```
 
-`READY_FOR_BROWSER_API` の plan だけを VS Code 統合ブラウザで direct `fetch` し、`readBack` を再取得して
+`READY_FOR_BROWSER_API` の plan だけを `m365_portal_browser_runner.mjs` へ渡す。runner は VS Code 統合ブラウザの
+同一 session GET から `ajaxsessionkey` と `x-admin*` / `x-ms-mac*` headers をメモリ内だけで継承する。
+値をログや戻り値へ出さずに direct `fetch` し、deployment poll と `readBack` を実行する。
+通常の `fetch` だけでは write が HTTP 400 になるため、session header 継承を省略しない。
+`readBack` を再取得して
 対象状態を照合する。401/403/404、schema 不一致、read-back 不一致なら停止し、フォーム操作を選択肢として提示する。
 
 ## 非公開 API の捕捉基準

--- a/.github/skills/admin/references/m365-tenant-api.md
+++ b/.github/skills/admin/references/m365-tenant-api.md
@@ -1,0 +1,112 @@
+# Microsoft 365 テナント管理 API
+
+確認日: 2026-09-11。公開 API は Microsoft Graph v1.0 を最優先する。公開 API がない操作は、
+観測済み private API をログイン済み統合ブラウザ session から直接呼ぶ。フォーム操作は API 失敗時だけ使う。
+
+## API 対応表
+
+| 操作 | 正常系 | 最小権限の目安 | 状態 |
+|---|---|---|---|
+| 契約 SKU と空き数 | `GET /subscribedSkus` | `LicenseAssignment.Read.All` | 公開 Graph v1.0 |
+| ユーザー別ライセンス棚卸 | `GET /users?$select=assignedLicenses,...` | `User.Read.All` | 公開 Graph v1.0 |
+| 非アクティブ候補 | `GET /users?$select=signInActivity,...` | `AuditLog.Read.All` + Entra ID P1/P2 | 公開 Graph v1.0 |
+| M365 サービス利用状況 | `GET /reports/getOffice365ActiveUserDetail(period='D180')` | `Reports.Read.All` | 公開 Graph v1.0 |
+| ユーザー作成 | `POST /users` | `User.Create` | 公開 Graph v1.0 |
+| 有効化・無効化 | `PATCH /users/{id}` の `accountEnabled` | `User.EnableDisableAccount.All` + `User.Read.All` | 公開 Graph v1.0 |
+| ライセンス付与・解除 | `POST /users/{id}/assignLicense` | `LicenseAssignment.ReadWrite.All` + License Administrator 等 | 公開 Graph v1.0 |
+| 組織アプリ/エージェント取得 | `GET /appCatalogs/teamsApps` | `AppCatalog.Read.All` | 公開 Graph v1.0 |
+| M365 app package の登録・更新 | `POST /appCatalogs/teamsApps[/{id}/appDefinitions]` | `AppCatalog.ReadWrite.All` | 公開 Graph v1.0、委任のみ |
+| Agent Registry の公開対象・Install 設定 | `POST /fd/addins/api/availableAgents` | `AI Administrator` | private API、browser session |
+| MCP コネクターの Registry 表示・公開対象 | M365 管理センター | `AI Administrator` | 読み取り通信のみ `observed/unsupported` |
+| Frontier 対象者の有効化 | `GET/POST /admin/api/settings/company/frontier/access` | 製品画面で確認 | private API、browser session |
+| Copilot メニューのプレビュー機能 | Copilot 管理画面 | 製品画面で確認 | 読み取り通信のみ `observed/unsupported` |
+
+`signInActivity.lastSuccessfulSignInDateTime` は成功した対話/非対話サインインの最終日時を示す。
+値がないユーザーを自動削除・無効化しない。新規、サービス、共有、緊急アクセスアカウントを除外し、
+M365 利用状況レポートと所有者確認を加えて候補を確定する。
+
+## CLI
+
+```powershell
+# 読み取り専用。詳細には個人情報を含むため report はアクセス制御された場所へ出力する
+python .github/skills/admin/scripts/manage_m365_users.py inventory `
+  --inactive-days 90 --report-file m365-inventory.json
+
+# 変更は必ず dry-run の PLAN_HASH を承認してから適用
+python .github/skills/admin/scripts/manage_m365_users.py license `
+  --user user@example.com --add-sku <SKU_PART_NUMBER>
+python .github/skills/admin/scripts/manage_m365_users.py license `
+  --user user@example.com --add-sku <SKU_PART_NUMBER> `
+  --expected-hash <APPROVED_HASH> --apply
+
+python .github/skills/admin/scripts/manage_m365_users.py account `
+  --user user@example.com --enabled false
+```
+
+新規ユーザーの一時パスワードは引数やファイルへ書かず、実行プロセスの
+`M365_NEW_USER_PASSWORD` 環境変数からだけ渡す。出力・plan 表示では必ず伏せる。
+
+## M365 Agents 管理センターの観測結果
+
+2026-09-11、`https://admin.cloud.microsoft/?#/agents/`、admin-main build `2026.9.3.7` で
+同じ読み取りを2回実行し、次の request metadata と HTTP status が一致した。公開契約ではないため
+`observed/private` とし、origin/path/method/schema allowlist、承認 hash、read-back を必須にする。
+
+| 画面 | Method / path | Query parameter 名 | Status |
+|---|---|---|---|
+| Registry | `GET /fd/addins/api/agents` | `limit`, `returnIfCacheIsNotReady`, `scopes`, `sortBy`, `sortOrder`, `workloads` | `200` |
+| Registry | `GET /admin/api/agents/actionsconfig` | なし | `200` |
+| Registry | `GET /admin/api/agents/eligibilityconfig` | なし | `200` |
+| Agent preferences | `GET /admin/api/agentmanagement/preferences` | なし | `200` |
+| Requests / Local agents Frontier | `GET /admin/api/copilotsettings/settings` | なし | `200` |
+| Copilot preferences | `GET /admin/api/copilot/getPreferences` | なし | `200` |
+| Tools | `GET /admin/api/agentssettings/agenttools` | なし | `200` |
+| Tools pending requests | `GET /admin/api/agentssettings/titles/requests/pending` | なし | `200` |
+| Power Platform resource query | `POST https://<tenant-region>.tenant.api.powerplatform.com/resourcequery/resources/query` | `api-version` | `200` |
+
+書き込みは `POST /admin/api/settings/company/frontier/access` と
+`POST /fd/addins/api/availableAgents?botId=...&environmentId=...` を確認済み。後者は locale/market、
+`WorkloadManagementList`、`SendEmailToUsers` を受ける。ID は GET inventory から解決し、文書へ固定しない。
+
+```powershell
+python .github/skills/admin/scripts/manage_m365_portal_api.py frontier-access `
+  --payload-file frontier-plan.json
+# 承認後、同じ入力に --expected-hash <APPROVED_HASH> --apply
+```
+
+`READY_FOR_BROWSER_API` の plan だけを VS Code 統合ブラウザで direct `fetch` し、`readBack` を再取得して
+対象状態を照合する。401/403/404、schema 不一致、read-back 不一致なら停止し、フォーム操作を選択肢として提示する。
+
+## 非公開 API の捕捉基準
+
+公開 API がない操作は VS Code 統合ブラウザだけで調査する。Playwright MCP サーバーや単体
+Playwright は使わない。画面を開く前に使用プロファイルを確認し、サインインはユーザーが直接行う。
+
+記録してよい項目:
+
+- 確認日時、画面 URL、操作名、portal build/version
+- request の origin、path、query parameter の名前、HTTP method
+- request/response JSON のフィールド名と型、HTTP status、correlation ID
+- 必要な token audience と管理ロール。token 値そのものは記録しない
+
+記録禁止:
+
+- `Authorization`、Cookie、CSRF token、client secret、password
+- UPN、氏名、テナント ID、実 GUID、応答本文中の業務データ
+- 署名付き URL と preauthenticated download URL
+
+採用条件は、同じ読み取り操作を2回実行して endpoint と schema が一致し、公開 API がないことを
+Learn で確認し、秘密情報を除いた fixture で契約テストを作れること。Cookie/CSRF に依存する通信は
+ログイン済み統合ブラウザ内の direct API を正常系とし、token/Cookie を外へ取り出さない。非公開 API は
+`observed/private`、確認日、portal build を併記し、変更系は dry-run、影響範囲、承認ハッシュ、
+read-back を必須にする。画面 click/form 操作は direct API を実行できない場合だけ使う。
+
+## 公式資料
+
+- [List subscribedSkus](https://learn.microsoft.com/graph/api/subscribedsku-list)
+- [Assign license](https://learn.microsoft.com/graph/api/user-assignlicense)
+- [List users](https://learn.microsoft.com/graph/api/user-list)
+- [Create user](https://learn.microsoft.com/graph/api/user-post-users)
+- [Update user](https://learn.microsoft.com/graph/api/user-update)
+- [Publish teamsApp](https://learn.microsoft.com/graph/api/teamsapp-publish)
+- [Update teamsApp](https://learn.microsoft.com/graph/api/teamsapp-update)

--- a/.github/skills/admin/scripts/m365_portal_browser_runner.mjs
+++ b/.github/skills/admin/scripts/m365_portal_browser_runner.mjs
@@ -1,0 +1,173 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+const ORIGIN = "https://admin.cloud.microsoft";
+const CONTRACTS = new Map([
+  ["frontier-access", { method: "POST", path: "/admin/api/settings/company/frontier/access" }],
+  ["agent-availability", { method: "POST", path: "/fd/addins/api/availableAgents" }],
+  ["agent-lifecycle", { method: "POST", path: "/fd/addins/api/apps" }],
+  ["agent-publish", { method: "POST", path: "/fd/addins/api/v2/actionableApps" }],
+  ["agent-permission-approve", { method: "POST", path: "/fd/addins/api/agentActions/approve" }],
+  ["agent-permission-approve-v1", { method: "POST", path: "/fd/addins/api/v1/agentactions/approve" }],
+]);
+const READ_PATHS = [
+  /^\/admin\/api\/settings\/company\/frontier\/access$/,
+  /^\/fd\/addins\/api\/agents(?:\/.*)?$/,
+  /^\/fd\/addins\/api\/availableAgents\/details\/[^/]+$/,
+  /^\/fd\/addins\/api\/deploymentRequestStatus\/[^/]+$/,
+];
+const SESSION_HEADER_NAMES = new Set([
+  "ajaxsessionkey",
+  "x-admin-portal-flight",
+  "x-adminapp-request",
+  "x-ms-mac-appid",
+  "x-ms-mac-hostingapp",
+  "x-ms-mac-target-app",
+  "x-ms-mac-version",
+  "x-usage-origin",
+]);
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${asciiJson(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return asciiJson(value);
+}
+
+function asciiJson(value) {
+  return JSON.stringify(value).replace(/[\u007f-\uffff]/g, (character) =>
+    `\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  );
+}
+
+export function canonicalHash(plan) {
+  return createHash("sha256").update(canonicalJson(plan), "utf8").digest("hex");
+}
+
+function assertRelativePath(path, label) {
+  if (typeof path !== "string" || !path.startsWith("/") || path.startsWith("//")) {
+    throw new Error(`${label} must be an origin-relative path`);
+  }
+}
+
+export function validatePlan(plan) {
+  if (!plan || typeof plan !== "object" || Array.isArray(plan)) throw new Error("plan must be an object");
+  const contract = CONTRACTS.get(plan.operation);
+  if (!contract) throw new Error("operation is not allowlisted");
+  if (plan.origin !== ORIGIN) throw new Error("origin is not allowlisted");
+  if (plan.method !== contract.method || plan.path !== contract.path) throw new Error("write contract mismatch");
+  assertRelativePath(plan.path, "path");
+  assertRelativePath(plan.readBack, "readBack");
+  if (!READ_PATHS.some((pattern) => pattern.test(plan.readBack))) throw new Error("readBack is not allowlisted");
+  if (!plan.payload || typeof plan.payload !== "object" || Array.isArray(plan.payload)) {
+    throw new Error("payload must be an object");
+  }
+  if (plan.operation.startsWith("agent-permission-approve")) {
+    if (!plan.query || typeof plan.query.workload !== "string" || !plan.query.workload) {
+      throw new Error("permission approval requires workload query");
+    }
+  }
+  return plan;
+}
+
+export async function loadApprovedPlan(planPath, expectedHash) {
+  const plan = validatePlan(JSON.parse(await readFile(planPath, "utf8")));
+  const actualHash = canonicalHash(plan);
+  if (!expectedHash || actualHash !== expectedHash) throw new Error("approved plan hash mismatch");
+  return plan;
+}
+
+export async function executeApprovedPlan(page, plan, options = {}) {
+  validatePlan(plan);
+  const pageOrigin = new URL(page.url()).origin;
+  if (pageOrigin !== ORIGIN) throw new Error("browser is not on the approved origin");
+
+  const seedRequestPromise = page.waitForRequest(
+    (request) => request.url().startsWith(`${ORIGIN}/fd/addins/api/`) && request.method() === "GET",
+    { timeout: options.headerTimeoutMs ?? 20_000 },
+  );
+  await page.reload({ waitUntil: "domcontentloaded", timeout: options.headerTimeoutMs ?? 20_000 });
+  const seedHeaders = await (await seedRequestPromise).allHeaders();
+  const sessionHeaders = Object.fromEntries(
+    Object.entries(seedHeaders).filter(([name]) => SESSION_HEADER_NAMES.has(name.toLowerCase())),
+  );
+  if (!sessionHeaders.ajaxsessionkey) throw new Error("browser session header was not observed");
+
+  return page.evaluate(
+    async ({ approvedPlan, headers, pollIntervalMs, maxPolls }) => {
+      const requestJson = async (path, init = {}) => {
+        const response = await fetch(path, {
+          credentials: "include",
+          cache: "no-store",
+          ...init,
+          headers: { Accept: "application/json", ...headers, ...init.headers },
+        });
+        let body = null;
+        const text = await response.text();
+        if (text) {
+          try {
+            body = JSON.parse(text);
+          } catch {
+            throw new Error(`non-JSON response from ${new URL(path, location.origin).pathname}`);
+          }
+        }
+        if (!response.ok) throw new Error(`HTTP ${response.status} from ${new URL(path, location.origin).pathname}`);
+        return { status: response.status, body };
+      };
+      const withQuery = (path, query = {}) => {
+        const url = new URL(path, location.origin);
+        for (const [name, value] of Object.entries(query || {})) url.searchParams.set(name, String(value));
+        return `${url.pathname}${url.search}`;
+      };
+
+      const write = await requestJson(withQuery(approvedPlan.path, approvedPlan.query), {
+        method: approvedPlan.method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(approvedPlan.payload),
+      });
+      const requestId =
+        write.body?.appManagementRequestID ??
+        write.body?.deploymentRequestId ??
+        write.body?.requestId ??
+        write.body?.RequestId;
+      let deploymentStatus = null;
+      let polls = 0;
+      if (requestId) {
+        for (; polls < maxPolls; polls += 1) {
+          const poll = await requestJson(
+            `/fd/addins/api/deploymentRequestStatus/${encodeURIComponent(requestId)}`,
+          );
+          deploymentStatus =
+            poll.body?.requestStatus ?? poll.body?.status ?? poll.body?.deploymentStatus ?? poll.body?.udStatusCode;
+          if (!new Set(["InProgress", "Delayed", "Pending", null, undefined]).has(deploymentStatus)) break;
+          await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+        }
+        if (polls === maxPolls) throw new Error("deployment polling timed out");
+        if (new Set(["Failed", "Failure", "PartialSuccess"]).has(deploymentStatus)) {
+          throw new Error(`deployment ended with ${deploymentStatus}`);
+        }
+      }
+
+      const readBack = await requestJson(withQuery(approvedPlan.readBack, approvedPlan.readBackQuery));
+      if (!readBack.body || typeof readBack.body !== "object") throw new Error("read-back schema mismatch");
+      return {
+        writeStatus: write.status,
+        requestIdPresent: Boolean(requestId),
+        deploymentStatus,
+        polls,
+        readBackStatus: readBack.status,
+        readBackKeys: Object.keys(readBack.body).sort(),
+      };
+    },
+    {
+      approvedPlan: plan,
+      headers: sessionHeaders,
+      pollIntervalMs: options.pollIntervalMs ?? 2_000,
+      maxPolls: options.maxPolls ?? 30,
+    },
+  );
+}

--- a/.github/skills/admin/scripts/m365_portal_browser_runner.mjs
+++ b/.github/skills/admin/scripts/m365_portal_browser_runner.mjs
@@ -7,8 +7,9 @@ const CONTRACTS = new Map([
   ["agent-availability", { method: "POST", path: "/fd/addins/api/availableAgents" }],
   ["agent-lifecycle", { method: "POST", path: "/fd/addins/api/apps" }],
   ["agent-publish", { method: "POST", path: "/fd/addins/api/v2/actionableApps" }],
-  ["agent-permission-approve", { method: "POST", path: "/fd/addins/api/agentActions/approve" }],
-  ["agent-permission-approve-v1", { method: "POST", path: "/fd/addins/api/v1/agentactions/approve" }],
+  ["agent-request-approve", { method: "POST", path: "/fd/addins/api/agentActions/approve" }],
+  ["agent-permission-update", { method: "POST", path: "/fd/addins/api/v2/AgentPermission/update" }],
+  ["agent-request-approve-v1", { method: "POST", path: "/fd/addins/api/v1/agentactions/approve" }],
 ]);
 const READ_PATHS = [
   /^\/admin\/api\/settings\/company\/frontier\/access$/,
@@ -66,9 +67,33 @@ export function validatePlan(plan) {
   if (!plan.payload || typeof plan.payload !== "object" || Array.isArray(plan.payload)) {
     throw new Error("payload must be an object");
   }
-  if (plan.operation.startsWith("agent-permission-approve")) {
+  if (plan.operation === "agent-request-approve") {
     if (!plan.query || typeof plan.query.workload !== "string" || !plan.query.workload) {
-      throw new Error("permission approval requires workload query");
+      throw new Error("request approval requires workload query");
+    }
+  }
+  if (plan.operation === "agent-permission-update") {
+    const requests = plan.payload.PermissionRequestData;
+    if (typeof plan.payload.ActiveDirectoryAppId !== "string" || !plan.payload.ActiveDirectoryAppId) {
+      throw new Error("permission update requires ActiveDirectoryAppId");
+    }
+    if (!Array.isArray(requests) || requests.length === 0) {
+      throw new Error("permission update requires PermissionRequestData");
+    }
+    const fields = ["Action", "AppId", "ResourceId", "Scope", "Type"];
+    for (const request of requests) {
+      if (!request || typeof request !== "object" || Array.isArray(request)) {
+        throw new Error("permission request must be an object");
+      }
+      if (Object.keys(request).sort().join(",") !== fields.join(",")) {
+        throw new Error("permission request fields do not match the observed contract");
+      }
+      if (!["Scope", "Role"].includes(request.Type) || !["Grant", "Revoke"].includes(request.Action)) {
+        throw new Error("permission request enum is invalid");
+      }
+      if (![request.ResourceId, request.Scope, request.AppId].every((value) => typeof value === "string" && value)) {
+        throw new Error("permission request identifiers must be non-empty strings");
+      }
     }
   }
   return plan;
@@ -79,6 +104,11 @@ export async function loadApprovedPlan(planPath, expectedHash) {
   const actualHash = canonicalHash(plan);
   if (!expectedHash || actualHash !== expectedHash) throw new Error("approved plan hash mismatch");
   return plan;
+}
+
+export async function runApprovedPlan(page, planPath, expectedHash, options = {}) {
+  const plan = await loadApprovedPlan(planPath, expectedHash);
+  return executeApprovedPlan(page, plan, options);
 }
 
 export async function executeApprovedPlan(page, plan, options = {}) {

--- a/.github/skills/admin/scripts/manage_m365_portal_api.py
+++ b/.github/skills/admin/scripts/manage_m365_portal_api.py
@@ -1,0 +1,115 @@
+"""M365 管理センター private API の承認 plan を検証する。
+
+実送信はログイン済み VS Code 統合ブラウザの同一オリジン fetch で行う。
+このスクリプトは観測済み endpoint 以外を拒否し、dry-run の PLAN_HASH を生成する。
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+CONTRACTS = {
+    "frontier-access": {
+        "method": "POST",
+        "path": "/admin/api/settings/company/frontier/access",
+        "readBack": "/admin/api/settings/company/frontier/access",
+        "required": {"frontierPolicy", "audienceStatus"},
+        "allowed": {
+            "frontierPolicy",
+            "audienceStatus",
+            "assignedUsers",
+            "unassignedUsers",
+            "assignedGroups",
+            "unassignedGroups",
+        },
+    },
+    "agent-availability": {
+        "method": "POST",
+        "path": "/fd/addins/api/availableAgents",
+        "readBack": "/fd/addins/api/agents",
+        "required": {"Locale", "Market", "WorkloadManagementList", "SendEmailToUsers"},
+        "allowed": {"Locale", "Market", "WorkloadManagementList", "SendEmailToUsers"},
+    },
+}
+
+
+def canonical_hash(value: dict[str, Any]) -> str:
+    encoded = json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def load_payload(path: str) -> dict[str, Any]:
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SystemExit(f"payload を読み込めません: {error}") from error
+    if not isinstance(value, dict):
+        raise SystemExit("payload は JSON object で指定してください。")
+    return value
+
+
+def validate_payload(operation: str, payload: dict[str, Any]) -> None:
+    contract = CONTRACTS[operation]
+    unknown = sorted(set(payload) - contract["allowed"])
+    missing = sorted(contract["required"] - set(payload))
+    if unknown:
+        raise SystemExit(f"未確認の payload field です: {', '.join(unknown)}")
+    if missing:
+        raise SystemExit(f"必須 payload field がありません: {', '.join(missing)}")
+    if operation == "frontier-access":
+        for key in ("assignedUsers", "unassignedUsers", "assignedGroups", "unassignedGroups"):
+            if key in payload and not isinstance(payload[key], list):
+                raise SystemExit(f"{key} は配列で指定してください。")
+    if operation == "agent-availability" and not isinstance(payload["WorkloadManagementList"], list):
+        raise SystemExit("WorkloadManagementList は配列で指定してください。")
+
+
+def build_plan(args: argparse.Namespace) -> dict[str, Any]:
+    payload = load_payload(args.payload_file)
+    validate_payload(args.operation, payload)
+    contract = CONTRACTS[args.operation]
+    query: dict[str, str] = {}
+    if args.operation == "agent-availability":
+        if not args.bot_id or not args.environment_id:
+            raise SystemExit("agent-availability では --bot-id と --environment-id が必須です。")
+        query = {"botId": args.bot_id, "environmentId": args.environment_id}
+    return {
+        "origin": "https://admin.cloud.microsoft",
+        "operation": args.operation,
+        "method": contract["method"],
+        "path": contract["path"],
+        "query": query,
+        "payload": payload,
+        "readBack": contract["readBack"],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=sorted(CONTRACTS))
+    parser.add_argument("--payload-file", required=True)
+    parser.add_argument("--bot-id")
+    parser.add_argument("--environment-id")
+    parser.add_argument("--expected-hash")
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+
+    plan = build_plan(args)
+    digest = canonical_hash(plan)
+    print(json.dumps(plan, ensure_ascii=False, indent=2))
+    print(f"PLAN_HASH={digest}")
+    if not args.apply:
+        print("DRY-RUN: 変更していません。")
+        return
+    if args.expected_hash != digest:
+        raise SystemExit("承認済み plan hash が一致しません。")
+    print("READY_FOR_BROWSER_API")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/admin/scripts/manage_m365_portal_api.py
+++ b/.github/skills/admin/scripts/manage_m365_portal_api.py
@@ -35,7 +35,61 @@ CONTRACTS = {
         "required": {"Locale", "Market", "WorkloadManagementList", "SendEmailToUsers"},
         "allowed": {"Locale", "Market", "WorkloadManagementList", "SendEmailToUsers"},
     },
+    "agent-lifecycle": {
+        "method": "POST",
+        "path": "/fd/addins/api/apps",
+        "readBack": "/fd/addins/api/agents",
+        "required": {
+            "Locale",
+            "ContentMarket",
+            "WorkloadManagementList",
+            "UserAssignmentDetails",
+            "DeploymentRolloutType",
+            "SendEmailToUsers",
+        },
+        "allowed": {
+            "Locale",
+            "ContentMarket",
+            "WorkloadManagementList",
+            "UserAssignmentDetails",
+            "DeploymentRolloutType",
+            "SendEmailToUsers",
+        },
+    },
+    "agent-publish": {
+        "method": "POST",
+        "path": "/fd/addins/api/v2/actionableApps",
+        "readBack": "/fd/addins/api/agents",
+        "required": {"Apps"},
+        "allowed": {"Apps"},
+    },
+    "agent-permission-approve": {
+        "method": "POST",
+        "path": "/fd/addins/api/agentActions/approve",
+        "readBack": "/fd/addins/api/agents",
+        "required": {"requestIds"},
+        "allowed": {"requestIds"},
+    },
 }
+
+LIFECYCLE_COMMANDS = {"DEPLOY", "UPDATE", "UNDEPLOY", "ADDINTOMOSUPDATE", "ADDINMOSMERGE"}
+WORKLOAD_FIELDS = {
+    "AppsourceAssetID",
+    "ProductID",
+    "Command",
+    "ActiveDirectoryAppId",
+    "Version",
+    "AppType",
+    "AppFileName",
+    "AppFileUrl",
+    "ApplicationTemplateId",
+    "Workload",
+    "MosOperationId",
+    "TitleID",
+}
+ASSIGNMENT_FIELDS = {"Members", "DeployToEveryone", "UserAssignmentCategory"}
+PUBLISH_COMMANDS = {"APPROVE", "FINALIZEPACKAGE", "UPDATESTAGEDAPP"}
+PUBLISH_FIELDS = {"AppId", "Command", "Workload", "IterationEtag", "Version", "TitleId", "MosOperationId"}
 
 
 def canonical_hash(value: dict[str, Any]) -> str:
@@ -67,6 +121,63 @@ def validate_payload(operation: str, payload: dict[str, Any]) -> None:
                 raise SystemExit(f"{key} は配列で指定してください。")
     if operation == "agent-availability" and not isinstance(payload["WorkloadManagementList"], list):
         raise SystemExit("WorkloadManagementList は配列で指定してください。")
+    if operation == "agent-lifecycle":
+        workloads = payload["WorkloadManagementList"]
+        if not isinstance(workloads, list) or not workloads:
+            raise SystemExit("WorkloadManagementList は空でない配列で指定してください。")
+        for workload in workloads:
+            if not isinstance(workload, dict):
+                raise SystemExit("WorkloadManagementList の各要素は JSON object で指定してください。")
+            unknown_workload = sorted(set(workload) - WORKLOAD_FIELDS)
+            if unknown_workload:
+                raise SystemExit(f"未確認の workload field です: {', '.join(unknown_workload)}")
+            if workload.get("Command") not in LIFECYCLE_COMMANDS:
+                raise SystemExit("未確認の lifecycle Command です。")
+            if not workload.get("ProductID") and not workload.get("AppsourceAssetID"):
+                raise SystemExit("workload には ProductID または AppsourceAssetID が必要です。")
+        assignments = payload["UserAssignmentDetails"]
+        if not isinstance(assignments, dict):
+            raise SystemExit("UserAssignmentDetails は JSON object で指定してください。")
+        unknown_assignments = sorted(set(assignments) - ASSIGNMENT_FIELDS)
+        if unknown_assignments:
+            raise SystemExit(f"未確認の UserAssignmentDetails field です: {', '.join(unknown_assignments)}")
+        if set(assignments) != ASSIGNMENT_FIELDS:
+            raise SystemExit("UserAssignmentDetails の field が不足しています。")
+        if not isinstance(assignments["Members"], list):
+            raise SystemExit("Members は配列で指定してください。")
+        for member in assignments["Members"]:
+            if not isinstance(member, dict) or set(member) != {"Id", "Type"}:
+                raise SystemExit("Members の各要素には Id と Type が必要です。")
+            if member["Type"] not in {"User", "Group"}:
+                raise SystemExit("Member Type は User または Group で指定してください。")
+        if not isinstance(assignments["DeployToEveryone"], bool):
+            raise SystemExit("DeployToEveryone は boolean で指定してください。")
+        if assignments["UserAssignmentCategory"] not in {"None", "Everyone", "SpecificUsers", "NoOne"}:
+            raise SystemExit("未確認の UserAssignmentCategory です。")
+        if payload["DeploymentRolloutType"] not in {"None", "FullRollout", "TestRollout"}:
+            raise SystemExit("未確認の DeploymentRolloutType です。")
+        if not isinstance(payload["SendEmailToUsers"], bool):
+            raise SystemExit("SendEmailToUsers は boolean で指定してください。")
+    if operation == "agent-publish":
+        apps = payload["Apps"]
+        if not isinstance(apps, list) or not apps:
+            raise SystemExit("Apps は空でない配列で指定してください。")
+        for app in apps:
+            if not isinstance(app, dict):
+                raise SystemExit("Apps の各要素は JSON object で指定してください。")
+            unknown_app = sorted(set(app) - PUBLISH_FIELDS)
+            if unknown_app:
+                raise SystemExit(f"未確認の publish field です: {', '.join(unknown_app)}")
+            if not app.get("AppId") or not app.get("Workload"):
+                raise SystemExit("publish app には AppId と Workload が必要です。")
+            if app.get("Command") not in PUBLISH_COMMANDS:
+                raise SystemExit("未確認の publish Command です。")
+    if operation == "agent-permission-approve":
+        request_ids = payload["requestIds"]
+        if not isinstance(request_ids, list) or not request_ids:
+            raise SystemExit("requestIds は空でない配列で指定してください。")
+        if any(not isinstance(value, str) or not value.strip() for value in request_ids):
+            raise SystemExit("requestIds の各要素は空でない文字列で指定してください。")
 
 
 def build_plan(args: argparse.Namespace) -> dict[str, Any]:
@@ -78,6 +189,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         if not args.bot_id or not args.environment_id:
             raise SystemExit("agent-availability では --bot-id と --environment-id が必須です。")
         query = {"botId": args.bot_id, "environmentId": args.environment_id}
+    if args.operation == "agent-permission-approve":
+        if not args.workload:
+            raise SystemExit("agent-permission-approve では --workload が必須です。")
+        query = {"workload": args.workload}
     return {
         "origin": "https://admin.cloud.microsoft",
         "operation": args.operation,
@@ -95,6 +210,7 @@ def main() -> None:
     parser.add_argument("--payload-file", required=True)
     parser.add_argument("--bot-id")
     parser.add_argument("--environment-id")
+    parser.add_argument("--workload")
     parser.add_argument("--expected-hash")
     parser.add_argument("--apply", action="store_true")
     args = parser.parse_args()

--- a/.github/skills/admin/scripts/manage_m365_portal_api.py
+++ b/.github/skills/admin/scripts/manage_m365_portal_api.py
@@ -63,12 +63,19 @@ CONTRACTS = {
         "required": {"Apps"},
         "allowed": {"Apps"},
     },
-    "agent-permission-approve": {
+    "agent-request-approve": {
         "method": "POST",
         "path": "/fd/addins/api/agentActions/approve",
         "readBack": "/fd/addins/api/agents",
         "required": {"requestIds"},
         "allowed": {"requestIds"},
+    },
+    "agent-permission-update": {
+        "method": "POST",
+        "path": "/fd/addins/api/v2/AgentPermission/update",
+        "readBack": "/fd/addins/api/agents",
+        "required": {"ActiveDirectoryAppId", "PermissionRequestData"},
+        "allowed": {"ActiveDirectoryAppId", "PermissionRequestData"},
     },
 }
 
@@ -90,6 +97,7 @@ WORKLOAD_FIELDS = {
 ASSIGNMENT_FIELDS = {"Members", "DeployToEveryone", "UserAssignmentCategory"}
 PUBLISH_COMMANDS = {"APPROVE", "FINALIZEPACKAGE", "UPDATESTAGEDAPP"}
 PUBLISH_FIELDS = {"AppId", "Command", "Workload", "IterationEtag", "Version", "TitleId", "MosOperationId"}
+PERMISSION_FIELDS = {"Type", "Action", "ResourceId", "Scope", "AppId"}
 
 
 def canonical_hash(value: dict[str, Any]) -> str:
@@ -172,12 +180,28 @@ def validate_payload(operation: str, payload: dict[str, Any]) -> None:
                 raise SystemExit("publish app には AppId と Workload が必要です。")
             if app.get("Command") not in PUBLISH_COMMANDS:
                 raise SystemExit("未確認の publish Command です。")
-    if operation == "agent-permission-approve":
+    if operation == "agent-request-approve":
         request_ids = payload["requestIds"]
         if not isinstance(request_ids, list) or not request_ids:
             raise SystemExit("requestIds は空でない配列で指定してください。")
         if any(not isinstance(value, str) or not value.strip() for value in request_ids):
             raise SystemExit("requestIds の各要素は空でない文字列で指定してください。")
+    if operation == "agent-permission-update":
+        if not isinstance(payload["ActiveDirectoryAppId"], str) or not payload["ActiveDirectoryAppId"].strip():
+            raise SystemExit("ActiveDirectoryAppId は空でない文字列で指定してください。")
+        requests = payload["PermissionRequestData"]
+        if not isinstance(requests, list) or not requests:
+            raise SystemExit("PermissionRequestData は空でない配列で指定してください。")
+        for request in requests:
+            if not isinstance(request, dict) or set(request) != PERMISSION_FIELDS:
+                raise SystemExit("permission request の field が一致しません。")
+            if request["Type"] not in {"Scope", "Role"}:
+                raise SystemExit("permission Type は Scope または Role で指定してください。")
+            if request["Action"] not in {"Grant", "Revoke"}:
+                raise SystemExit("permission Action は Grant または Revoke で指定してください。")
+            for key in ("ResourceId", "Scope", "AppId"):
+                if not isinstance(request[key], str) or not request[key].strip():
+                    raise SystemExit(f"{key} は空でない文字列で指定してください。")
 
 
 def build_plan(args: argparse.Namespace) -> dict[str, Any]:
@@ -189,9 +213,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         if not args.bot_id or not args.environment_id:
             raise SystemExit("agent-availability では --bot-id と --environment-id が必須です。")
         query = {"botId": args.bot_id, "environmentId": args.environment_id}
-    if args.operation == "agent-permission-approve":
+    if args.operation == "agent-request-approve":
         if not args.workload:
-            raise SystemExit("agent-permission-approve では --workload が必須です。")
+            raise SystemExit("agent-request-approve では --workload が必須です。")
         query = {"workload": args.workload}
     return {
         "origin": "https://admin.cloud.microsoft",

--- a/.github/skills/admin/scripts/manage_m365_users.py
+++ b/.github/skills/admin/scripts/manage_m365_users.py
@@ -1,0 +1,250 @@
+"""Microsoft Graph v1.0 で M365 ユーザーとライセンスを管理する。
+
+読み取りは即時実行し、変更は dry-run -> plan hash -> --apply の二段階で行う。
+認証は standard/scripts/auth_helper.py のキャッシュ済み認証だけを使う。
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+
+HERE = Path(__file__).resolve().parent
+STANDARD_SCRIPTS = (HERE / ".." / ".." / "standard" / "scripts").resolve()
+sys.path.insert(0, str(STANDARD_SCRIPTS))
+
+from auth_helper import get_session  # noqa: E402
+
+
+GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+TIMEOUT = 120
+
+
+def graph_request(method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+    session = get_session(scope=GRAPH_SCOPE)
+    response = session.request(method, f"{GRAPH_BASE}{path}", json=body, timeout=TIMEOUT)
+    if response.status_code >= 400:
+        raise RuntimeError(f"{method} {path} failed: HTTP {response.status_code} {response.text}")
+    return response.json() if response.content else None
+
+
+def graph_collection(path: str) -> list[dict[str, Any]]:
+    values: list[dict[str, Any]] = []
+    url = f"{GRAPH_BASE}{path}"
+    session = get_session(scope=GRAPH_SCOPE)
+    while url:
+        response = session.get(url, timeout=TIMEOUT)
+        if response.status_code >= 400:
+            raise RuntimeError(f"GET {path} failed: HTTP {response.status_code} {response.text}")
+        page = response.json()
+        values.extend(page.get("value") or [])
+        url = page.get("@odata.nextLink")
+    return values
+
+
+def canonical_hash(plan: dict[str, Any]) -> str:
+    payload = json.dumps(plan, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def apply_plan(plan: dict[str, Any], args: argparse.Namespace) -> Any:
+    plan_hash = canonical_hash(plan)
+    printable = {**plan, "body": redact(plan.get("body") or {})}
+    print(json.dumps(printable, ensure_ascii=False, indent=2))
+    print(f"PLAN_HASH={plan_hash}")
+    if not args.apply:
+        print("DRY-RUN: 変更していません。適用時は --expected-hash と --apply を指定してください。")
+        return None
+    if args.expected_hash != plan_hash:
+        raise SystemExit("承認済み plan hash が一致しません。最新の dry-run を再確認してください。")
+    result = graph_request(plan["method"], plan["path"], plan.get("body"))
+    print("APPLIED")
+    return result
+
+
+def redact(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: "<redacted>" if key.lower() in {"password", "secret", "clientsecret"} else redact(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact(item) for item in value]
+    return value
+
+
+def parse_graph_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def inventory(args: argparse.Namespace) -> None:
+    skus = graph_collection("/subscribedSkus")
+    users = graph_collection(
+        "/users?$select=id,displayName,userPrincipalName,accountEnabled,usageLocation,"
+        "assignedLicenses,signInActivity&$top=500"
+    )
+    sku_by_id = {str(sku.get("skuId")): sku for sku in skus}
+    cutoff = datetime.now(timezone.utc) - timedelta(days=args.inactive_days)
+    inactive = []
+    for user in users:
+        activity = user.get("signInActivity") or {}
+        last_sign_in = parse_graph_time(activity.get("lastSuccessfulSignInDateTime"))
+        user["assignedSkuPartNumbers"] = [
+            (sku_by_id.get(str(item.get("skuId"))) or {}).get("skuPartNumber", str(item.get("skuId")))
+            for item in user.get("assignedLicenses") or []
+        ]
+        user["lastSuccessfulSignInDateTime"] = last_sign_in.isoformat() if last_sign_in else None
+        user.pop("signInActivity", None)
+        if user.get("accountEnabled") and (last_sign_in is None or last_sign_in < cutoff):
+            inactive.append(user)
+
+    report = {
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "inactiveDays": args.inactive_days,
+        "summary": {
+            "users": len(users),
+            "enabledUsers": sum(bool(user.get("accountEnabled")) for user in users),
+            "licensedUsers": sum(bool(user.get("assignedLicenses")) for user in users),
+            "inactiveCandidates": len(inactive),
+        },
+        "skus": [
+            {
+                "skuId": sku.get("skuId"),
+                "skuPartNumber": sku.get("skuPartNumber"),
+                "enabled": (sku.get("prepaidUnits") or {}).get("enabled", 0),
+                "consumed": sku.get("consumedUnits", 0),
+                "available": max(
+                    0,
+                    (sku.get("prepaidUnits") or {}).get("enabled", 0) - sku.get("consumedUnits", 0),
+                ),
+            }
+            for sku in skus
+        ],
+        "users": users,
+        "inactiveCandidates": inactive,
+    }
+    print(json.dumps(report["summary"], ensure_ascii=False, indent=2))
+    if args.report_file:
+        output = Path(args.report_file)
+        output.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"Report: {output.resolve()}")
+
+
+def sku_id(value: str) -> str:
+    skus = graph_collection("/subscribedSkus")
+    for sku in skus:
+        if value.lower() in {str(sku.get("skuId", "")).lower(), str(sku.get("skuPartNumber", "")).lower()}:
+            return str(sku["skuId"])
+    raise SystemExit(f"SKU が見つかりません: {value}")
+
+
+def license_change(args: argparse.Namespace) -> None:
+    add_ids = [sku_id(value) for value in args.add_sku]
+    remove_ids = [sku_id(value) for value in args.remove_sku]
+    if not add_ids and not remove_ids:
+        raise SystemExit("--add-sku または --remove-sku を指定してください。")
+    user = quote(args.user, safe="")
+    plan = {
+        "operation": "license-change",
+        "method": "POST",
+        "path": f"/users/{user}/assignLicense",
+        "body": {
+            "addLicenses": [{"skuId": value, "disabledPlans": []} for value in add_ids],
+            "removeLicenses": remove_ids,
+        },
+    }
+    apply_plan(plan, args)
+
+
+def set_account(args: argparse.Namespace) -> None:
+    user = quote(args.user, safe="")
+    plan = {
+        "operation": "set-account-enabled",
+        "method": "PATCH",
+        "path": f"/users/{user}",
+        "body": {"accountEnabled": args.enabled == "true"},
+    }
+    apply_plan(plan, args)
+
+
+def create_user(args: argparse.Namespace) -> None:
+    password = os.getenv(args.password_env)
+    if not password:
+        raise SystemExit(f"一時パスワードを環境変数 {args.password_env} に設定してください。")
+    plan = {
+        "operation": "create-user",
+        "method": "POST",
+        "path": "/users",
+        "body": {
+            "accountEnabled": True,
+            "displayName": args.display_name,
+            "mailNickname": args.mail_nickname,
+            "userPrincipalName": args.user_principal_name,
+            "usageLocation": args.usage_location,
+            "passwordProfile": {"forceChangePasswordNextSignIn": True, "password": password},
+        },
+    }
+    apply_plan(plan, args)
+
+
+def add_apply_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--expected-hash")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    inventory_parser = subparsers.add_parser("inventory", help="ライセンスと非アクティブ候補を棚卸")
+    inventory_parser.add_argument("--inactive-days", type=int, default=90)
+    inventory_parser.add_argument("--report-file")
+    inventory_parser.set_defaults(handler=inventory)
+
+    license_parser = subparsers.add_parser("license", help="ライセンスを付与または解除")
+    license_parser.add_argument("--user", required=True, help="User ID または UPN")
+    license_parser.add_argument("--add-sku", action="append", default=[], help="skuId または skuPartNumber")
+    license_parser.add_argument("--remove-sku", action="append", default=[], help="skuId または skuPartNumber")
+    add_apply_arguments(license_parser)
+    license_parser.set_defaults(handler=license_change)
+
+    account_parser = subparsers.add_parser("account", help="ユーザーを有効化または無効化")
+    account_parser.add_argument("--user", required=True, help="User ID または UPN")
+    account_parser.add_argument("--enabled", choices=("true", "false"), required=True)
+    add_apply_arguments(account_parser)
+    account_parser.set_defaults(handler=set_account)
+
+    create_parser = subparsers.add_parser("create-user", help="クラウドユーザーを作成")
+    create_parser.add_argument("--display-name", required=True)
+    create_parser.add_argument("--mail-nickname", required=True)
+    create_parser.add_argument("--user-principal-name", required=True)
+    create_parser.add_argument("--usage-location", required=True, help="ISO 3166-1 alpha-2 (例: JP)")
+    create_parser.add_argument("--password-env", default="M365_NEW_USER_PASSWORD")
+    add_apply_arguments(create_parser)
+    create_parser.set_defaults(handler=create_user)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if getattr(args, "inactive_days", 1) < 1:
+        raise SystemExit("--inactive-days は 1 以上にしてください。")
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/admin/tests/test_m365_portal_browser_runner.mjs
+++ b/.github/skills/admin/tests/test_m365_portal_browser_runner.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  canonicalHash,
+  validatePlan,
+} from "../scripts/m365_portal_browser_runner.mjs";
+
+const lifecyclePlan = {
+  origin: "https://admin.cloud.microsoft",
+  operation: "agent-lifecycle",
+  method: "POST",
+  path: "/fd/addins/api/apps",
+  query: {},
+  payload: { WorkloadManagementList: [] },
+  readBack: "/fd/addins/api/agents",
+};
+
+test("canonical hash is independent of object key order", () => {
+  assert.equal(canonicalHash({ a: 1, b: 2 }), canonicalHash({ b: 2, a: 1 }));
+});
+
+test("canonical hash matches the Python planner for non-ASCII text", () => {
+  assert.equal(
+    canonicalHash({ label: "公開", a: 1 }),
+    "31df002d712a1505df7ae9aef407de26bfa3ef5c3a1d56e1816cc26d63d2b3f8",
+  );
+});
+
+test("allows the observed lifecycle endpoint", () => {
+  assert.equal(validatePlan(lifecyclePlan), lifecyclePlan);
+});
+
+test("allows the observed publish endpoint", () => {
+  const plan = {
+    ...lifecyclePlan,
+    operation: "agent-publish",
+    path: "/fd/addins/api/v2/actionableApps",
+  };
+  assert.equal(validatePlan(plan), plan);
+});
+
+test("rejects a write path that does not match the operation", () => {
+  assert.throws(
+    () => validatePlan({ ...lifecyclePlan, path: "/fd/addins/api/other" }),
+    /write contract mismatch/,
+  );
+});
+
+test("rejects an unobserved read-back path", () => {
+  assert.throws(
+    () => validatePlan({ ...lifecyclePlan, readBack: "/admin/api/users" }),
+    /readBack is not allowlisted/,
+  );
+});
+
+test("permission approval requires a workload query", () => {
+  assert.throws(
+    () =>
+      validatePlan({
+        ...lifecyclePlan,
+        operation: "agent-permission-approve",
+        path: "/fd/addins/api/agentActions/approve",
+      }),
+    /requires workload query/,
+  );
+});

--- a/.github/skills/admin/tests/test_m365_portal_browser_runner.mjs
+++ b/.github/skills/admin/tests/test_m365_portal_browser_runner.mjs
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 
 import {
   canonicalHash,
+  runApprovedPlan,
   validatePlan,
 } from "../scripts/m365_portal_browser_runner.mjs";
 
@@ -54,14 +58,62 @@ test("rejects an unobserved read-back path", () => {
   );
 });
 
-test("permission approval requires a workload query", () => {
+test("request approval requires a workload query", () => {
   assert.throws(
     () =>
       validatePlan({
         ...lifecyclePlan,
-        operation: "agent-permission-approve",
+        operation: "agent-request-approve",
         path: "/fd/addins/api/agentActions/approve",
       }),
     /requires workload query/,
   );
+});
+
+test("allows the observed permission update payload", () => {
+  const plan = {
+    ...lifecyclePlan,
+    operation: "agent-permission-update",
+    path: "/fd/addins/api/v2/AgentPermission/update",
+    payload: {
+      ActiveDirectoryAppId: "agent-app-example",
+      PermissionRequestData: [
+        {
+          Type: "Role",
+          Action: "Grant",
+          ResourceId: "resource-example",
+          Scope: "role.example",
+          AppId: "api-example",
+        },
+      ],
+    },
+  };
+  assert.equal(validatePlan(plan), plan);
+});
+
+test("rejects incomplete permission update payload", () => {
+  assert.throws(
+    () =>
+      validatePlan({
+        ...lifecyclePlan,
+        operation: "agent-permission-update",
+        path: "/fd/addins/api/v2/AgentPermission/update",
+        payload: { ActiveDirectoryAppId: "agent-app-example", PermissionRequestData: [{}] },
+      }),
+    /fields do not match/,
+  );
+});
+
+test("runApprovedPlan rejects an unapproved hash before browser access", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "m365-runner-"));
+  const planPath = join(directory, "plan.json");
+  await writeFile(planPath, JSON.stringify(lifecyclePlan), "utf8");
+  let browserWasAccessed = false;
+  const page = new Proxy({}, { get: () => { browserWasAccessed = true; } });
+  try {
+    await assert.rejects(runApprovedPlan(page, planPath, "not-approved"), /approved plan hash mismatch/);
+    assert.equal(browserWasAccessed, false);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });

--- a/.github/skills/admin/tests/test_manage_m365_portal_api.py
+++ b/.github/skills/admin/tests/test_manage_m365_portal_api.py
@@ -1,0 +1,59 @@
+import argparse
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "manage_m365_portal_api.py"
+SPEC = importlib.util.spec_from_file_location("manage_m365_portal_api", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class ManageM365PortalApiTests(unittest.TestCase):
+    def payload_file(self, payload):
+        handle = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8")
+        with handle:
+            json.dump(payload, handle)
+        self.addCleanup(Path(handle.name).unlink, missing_ok=True)
+        return handle.name
+
+    def test_frontier_plan_uses_fixed_endpoint(self):
+        args = argparse.Namespace(
+            operation="frontier-access",
+            payload_file=self.payload_file({"frontierPolicy": 1, "audienceStatus": "PartiallyEnrolled"}),
+            bot_id=None,
+            environment_id=None,
+        )
+        plan = MODULE.build_plan(args)
+        self.assertEqual("/admin/api/settings/company/frontier/access", plan["path"])
+        self.assertEqual("/admin/api/settings/company/frontier/access", plan["readBack"])
+
+    def test_unknown_frontier_field_is_rejected(self):
+        with self.assertRaises(SystemExit):
+            MODULE.validate_payload(
+                "frontier-access",
+                {"frontierPolicy": 1, "audienceStatus": "PartiallyEnrolled", "url": "https://example.com"},
+            )
+
+    def test_agent_plan_requires_inventory_ids(self):
+        args = argparse.Namespace(
+            operation="agent-availability",
+            payload_file=self.payload_file(
+                {"Locale": "en-US", "Market": "US", "WorkloadManagementList": [], "SendEmailToUsers": False}
+            ),
+            bot_id=None,
+            environment_id=None,
+        )
+        with self.assertRaises(SystemExit):
+            MODULE.build_plan(args)
+
+    def test_hash_is_order_independent(self):
+        self.assertEqual(MODULE.canonical_hash({"a": 1, "b": 2}), MODULE.canonical_hash({"b": 2, "a": 1}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/skills/admin/tests/test_manage_m365_portal_api.py
+++ b/.github/skills/admin/tests/test_manage_m365_portal_api.py
@@ -110,9 +110,9 @@ class ManageM365PortalApiTests(unittest.TestCase):
         plan = MODULE.build_plan(args)
         self.assertEqual("/fd/addins/api/v2/actionableApps", plan["path"])
 
-    def test_permission_approval_uses_workload_query(self):
+    def test_request_approval_uses_workload_query(self):
         args = argparse.Namespace(
-            operation="agent-permission-approve",
+            operation="agent-request-approve",
             payload_file=self.payload_file({"requestIds": ["request-example"]}),
             bot_id=None,
             environment_id=None,
@@ -121,6 +121,30 @@ class ManageM365PortalApiTests(unittest.TestCase):
         plan = MODULE.build_plan(args)
         self.assertEqual("/fd/addins/api/agentActions/approve", plan["path"])
         self.assertEqual({"workload": "SharedAgent"}, plan["query"])
+
+    def test_permission_update_uses_agent_permission_endpoint(self):
+        args = argparse.Namespace(
+            operation="agent-permission-update",
+            payload_file=self.payload_file(
+                {
+                    "ActiveDirectoryAppId": "app-example",
+                    "PermissionRequestData": [
+                        {
+                            "Type": "Scope",
+                            "Action": "Grant",
+                            "ResourceId": "resource-example",
+                            "Scope": "scope.example",
+                            "AppId": "api-example",
+                        }
+                    ],
+                }
+            ),
+            bot_id=None,
+            environment_id=None,
+            workload=None,
+        )
+        plan = MODULE.build_plan(args)
+        self.assertEqual("/fd/addins/api/v2/AgentPermission/update", plan["path"])
 
     def test_hash_is_order_independent(self):
         self.assertEqual(MODULE.canonical_hash({"a": 1, "b": 2}), MODULE.canonical_hash({"b": 2, "a": 1}))

--- a/.github/skills/admin/tests/test_manage_m365_portal_api.py
+++ b/.github/skills/admin/tests/test_manage_m365_portal_api.py
@@ -51,6 +51,77 @@ class ManageM365PortalApiTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             MODULE.build_plan(args)
 
+    def test_lifecycle_plan_uses_fixed_endpoint(self):
+        args = argparse.Namespace(
+            operation="agent-lifecycle",
+            payload_file=self.payload_file(
+                {
+                    "Locale": "en-US",
+                    "ContentMarket": "US",
+                    "WorkloadManagementList": [
+                        {"ProductID": "00000000-0000-0000-0000-000000000000", "Command": "DEPLOY"}
+                    ],
+                    "UserAssignmentDetails": {
+                        "Members": [],
+                        "DeployToEveryone": False,
+                        "UserAssignmentCategory": "SpecificUsers",
+                    },
+                    "DeploymentRolloutType": "FullRollout",
+                    "SendEmailToUsers": False,
+                }
+            ),
+            bot_id=None,
+            environment_id=None,
+        )
+        plan = MODULE.build_plan(args)
+        self.assertEqual("/fd/addins/api/apps", plan["path"])
+        self.assertEqual("/fd/addins/api/agents", plan["readBack"])
+
+    def test_lifecycle_rejects_unobserved_command(self):
+        with self.assertRaises(SystemExit):
+            MODULE.validate_payload(
+                "agent-lifecycle",
+                {
+                    "Locale": "en-US",
+                    "ContentMarket": "US",
+                    "WorkloadManagementList": [
+                        {"ProductID": "00000000-0000-0000-0000-000000000000", "Command": "DeleteEverything"}
+                    ],
+                    "UserAssignmentDetails": {
+                        "Members": [],
+                        "DeployToEveryone": False,
+                        "UserAssignmentCategory": "SpecificUsers",
+                    },
+                    "DeploymentRolloutType": "FullRollout",
+                    "SendEmailToUsers": False,
+                },
+            )
+
+    def test_publish_plan_uses_actionable_apps_endpoint(self):
+        args = argparse.Namespace(
+            operation="agent-publish",
+            payload_file=self.payload_file(
+                {"Apps": [{"AppId": "T_example", "Command": "APPROVE", "Workload": "SharedAgent"}]}
+            ),
+            bot_id=None,
+            environment_id=None,
+            workload=None,
+        )
+        plan = MODULE.build_plan(args)
+        self.assertEqual("/fd/addins/api/v2/actionableApps", plan["path"])
+
+    def test_permission_approval_uses_workload_query(self):
+        args = argparse.Namespace(
+            operation="agent-permission-approve",
+            payload_file=self.payload_file({"requestIds": ["request-example"]}),
+            bot_id=None,
+            environment_id=None,
+            workload="SharedAgent",
+        )
+        plan = MODULE.build_plan(args)
+        self.assertEqual("/fd/addins/api/agentActions/approve", plan["path"])
+        self.assertEqual({"workload": "SharedAgent"}, plan["query"])
+
     def test_hash_is_order_independent(self):
         self.assertEqual(MODULE.canonical_hash({"a": 1, "b": 2}), MODULE.canonical_hash({"b": 2, "a": 1}))
 

--- a/.github/skills/admin/tests/test_manage_m365_users.py
+++ b/.github/skills/admin/tests/test_manage_m365_users.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "manage_m365_users.py"
+SPEC = importlib.util.spec_from_file_location("manage_m365_users", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class ManageM365UsersTests(unittest.TestCase):
+    def test_plan_hash_is_order_independent(self):
+        left = {"method": "PATCH", "body": {"accountEnabled": False}, "path": "/users/example"}
+        right = {"path": "/users/example", "body": {"accountEnabled": False}, "method": "PATCH"}
+
+        self.assertEqual(MODULE.canonical_hash(left), MODULE.canonical_hash(right))
+
+    def test_redact_removes_nested_passwords(self):
+        body = {"passwordProfile": {"password": "not-for-output"}, "displayName": "Example"}
+
+        redacted = MODULE.redact(body)
+
+        self.assertEqual(redacted["passwordProfile"]["password"], "<redacted>")
+        self.assertEqual(redacted["displayName"], "Example")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
admin スキルに M365 Graph 管理 CLI と、Agent Registry private API の承認 plan validator / browser-session runner を追加します。

- Install/Uninstall: POST /fd/addins/api/apps（write/poll/read-back 実測済み）
- Publish/Finalize: POST /fd/addins/api/v2/actionableApps（契約捕捉・runner対応、成功mutation未実測）
- 利用要求承認: POST /fd/addins/api/agentActions/approve
- Entra permission更新: POST /fd/addins/api/v2/AgentPermission/update
- PermissionRequestData: Type=Scope|Role、Action=Grant|Revoke、ResourceId/Scope/AppId
- dry-run -> PLAN_HASH -> runApprovedPlan -> session header継承 -> write -> poll -> read-back
- Python 80 tests / Node 10 tests / validate_skill.py PASS
- 完全なAPI-only判定には、AppCatalog scopeを持つdisposable agentでPublish/Permission成功実測が残る
- マージ順: このPR (#450)を先にマージし、その後Cowork PR #451