### PR TITLE
skill(cowork): スキルを追加/更新

### DIFF
--- a/.github/skills/cowork/SKILL.md
+++ b/.github/skills/cowork/SKILL.md
@@ -102,6 +102,8 @@ OAuth 同意が必要な場合は `Privileged Role Administrator` を担当工�
 | [scripts/build_agent_package.ps1](scripts/build_agent_package.ps1) | `.env` の `COWORK_OAUTH_REGISTRATION_ID`（引用符付きでも可）を manifest.json のプレースホルダーに注入し、必須ファイルを検証して .zip を生成（Step 7） |
 | [scripts/manage_agent_package_graph.py](scripts/manage_agent_package_graph.py) | Graph v1.0 で組織アプリ/エージェントを一覧し、M365 app package を新規登録または更新（Step 8） |
 | [scripts/manage_oauth_registration_api.py](scripts/manage_oauth_registration_api.py) | Developer Portal OAuth private API の CRUD plan を検証（Step 5）。実送信はログイン済み統合ブラウザ session で行う |
+| [../admin/scripts/manage_m365_portal_api.py](../admin/scripts/manage_m365_portal_api.py) | Agent Registry の Install / Publish / Permission plan を検証（Step 8） |
+| [../admin/scripts/m365_portal_browser_runner.mjs](../admin/scripts/m365_portal_browser_runner.mjs) | 承認済みplanをbrowser session APIで実行し、pollとread-backを検証（Step 8） |
 
 ## ワークフロー（正常系）
 
@@ -458,10 +460,11 @@ python .github/skills/cowork/scripts/manage_agent_package_graph.py deploy `
   --package <name>.zip --requires-review --expected-hash <APPROVED_HASH> --apply
 ```
 
-Graph のアプリカタログ登録と、Agent Registry の公開対象/Install 設定は別工程である。
-公開対象/Install/Block は管理センター private API を正常系とし、GET inventory から対象 ID と action config を
-解決して `manage_m365_portal_api.py` の plan を作り、hash 承認後に統合ブラウザ session API で送信・読み戻す。
-Graph が権限または package 種別に対応しない場合だけ、次の管理センター fallback を使う。
+Graph のアプリカタログ登録と、Agent Registry の公開/Install 設定は別工程である。
+Install/Uninstall、Publish/Finalize、permission approval は管理センター private API を正常系とし、GET inventory から
+対象 ID を解決して `manage_m365_portal_api.py` の plan を作る。hash 承認後は
+`m365_portal_browser_runner.mjs` で送信し、deployment status とAgent detailsを読み戻す。
+API が401/403/404、schema不一致、read-back不一致の場合だけ、次の管理センターfallbackを選択する。
 
 #### 管理センター fallback
 

--- a/.github/skills/cowork/SKILL.md
+++ b/.github/skills/cowork/SKILL.md
@@ -100,6 +100,8 @@ OAuth 同意が必要な場合は `Privileged Role Administrator` を担当工�
 | [scripts/register_mcp_client.py](scripts/register_mcp_client.py) | Client ID を Dataverse 許可 MCP クライアント（`allowedmcpclients`）に登録・有効化・確認（Step 4） |
 | [scripts/diagnose_cowork_connector.py](scripts/diagnose_cowork_connector.py) | アプリ登録・admin consent・allowedmcpclients の3層をまとめて診断（Step 4→5 の間で実行推奨） |
 | [scripts/build_agent_package.ps1](scripts/build_agent_package.ps1) | `.env` の `COWORK_OAUTH_REGISTRATION_ID`（引用符付きでも可）を manifest.json のプレースホルダーに注入し、必須ファイルを検証して .zip を生成（Step 7） |
+| [scripts/manage_agent_package_graph.py](scripts/manage_agent_package_graph.py) | Graph v1.0 で組織アプリ/エージェントを一覧し、M365 app package を新規登録または更新（Step 8） |
+| [scripts/manage_oauth_registration_api.py](scripts/manage_oauth_registration_api.py) | Developer Portal OAuth private API の CRUD plan を検証（Step 5）。実送信はログイン済み統合ブラウザ session で行う |
 
 ## ワークフロー（正常系）
 
@@ -289,11 +291,22 @@ python .github/skills/cowork/scripts/register_mcp_client.py --app-id <CLIENT_ID>
 > ```
 > いずれかのレイヤーが ❌/❓ の場合は、表示される対処コマンドを実行してから Step 5 に進む。
 
-### Step 5: Teams 開発者ポータルで OAuth client 登録 → registrationId 取得（ブラウザ）
+### Step 5: OAuth client registration API → registrationId 取得
 
-実行前に [ブラウザ自動化方針](../standard/references/browser-automation.md)に従い、
-`AskUserQuestion` で使用する Edge プロファイルを確認する。回答前はポータルを開かず、
-Step 8 のアップロードでも同じプロファイルを使用する。
+正常系は Developer Portal private API の CRUD。CLI で payload と `PLAN_HASH` を検証し、承認後に
+ログイン済み VS Code 統合ブラウザから同一オリジン API を直接実行して GET で読み戻す。
+専用 portal client は Device Code flow を許可せず `AADSTS7000218` になるため、Bearer token や Cookie を
+CLI へ取り出さない。手順と endpoint は [portal-api-automation.md](references/portal-api-automation.md)を参照。
+
+```powershell
+python .github/skills/cowork/scripts/manage_oauth_registration_api.py create `
+  --name "Dataverse MCP OAuth" --base-url $env:DATAVERSE_URL `
+  --scopes "$env:DATAVERSE_URL/.default,offline_access"
+# 承認後、同じ引数に --expected-hash <APPROVED_HASH> --apply
+```
+
+API が `401` / `403` / `404`、または観測済み schema と一致しない場合だけフォーム操作へ切り替える。
+[ブラウザ自動化方針](../standard/references/browser-automation.md)に従い、使用する Edge プロファイルを確認する。
 
 [dev.teams.microsoft.com/tools](https://dev.teams.microsoft.com/tools) → Tools →
 **OAuth client registration** → New（**SSO client registration ではない**）。
@@ -428,7 +441,29 @@ Compress-Archive -Path manifest.built.json, color.png, outline.png, dataverse-mc
 ZIP 検証: ルートに `manifest.json`（build 後、プレースホルダーが実 ID に置換済み）/ `dataverse-mcp-tools.json`、
 `skills/<skill-name>/SKILL.md` が含まれること。
 
-### Step 8: アップロード（M365 管理センター → エージェント画面）
+### Step 8: 組織カタログへ登録・更新する
+
+公開 API を正常系にする。`manage_agent_package_graph.py` は ZIP の `manifest.json.id` で既存アプリを
+判定し、新規なら `POST /appCatalogs/teamsApps`、既存なら
+`POST /appCatalogs/teamsApps/{id}/appDefinitions` を使う。詳細は
+[portal-api-automation.md](references/portal-api-automation.md)。
+
+```powershell
+# dry-run。package SHA-256 を含む PLAN_HASH を確認する
+python .github/skills/cowork/scripts/manage_agent_package_graph.py deploy `
+  --package <name>.zip --requires-review
+
+# 承認した同一 package だけを登録/更新する
+python .github/skills/cowork/scripts/manage_agent_package_graph.py deploy `
+  --package <name>.zip --requires-review --expected-hash <APPROVED_HASH> --apply
+```
+
+Graph のアプリカタログ登録と、Agent Registry の公開対象/Install 設定は別工程である。
+公開対象/Install/Block は管理センター private API を正常系とし、GET inventory から対象 ID と action config を
+解決して `manage_m365_portal_api.py` の plan を作り、hash 承認後に統合ブラウザ session API で送信・読み戻す。
+Graph が権限または package 種別に対応しない場合だけ、次の管理センター fallback を使う。
+
+#### 管理センター fallback
 
 > ⚠️ Cowork プラグインは**「統合アプリ」ではなく、新しい「エージェント」画面**からアップロードする（UI 変更済み）。
 
@@ -464,12 +499,13 @@ ZIP 検証: ルートに `manifest.json`（build 後、プレースホルダー�
 
 1. manifest.json の **`version` をインクリメント**（例: `1.0.2` → `1.0.3`）。`id` は変更しない。
 2. zip を再ビルド（Step 7 と同じ。`dataverse-mcp-tools.json` も忘れず含める）。
-3. 管理センター → **エージェント（Agents）** (`#/agents/all`) → **Registry** タブ →
+3. Step 8 の `manage_agent_package_graph.py deploy` で更新する。
+4. Graph が未対応の場合は、管理センター → **エージェント（Agents）** (`#/agents/all`) → **Registry** タブ →
    ツールバー右の **More actions（…、Export の隣）** → **Add agent**。
-4. **Upload agent** で新しい zip を選択 → 検証が再実行される（`id` が一致するため更新として処理される）。
-5. **Publish to users**（公開対象と Install を選択。**更新時も再選択が必要**） →
+5. **Upload agent** で新しい zip を選択 → 検証が再実行される（`id` が一致するため更新として処理される）。
+6. **Publish to users**（公開対象と Install を選択。**更新時も再選択が必要**） →
    **Apply template**（Default で Next）→ **Accept permissions** → **Review & finish** → **Publish**。
-6. 「**You uploaded \<name\>**」表示で完了 → **Close**。
+7. 「**You uploaded \<name\>**」表示で完了 → **Close**。
 
 > 注意:
 > - `id` を変えると別エージェント扱いになり、既存の公開設定・同意が引き継がれない。
@@ -490,13 +526,16 @@ ZIP 検証: ルートに `manifest.json`（build 後、プレースホルダー�
 - [ ] Teams ポータル **OAuth client registration**（SSO ではない）: Base URL は `/api/mcp` なし、scope は `.default offline_access`、Restrict by app = Any Teams app → registrationId を manifest に反映
 - [ ] manifest に `mcpToolDescription: { file: "dataverse-mcp-tools.json" }`（JSONツール定義）
 - [ ] ZIP ルートに manifest.json / dataverse-mcp-tools.json、skills/<name>/SKILL.md
-- [ ] 管理センターの**エージェント画面**からアップロード→Publish→Status=Available
+- [ ] `manage_agent_package_graph.py deploy` の package SHA-256 と PLAN_HASH を承認後に Graph で登録/更新
+- [ ] Graph で組織カタログへ登録、または管理センター fallback でアップロード
+- [ ] Agent Registry で Publish→Status=Available（Graph 登録成功とは別に確認）
 - [ ] Cowork に表示 → 初回同意 → データ取得成功
-- [ ] 更新時: version をインクリメント（id 据え置き）→ More actions → Update in store → Publish
+- [ ] 更新時: version をインクリメント（id 据え置き）→ Graph 更新または管理センター fallback → Publish
 
 ## 参考リンク
 
 - [Build plugins for Cowork (Frontier)](https://learn.microsoft.com/en-us/microsoft-365/copilot/cowork/cowork-plugin-development)
 - [Configure authentication for MCP and API plugins](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/plugin-authentication)
+- [ポータル API 自動化](references/portal-api-automation.md)
 - [Dataverse MCP 登録](../standard/references/dataverse-mcp-setup.md)
 - [自前 MCP Server の構築](../mcp-server/SKILL.md) / [コネクタ化の差分手順](references/custom-mcp-connector.md)

--- a/.github/skills/cowork/SKILL.md
+++ b/.github/skills/cowork/SKILL.md
@@ -461,7 +461,7 @@ python .github/skills/cowork/scripts/manage_agent_package_graph.py deploy `
 ```
 
 Graph のアプリカタログ登録と、Agent Registry の公開/Install 設定は別工程である。
-Install/Uninstall、Publish/Finalize、permission approval は管理センター private API を正常系とし、GET inventory から
+Install/Uninstall、Publish/Finalize、利用要求承認、Entra permission Grant/Revoke は管理センター private API を正常系とし、GET inventory から
 対象 ID を解決して `manage_m365_portal_api.py` の plan を作る。hash 承認後は
 `m365_portal_browser_runner.mjs` で送信し、deployment status とAgent detailsを読み戻す。
 API が401/403/404、schema不一致、read-back不一致の場合だけ、次の管理センターfallbackを選択する。

--- a/.github/skills/cowork/references/.env.example
+++ b/.github/skills/cowork/references/.env.example
@@ -1,0 +1,12 @@
+# Tenant and Dataverse
+TENANT_ID=
+DATAVERSE_URL=https://<org>.crm.dynamics.com
+PUBLISHER_PREFIX=new
+
+# Entra OAuth client used by the Cowork connector
+COWORK_OAUTH_CLIENT_ID=
+COWORK_OAUTH_CLIENT_SECRET=
+
+# Created by the Developer Portal OAuth registration API
+COWORK_OAUTH_REGISTRATION_ID=
+COWORK_PORTAL_REGION=amer

--- a/.github/skills/cowork/references/portal-api-automation.md
+++ b/.github/skills/cowork/references/portal-api-automation.md
@@ -19,7 +19,8 @@
 | OAuth client registration | `GET/POST/PATCH/DELETE /v1.0/oauthconfigurations` | private API、portal Bearer session |
 | Agent Registry の Install/Uninstall | `POST /fd/addins/api/apps` | private API、admin browser session |
 | Agent Registry の Publish/Finalize | `POST /fd/addins/api/v2/actionableApps` | private API、admin browser session |
-| Agent request/permission approval | `POST /fd/addins/api/agentActions/approve` | private API、admin browser session |
+| Agent 利用要求の承認 | `POST /fd/addins/api/agentActions/approve` | private API、admin browser session |
+| Agent Entra permission の更新 | `POST /fd/addins/api/v2/AgentPermission/update` | private API、admin browser session |
 | Frontier 対象者 | `GET/POST /admin/api/settings/company/frontier/access` | private API、admin browser session |
 
 ```powershell
@@ -68,8 +69,17 @@ Agent Registry の実測契約は次のとおり。package登録/更新はGraph�
 |---|---|
 | Install / Uninstall | `/fd/addins/api/apps`、`Command=DEPLOY/UNDEPLOY`、`UserAssignmentDetails` |
 | Publish / Finalize | `/fd/addins/api/v2/actionableApps`、`Apps[].Command=APPROVE/FINALIZEPACKAGE` |
-| Request / permission approval | `/fd/addins/api/agentActions/approve?workload=SharedAgent`、`requestIds[]` |
+| Agent 利用要求の承認 | `/fd/addins/api/agentActions/approve?workload=SharedAgent`、`requestIds[]` |
+| Entra permission Grant / Revoke | `/fd/addins/api/v2/AgentPermission/update`、`ActiveDirectoryAppId`、`PermissionRequestData[]` |
 | 完了確認 | `/fd/addins/api/deploymentRequestStatus/{requestId}` をpollし、Agent detailsをGET |
+
+`PermissionRequestData[]` は `Type` (`Scope` / `Role`)、`Action` (`Grant` / `Revoke`)、
+`ResourceId`、`Scope`、`AppId` の完全な組で送る。利用要求承認とEntra permission更新は別操作としてplanを作る。
+
+Install/Uninstallは成功応答とdetails read-backまで実測済み。Publish/FinalizeとEntra permission更新は
+bundle契約の捕捉とrunner契約テストまでで、成功mutationは未実測である。`AppCatalog.ReadWrite.All`を
+同意した検証用認証でdisposable packageを登録するか、管理者が検証専用agentを指定するまで、既存agentへ
+冪等性未確認のGrant/Revokeを送らない。
 
 ## Teams 開発者ポータル通信の調査
 

--- a/.github/skills/cowork/references/portal-api-automation.md
+++ b/.github/skills/cowork/references/portal-api-automation.md
@@ -1,0 +1,87 @@
+# Cowork ポータル API 自動化
+
+確認日: 2026-09-11。Cowork プラグインのライフサイクルは次の優先順位で自動化する。
+
+1. Microsoft 365 Agents Toolkit CLI (`atk`)
+2. Microsoft Graph v1.0 の Teams app catalog API
+3. 観測済み private API（ログイン済み VS Code 統合ブラウザ session から direct fetch）
+4. API を実行できない場合だけ VS Code 統合ブラウザでフォーム操作
+
+## ライフサイクル対応表
+
+| 工程 | 正常系 | 備考 |
+|---|---|---|
+| plugin import/export | `atk import openplugin` / `atk export openplugin` | Agents Toolkit CLI 1.1.12 以上 |
+| package/validate | `atk package` | manifest と package の事前検証 |
+| 個人テスト | `atk install --file-path ... --scope Personal` | `TitleId` / `AppId` を保存 |
+| 組織カタログ一覧 | `manage_agent_package_graph.py list` | Graph v1.0 |
+| 組織カタログ新規/更新 | `manage_agent_package_graph.py deploy` | manifest ID を維持し version を増加 |
+| OAuth client registration | `GET/POST/PATCH/DELETE /v1.0/oauthconfigurations` | private API、portal Bearer session |
+| Agent Registry の公開対象/Install | `/fd/addins/api/availableAgents` | private API、admin browser session |
+| Frontier 対象者 | `GET/POST /admin/api/settings/company/frontier/access` | private API、admin browser session |
+
+```powershell
+# 読み取り専用
+python .github/skills/cowork/scripts/manage_agent_package_graph.py list
+
+# dry-run。ZIP の SHA-256 を含む PLAN_HASH を表示
+python .github/skills/cowork/scripts/manage_agent_package_graph.py deploy `
+  --package <plugin.zip> --requires-review
+
+# 承認済みの同一 ZIP だけを登録/更新
+python .github/skills/cowork/scripts/manage_agent_package_graph.py deploy `
+  --package <plugin.zip> --requires-review `
+  --expected-hash <APPROVED_HASH> --apply
+```
+
+Graph の app catalog 登録成功は、M365 Agent Registry で対象ユーザーへ公開されたことを意味しない。
+登録/更新、管理者承認、公開対象、Cowork への同期、初回 OAuth 同意、MCP `tools/list`/`tools/call`
+を別々に検証する。
+
+## ポータル読み取り API の観測結果
+
+2026-09-11 に VS Code 統合ブラウザで同じ読み取りを2回実行し、endpoint、query parameter 名、
+HTTP status の一致を確認した。Developer Portal の build は画面と捕捉通信から取得できなかった。
+次の通信はすべて `observed/unsupported` であり、公開 API や再送可能な契約として扱わない。
+
+| 画面 | Method / path | Query parameter 名 | Status |
+|---|---|---|---|
+| OAuth client registration | `GET https://dev.teams.microsoft.com/cosmicprodamer/v1.0/oauthconfigurations` | `identityProvider` | `200` |
+| Apps | `GET https://dev.teams.microsoft.com/amer/api/appdefinitions/my/count` | なし | `200` |
+| M365 Agent Registry | `GET https://admin.cloud.microsoft/fd/addins/api/agents` | `limit`, `returnIfCacheIsNotReady`, `scopes`, `sortBy`, `sortOrder`, `workloads` | `200` |
+| Agent tools | `GET https://admin.cloud.microsoft/admin/api/agentssettings/agenttools` | なし | `200` |
+
+OAuth registration の list/get/create/update/delete を確認済み。region は `cosmicprodamer` / `apac` / `emea`。
+専用 portal client の Device Code 認証は `AADSTS7000218` になるため、CLI へ token を移送せず、ログイン済み
+Developer Portal 内から direct API を実行する。package 登録・更新は引き続き Graph v1.0 を正常系とする。
+
+変更は `manage_oauth_registration_api.py` または admin の `manage_m365_portal_api.py` で dry-run し、
+`PLAN_HASH` 承認後に `--apply` で `READY_FOR_BROWSER_API` を得る。その plan だけを送信し、GET で読み戻す。
+
+## Teams 開発者ポータル通信の調査
+
+OAuth client registration の作成画面は client secret を扱うため、通信本文を保存しない。
+ブラウザ上の操作と同じセッションで request event を監視し、origin/path/method、秘密を除いた
+フィールド名、response status だけを記録する。Bearer token、Cookie、CSRF token、client secret、
+registration ID の実値はチャット、ログ、fixture、SKILL.md に出さない。
+
+次を個別に調査する:
+
+- OAuth registration の list/get/create/update/delete
+- registration の organization/app usage restriction
+- M365 Agent Registry の list/get/upload/update/publish/disable
+- package 内 `agentSkills` と `agentConnectors` の取得結果
+- Frontier 対象者と Copilot 機能トグルの get/update
+
+同じ読み取りを2回捕捉して schema が一致するまでは endpoint を固定しない。書き込み通信は
+dry-run plan を作り、ユーザーが対象と影響を承認した後にだけ実行する。Cookie/CSRF/Bearer はブラウザ外へ
+取り出さず、同一 session の direct API を正常系にする。API が 401/403/404、schema 不一致、read-back
+不一致の場合だけフォーム操作へ切り替える。詳細な秘匿化基準は
+[admin の M365 テナント管理 API](../../admin/references/m365-tenant-api.md)を参照。
+
+## 公式資料
+
+- [Build plugins for Copilot Cowork](https://learn.microsoft.com/microsoft-365/copilot/cowork/cowork-plugin-development)
+- [Publish Agents for Microsoft 365 Copilot](https://learn.microsoft.com/microsoft-365/copilot/extensibility/publish)
+- [Publish teamsApp](https://learn.microsoft.com/graph/api/teamsapp-publish)
+- [Update teamsApp](https://learn.microsoft.com/graph/api/teamsapp-update)

--- a/.github/skills/cowork/references/portal-api-automation.md
+++ b/.github/skills/cowork/references/portal-api-automation.md
@@ -17,7 +17,9 @@
 | 組織カタログ一覧 | `manage_agent_package_graph.py list` | Graph v1.0 |
 | 組織カタログ新規/更新 | `manage_agent_package_graph.py deploy` | manifest ID を維持し version を増加 |
 | OAuth client registration | `GET/POST/PATCH/DELETE /v1.0/oauthconfigurations` | private API、portal Bearer session |
-| Agent Registry の公開対象/Install | `/fd/addins/api/availableAgents` | private API、admin browser session |
+| Agent Registry の Install/Uninstall | `POST /fd/addins/api/apps` | private API、admin browser session |
+| Agent Registry の Publish/Finalize | `POST /fd/addins/api/v2/actionableApps` | private API、admin browser session |
+| Agent request/permission approval | `POST /fd/addins/api/agentActions/approve` | private API、admin browser session |
 | Frontier 対象者 | `GET/POST /admin/api/settings/company/frontier/access` | private API、admin browser session |
 
 ```powershell
@@ -56,7 +58,18 @@ OAuth registration の list/get/create/update/delete を確認済み。region �
 Developer Portal 内から direct API を実行する。package 登録・更新は引き続き Graph v1.0 を正常系とする。
 
 変更は `manage_oauth_registration_api.py` または admin の `manage_m365_portal_api.py` で dry-run し、
-`PLAN_HASH` 承認後に `--apply` で `READY_FOR_BROWSER_API` を得る。その plan だけを送信し、GET で読み戻す。
+`PLAN_HASH` 承認後に `--apply` で `READY_FOR_BROWSER_API` を得る。その plan だけを admin の
+`m365_portal_browser_runner.mjs` で送信する。runner は session headers を値を出力せず継承し、
+`appManagementRequestID` のpollとAgent detailsのread-backまで実行する。
+
+Agent Registry の実測契約は次のとおり。package登録/更新はGraph、登録後の配布ライフサイクルはprivate APIを正常系にする。
+
+| 工程 | 契約 |
+|---|---|
+| Install / Uninstall | `/fd/addins/api/apps`、`Command=DEPLOY/UNDEPLOY`、`UserAssignmentDetails` |
+| Publish / Finalize | `/fd/addins/api/v2/actionableApps`、`Apps[].Command=APPROVE/FINALIZEPACKAGE` |
+| Request / permission approval | `/fd/addins/api/agentActions/approve?workload=SharedAgent`、`requestIds[]` |
+| 完了確認 | `/fd/addins/api/deploymentRequestStatus/{requestId}` をpollし、Agent detailsをGET |
 
 ## Teams 開発者ポータル通信の調査
 

--- a/.github/skills/cowork/references/troubleshooting.md
+++ b/.github/skills/cowork/references/troubleshooting.md
@@ -348,4 +348,17 @@ manifest 注入が壊れる症状とその**下流での**対処（`.Trim("'", '
 他スクリプト（`standard` スキル配下含む）で `set_key()` を使う場合も同様に
 `quote_mode="never"` を指定することを推奨する。
 
+## 25. Developer Portal private API の Device Code 認証が `AADSTS7000218` になる
+
+**症状**: Developer Portal が使用する client ID と `AppDefinitions.ReadWrite` scope を指定しても、
+Device Code flow で `client_assertion` または `client_secret` が必要という `AADSTS7000218` が返る。
+
+**原因**: Portal の client はブラウザ内の認証方式を前提とし、汎用 CLI の Device Code flow を
+public client として許可していない。scope や auth cache の不具合ではない。
+
+**対処**: token、Cookie、client secret を CLI へ取り出さない。`manage_oauth_registration_api.py` で
+payload と `PLAN_HASH` を検証し、`READY_FOR_BROWSER_API` になった plan だけをログイン済み VS Code
+統合ブラウザの同一 session から OAuth CRUD API へ送信する。GET で読み戻して一致を確認する。
+401/403/404 または schema 不一致の場合だけ、Developer Portal のフォーム操作へ切り替える。
+
 

--- a/.github/skills/cowork/scripts/manage_agent_package_graph.py
+++ b/.github/skills/cowork/scripts/manage_agent_package_graph.py
@@ -1,0 +1,171 @@
+"""Microsoft Graph v1.0 で Cowork/M365 エージェントパッケージを管理する。
+
+deploy は ZIP 内 manifest.json の id で既存アプリを判定し、存在しなければ新規登録、
+存在すれば appDefinitions へ新バージョンを追加する。変更は plan hash の承認が必須。
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+
+HERE = Path(__file__).resolve().parent
+STANDARD_SCRIPTS = (HERE / ".." / ".." / "standard" / "scripts").resolve()
+sys.path.insert(0, str(STANDARD_SCRIPTS))
+
+from auth_helper import get_session  # noqa: E402
+
+
+GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+TIMEOUT = 180
+
+
+def graph_get(path: str) -> dict[str, Any]:
+    response = get_session(scope=GRAPH_SCOPE).get(f"{GRAPH_BASE}{path}", timeout=TIMEOUT)
+    if response.status_code >= 400:
+        raise RuntimeError(f"GET {path} failed: HTTP {response.status_code} {response.text}")
+    return response.json()
+
+
+def graph_binary_post(path: str, package: bytes) -> dict[str, Any] | None:
+    session = get_session(scope=GRAPH_SCOPE)
+    response = session.post(
+        f"{GRAPH_BASE}{path}",
+        data=package,
+        headers={"Content-Type": "application/zip"},
+        timeout=TIMEOUT,
+    )
+    if response.status_code >= 400:
+        raise RuntimeError(f"POST {path} failed: HTTP {response.status_code} {response.text}")
+    return response.json() if response.content else None
+
+
+def app_catalog() -> list[dict[str, Any]]:
+    path = (
+        "/appCatalogs/teamsApps?$filter=distributionMethod eq 'organization'"
+        "&$expand=appDefinitions&$top=100"
+    )
+    values: list[dict[str, Any]] = []
+    while path:
+        page = graph_get(path)
+        values.extend(page.get("value") or [])
+        next_link = page.get("@odata.nextLink")
+        path = next_link.removeprefix(GRAPH_BASE) if next_link else ""
+    return values
+
+
+def package_metadata(package_path: Path) -> tuple[dict[str, Any], bytes, str]:
+    package = package_path.read_bytes()
+    try:
+        with zipfile.ZipFile(package_path) as archive:
+            names = archive.namelist()
+            if "manifest.json" not in names:
+                raise SystemExit("ZIP ルートに manifest.json がありません。")
+            manifest = json.loads(archive.read("manifest.json").decode("utf-8-sig"))
+    except (zipfile.BadZipFile, json.JSONDecodeError) as error:
+        raise SystemExit(f"無効な M365 app package です: {error}") from error
+    for field in ("id", "version", "name"):
+        if field not in manifest:
+            raise SystemExit(f"manifest.json に必須フィールド {field} がありません。")
+    return manifest, package, hashlib.sha256(package).hexdigest()
+
+
+def plan_hash(plan: dict[str, Any]) -> str:
+    payload = json.dumps(plan, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def list_packages(args: argparse.Namespace) -> None:
+    packages = []
+    for app in app_catalog():
+        definitions = app.get("appDefinitions") or []
+        latest = definitions[-1] if definitions else {}
+        packages.append(
+            {
+                "teamsAppId": app.get("id"),
+                "manifestId": app.get("externalId"),
+                "displayName": app.get("displayName"),
+                "version": latest.get("version"),
+                "publishingState": latest.get("publishingState"),
+            }
+        )
+    output = {"count": len(packages), "packages": packages}
+    print(json.dumps(output, ensure_ascii=False, indent=2))
+    if args.report_file:
+        Path(args.report_file).write_text(json.dumps(output, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def deploy(args: argparse.Namespace) -> None:
+    package_path = Path(args.package)
+    if not package_path.is_file():
+        raise SystemExit(f"パッケージが見つかりません: {package_path}")
+    manifest, package, package_sha256 = package_metadata(package_path)
+    matches = [app for app in app_catalog() if str(app.get("externalId", "")).lower() == manifest["id"].lower()]
+    if len(matches) > 1:
+        raise SystemExit(f"manifest ID {manifest['id']} に一致する組織アプリが複数あります。")
+    if matches:
+        teams_app_id = matches[0]["id"]
+        path = f"/appCatalogs/teamsApps/{quote(teams_app_id, safe='')}/appDefinitions"
+        operation = "update"
+    else:
+        path = "/appCatalogs/teamsApps"
+        operation = "create"
+    if args.requires_review:
+        path += "?requiresReview=true"
+
+    plan = {
+        "operation": operation,
+        "method": "POST",
+        "path": path,
+        "manifestId": manifest["id"],
+        "displayName": (manifest.get("name") or {}).get("short"),
+        "version": manifest["version"],
+        "packageSha256": package_sha256,
+        "requiresReview": args.requires_review,
+    }
+    approved_hash = plan_hash(plan)
+    print(json.dumps(plan, ensure_ascii=False, indent=2))
+    print(f"PLAN_HASH={approved_hash}")
+    if not args.apply:
+        print("DRY-RUN: アップロードしていません。適用時は --expected-hash と --apply を指定してください。")
+        return
+    if args.expected_hash != approved_hash:
+        raise SystemExit("承認済み plan hash が一致しません。パッケージを再確認してください。")
+    result = graph_binary_post(path, package)
+    print("APPLIED")
+    if result:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="組織アプリカタログを一覧")
+    list_parser.add_argument("--report-file")
+    list_parser.set_defaults(handler=list_packages)
+
+    deploy_parser = subparsers.add_parser("deploy", help="パッケージを新規登録または更新")
+    deploy_parser.add_argument("--package", required=True)
+    deploy_parser.add_argument("--requires-review", action="store_true")
+    deploy_parser.add_argument("--apply", action="store_true")
+    deploy_parser.add_argument("--expected-hash")
+    deploy_parser.set_defaults(handler=deploy)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/cowork/scripts/manage_oauth_registration_api.py
+++ b/.github/skills/cowork/scripts/manage_oauth_registration_api.py
@@ -1,0 +1,288 @@
+"""Teams Developer Portal OAuth API の承認 plan を生成する。
+
+非公開 API のため、portal build で観測済みの DTO だけを許可する。実行はログイン済み
+VS Code 統合ブラウザの同一セッションで行い、変更前にこの plan hash を承認する。
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+
+HERE = Path(__file__).resolve().parent
+STANDARD_SCRIPTS = (HERE / ".." / ".." / "standard" / "scripts").resolve()
+sys.path.insert(0, str(STANDARD_SCRIPTS))
+
+REGION_BASES = {
+    "amer": "https://dev.teams.microsoft.com/cosmicprodamer",
+    "apac": "https://dev.teams.microsoft.com/cosmicprodapac",
+    "emea": "https://dev.teams.microsoft.com/cosmicprodemea",
+}
+ALLOWED_FIELDS = {
+    "description",
+    "applicableToApps",
+    "m365AppId",
+    "targetAudience",
+    "clientId",
+    "identityProvider",
+    "targetUrlsShouldStartWith",
+    "isPKCEEnabled",
+    "clientSecret",
+    "scopes",
+    "authorizationEndpoint",
+    "tokenExchangeEndpoint",
+    "tokenRefreshEndpoint",
+    "tokenExchangeMethodType",
+}
+SECRET_KEYS = {"clientSecret", "accessToken", "refreshToken", "token"}
+
+
+def canonical_hash(value: dict[str, Any]) -> str:
+    encoded = json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def redact(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: "<redacted>" if key in SECRET_KEYS else redact(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [redact(item) for item in value]
+    return value
+
+
+def api_base(region: str) -> str:
+    try:
+        return REGION_BASES[region.lower()]
+    except KeyError as error:
+        raise SystemExit(f"未対応の Developer Portal region です: {region}") from error
+
+
+def validate_payload(payload: dict[str, Any], *, creating: bool) -> dict[str, Any]:
+    unknown = sorted(set(payload) - ALLOWED_FIELDS)
+    if unknown:
+        raise SystemExit(f"未確認の OAuth DTO フィールドです: {', '.join(unknown)}")
+    required = {
+        "description",
+        "applicableToApps",
+        "targetAudience",
+        "clientId",
+        "identityProvider",
+        "targetUrlsShouldStartWith",
+        "clientSecret",
+        "scopes",
+        "authorizationEndpoint",
+        "tokenExchangeEndpoint",
+    }
+    if creating:
+        missing = sorted(field for field in required if not payload.get(field))
+        if missing:
+            raise SystemExit(f"OAuth registration の必須フィールドがありません: {', '.join(missing)}")
+    if payload.get("identityProvider", "Custom") != "Custom":
+        raise SystemExit("この CLI は identityProvider=Custom の OAuth registration 専用です。")
+    if payload.get("applicableToApps") not in {None, "AnyApp", "SpecificApp"}:
+        raise SystemExit("applicableToApps は AnyApp または SpecificApp です。")
+    if payload.get("targetAudience") not in {None, "HomeTenant", "AnyTenant"}:
+        raise SystemExit("targetAudience は HomeTenant または AnyTenant です。")
+    if payload.get("applicableToApps") == "SpecificApp" and not payload.get("m365AppId"):
+        raise SystemExit("SpecificApp では m365AppId が必須です。")
+    if "clientSecret" in payload and len(str(payload["clientSecret"])) < 10:
+        raise SystemExit("clientSecret は 10 文字以上である必要があります。")
+    return payload
+
+
+def registration_id(result: Any) -> str:
+    if isinstance(result, dict):
+        direct = result.get("oAuthConfigId")
+        nested = result.get("configurationRegistrationId") or {}
+        value = direct or (nested.get("oAuthConfigId") if isinstance(nested, dict) else None)
+        if value:
+            return str(value)
+    raise RuntimeError("API 応答に oAuthConfigId がありません。")
+
+
+def approved_apply(args: argparse.Namespace, plan: dict[str, Any], operation) -> Any:
+    digest = canonical_hash(plan)
+    print(json.dumps(redact(plan), ensure_ascii=False, indent=2))
+    print(f"PLAN_HASH={digest}")
+    if not args.apply:
+        print("DRY-RUN: 変更していません。適用時は --expected-hash と --apply を指定してください。")
+        return None
+    if args.expected_hash != digest:
+        raise SystemExit("承認済み plan hash が一致しません。")
+    result = operation()
+    print("READY_FOR_BROWSER_API")
+    return result
+
+
+def list_registrations(args: argparse.Namespace) -> None:
+    suffix = f"?identityProvider={quote(args.identity_provider, safe='')}" if args.identity_provider else ""
+    print(json.dumps({"method": "GET", "url": f"{api_base(args.region)}/v1.0/oauthconfigurations{suffix}"}, indent=2))
+
+
+def get_registration(args: argparse.Namespace) -> None:
+    print(json.dumps({
+        "method": "GET",
+        "url": f"{api_base(args.region)}/v1.0/oauthconfigurations/{quote(args.registration_id, safe='')}",
+    }, indent=2))
+
+
+def create_payload(args: argparse.Namespace) -> dict[str, Any]:
+    secret = os.getenv("COWORK_OAUTH_CLIENT_SECRET", "")
+    tenant_id = os.getenv("TENANT_ID", "")
+    if not secret:
+        raise SystemExit("COWORK_OAUTH_CLIENT_SECRET を .env または環境変数に設定してください。")
+    if not tenant_id and (not args.authorization_endpoint or not args.token_endpoint):
+        raise SystemExit("TENANT_ID、または authorization/token endpoint の明示指定が必要です。")
+    auth_base = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0"
+    payload = {
+        "description": args.name,
+        "applicableToApps": args.applicable_to_apps,
+        "targetAudience": args.target_audience,
+        "clientId": args.client_id,
+        "identityProvider": "Custom",
+        "targetUrlsShouldStartWith": [args.base_url.rstrip("/")],
+        "isPKCEEnabled": not args.disable_pkce,
+        "clientSecret": secret,
+        "scopes": [scope.strip() for scope in args.scopes.split(",") if scope.strip()],
+        "authorizationEndpoint": args.authorization_endpoint or f"{auth_base}/authorize",
+        "tokenExchangeEndpoint": args.token_endpoint or f"{auth_base}/token",
+        "tokenRefreshEndpoint": args.refresh_endpoint or args.token_endpoint or f"{auth_base}/token",
+        "tokenExchangeMethodType": args.token_exchange_method,
+    }
+    if args.m365_app_id:
+        payload["m365AppId"] = args.m365_app_id
+    return validate_payload(payload, creating=True)
+
+
+def create_registration(args: argparse.Namespace) -> None:
+    payload = create_payload(args)
+    plan = {
+        "operation": "create-oauth-registration",
+        "region": args.region,
+        "method": "POST",
+        "path": "/v1.0/oauthconfigurations",
+        "payload": {**redact(payload), "clientSecretSha256": hashlib.sha256(payload["clientSecret"].encode()).hexdigest()},
+    }
+
+    approved_apply(args, plan, lambda: None)
+
+
+def load_update_payload(path: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SystemExit(f"更新 payload を読み込めません: {error}") from error
+    if not isinstance(payload, dict):
+        raise SystemExit("更新 payload は JSON object で指定してください。")
+    if payload.get("clientSecret") == "${COWORK_OAUTH_CLIENT_SECRET}":
+        payload["clientSecret"] = os.getenv("COWORK_OAUTH_CLIENT_SECRET", "")
+    return validate_payload(payload, creating=False)
+
+
+def update_registration(args: argparse.Namespace) -> None:
+    payload = load_update_payload(args.payload_file)
+    config_id = quote(args.registration_id, safe="")
+    plan_payload = redact(payload)
+    if payload.get("clientSecret"):
+        plan_payload["clientSecretSha256"] = hashlib.sha256(payload["clientSecret"].encode()).hexdigest()
+    plan = {
+        "operation": "update-oauth-registration",
+        "region": args.region,
+        "method": "PATCH",
+        "path": f"/v1.0/oauthconfigurations/{config_id}",
+        "payload": plan_payload,
+    }
+
+    approved_apply(args, plan, lambda: None)
+
+
+def delete_registration(args: argparse.Namespace) -> None:
+    config_id = quote(args.registration_id, safe="")
+    path = f"/v1.0/oauthconfigurations/{config_id}"
+    plan = {
+        "operation": "delete-oauth-registration",
+        "region": args.region,
+        "method": "DELETE",
+        "path": path,
+    }
+
+    approved_apply(args, plan, lambda: None)
+
+
+def add_common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--region",
+        choices=sorted(REGION_BASES),
+        default=os.getenv("COWORK_PORTAL_REGION", "amer").lower(),
+    )
+
+
+def add_apply(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--expected-hash")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = commands.add_parser("list", help="OAuth registration を一覧")
+    add_common(list_parser)
+    list_parser.add_argument("--identity-provider", default="Custom")
+    list_parser.set_defaults(handler=list_registrations)
+
+    get_parser = commands.add_parser("get", help="OAuth registration を取得")
+    add_common(get_parser)
+    get_parser.add_argument("--registration-id", required=True)
+    get_parser.set_defaults(handler=get_registration)
+
+    create_parser = commands.add_parser("create", help="OAuth registration を作成")
+    add_common(create_parser)
+    add_apply(create_parser)
+    create_parser.add_argument("--name", required=True)
+    create_parser.add_argument("--base-url", required=True)
+    create_parser.add_argument("--client-id", default=os.getenv("COWORK_OAUTH_CLIENT_ID"), required=not os.getenv("COWORK_OAUTH_CLIENT_ID"))
+    create_parser.add_argument("--scopes", required=True, help="カンマ区切り")
+    create_parser.add_argument("--applicable-to-apps", choices=["AnyApp", "SpecificApp"], default="AnyApp")
+    create_parser.add_argument("--m365-app-id")
+    create_parser.add_argument("--target-audience", choices=["HomeTenant", "AnyTenant"], default="HomeTenant")
+    create_parser.add_argument("--authorization-endpoint")
+    create_parser.add_argument("--token-endpoint")
+    create_parser.add_argument("--refresh-endpoint")
+    create_parser.add_argument("--disable-pkce", action="store_true")
+    create_parser.add_argument(
+        "--token-exchange-method",
+        choices=["PostRequestBody", "BasicAuthorizationHeader"],
+        default="PostRequestBody",
+    )
+    create_parser.set_defaults(handler=create_registration)
+
+    update_parser = commands.add_parser("update", help="OAuth registration を PATCH")
+    add_common(update_parser)
+    add_apply(update_parser)
+    update_parser.add_argument("--registration-id", required=True)
+    update_parser.add_argument("--payload-file", required=True)
+    update_parser.set_defaults(handler=update_registration)
+
+    delete_parser = commands.add_parser("delete", help="OAuth registration を削除")
+    add_common(delete_parser)
+    add_apply(delete_parser)
+    delete_parser.add_argument("--registration-id", required=True)
+    delete_parser.set_defaults(handler=delete_registration)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/cowork/scripts/test_manage_agent_package_graph.py
+++ b/.github/skills/cowork/scripts/test_manage_agent_package_graph.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parent / "manage_agent_package_graph.py"
+SPEC = importlib.util.spec_from_file_location("manage_agent_package_graph", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+def make_package(path: Path, manifest_id: str = "<manifest-id>") -> None:
+    manifest = {"id": manifest_id, "version": "1.0.0", "name": {"short": "Example"}}
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("manifest.json", json.dumps(manifest))
+        archive.writestr("color.png", b"placeholder")
+
+
+class ManageAgentPackageTests(unittest.TestCase):
+    def test_package_metadata_reads_root_manifest(self):
+        with tempfile.TemporaryDirectory() as directory:
+            package_path = Path(directory) / "agent.zip"
+            make_package(package_path)
+
+            manifest, package, digest = MODULE.package_metadata(package_path)
+
+            self.assertEqual(manifest["version"], "1.0.0")
+            self.assertTrue(package)
+            self.assertEqual(len(digest), 64)
+
+    def test_plan_hash_changes_with_package_digest(self):
+        first = {"operation": "create", "packageSha256": "a" * 64}
+        second = {"operation": "create", "packageSha256": "b" * 64}
+
+        self.assertNotEqual(MODULE.plan_hash(first), MODULE.plan_hash(second))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/skills/cowork/scripts/test_manage_oauth_registration_api.py
+++ b/.github/skills/cowork/scripts/test_manage_oauth_registration_api.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parent / "manage_oauth_registration_api.py"
+SPEC = importlib.util.spec_from_file_location("manage_oauth_registration_api", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class ManageOauthRegistrationApiTests(unittest.TestCase):
+    def test_validate_payload_rejects_unknown_field(self):
+        with self.assertRaisesRegex(SystemExit, "未確認"):
+            MODULE.validate_payload({"unexpected": True}, creating=False)
+
+    def test_validate_payload_requires_specific_app_id(self):
+        with self.assertRaisesRegex(SystemExit, "m365AppId"):
+            MODULE.validate_payload({"applicableToApps": "SpecificApp"}, creating=False)
+
+    def test_redact_hides_nested_secret(self):
+        value = {"clientSecret": "secret-value", "nested": [{"token": "token-value"}]}
+
+        result = MODULE.redact(value)
+
+        self.assertEqual(result["clientSecret"], "<redacted>")
+        self.assertEqual(result["nested"][0]["token"], "<redacted>")
+
+    def test_registration_id_accepts_both_observed_response_shapes(self):
+        self.assertEqual(MODULE.registration_id({"oAuthConfigId": "direct"}), "direct")
+        self.assertEqual(
+            MODULE.registration_id({"configurationRegistrationId": {"oAuthConfigId": "nested"}}),
+            "nested",
+        )
+
+    def test_region_and_hash_are_deterministic(self):
+        self.assertTrue(MODULE.api_base("EMEA").endswith("cosmicprodemea"))
+        first = MODULE.canonical_hash({"method": "POST", "path": "/example"})
+        second = MODULE.canonical_hash({"path": "/example", "method": "POST"})
+
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Cowork スキルをAPI-firstに更新し、OAuth registration private CRUD、Graph app package管理、Agent Registry配布ライフサイクルを自動化します。

- Graphでpackage登録/更新
- private APIでInstall、Publish、Finalize、利用要求承認、Entra permission Grant/Revoke
- 利用要求承認とEntra permission更新を別contractとして明記
- adminのbrowser-session runnerで承認hash、deployment poll、read-backを強制
- APIが401/403/404、schema/read-back不一致の場合だけフォーム操作へfallback
- Cowork Python 10 tests / validate_skill.py PASS
- Publish/Permission成功mutationはdisposable検証agentの用意後に実測する
- 依存: admin PR #450
- マージ順: #450 -> #451